### PR TITLE
feat(dev): seed Xtream provider from local.properties on first boot

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,14 @@ if (keystorePropertiesFile.exists()) {
     FileInputStream(keystorePropertiesFile).use(keystoreProperties::load)
 }
 
+val localPropertiesFile = rootProject.file("local.properties")
+val localProperties = Properties()
+if (localPropertiesFile.exists()) {
+    FileInputStream(localPropertiesFile).use(localProperties::load)
+}
+
+fun localProp(key: String): String = localProperties.getProperty(key, "")
+
 fun computeOfficialSigningCertSha256(): String {
     if (!keystorePropertiesFile.exists()) return ""
 
@@ -53,6 +61,10 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField("String", "OFFICIAL_APPLICATION_ID", "\"com.streamvault.app\"")
         buildConfigField("String", "OFFICIAL_SIGNING_CERT_SHA256", "\"$officialSigningCertSha256\"")
+        buildConfigField("String", "XTREAM_DEV_SERVER", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_USERNAME", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_PASSWORD", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_NAME", "\"\"")
     }
 
     signingConfigs {
@@ -67,6 +79,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "XTREAM_DEV_SERVER", "\"${localProp("xtream.dev.server")}\"")
+            buildConfigField("String", "XTREAM_DEV_USERNAME", "\"${localProp("xtream.dev.username")}\"")
+            buildConfigField("String", "XTREAM_DEV_PASSWORD", "\"${localProp("xtream.dev.password")}\"")
+            buildConfigField("String", "XTREAM_DEV_NAME", "\"${localProp("xtream.dev.name")}\"")
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
@@ -30,21 +30,26 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
+import com.streamvault.app.BuildConfig
 import com.streamvault.app.R
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.design.AppColors
 import com.streamvault.domain.repository.ProviderRepository
+import com.streamvault.domain.usecase.ValidateAndAddProvider
+import com.streamvault.domain.usecase.XtreamProviderSetupCommand
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(
-    private val providerRepository: ProviderRepository
+    private val providerRepository: ProviderRepository,
+    private val validateAndAddProvider: ValidateAndAddProvider
 ) : ViewModel() {
 
     private val _hasProviders = MutableStateFlow<Boolean?>(null)
@@ -52,10 +57,32 @@ class WelcomeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            maybeSeedDevProvider()
             providerRepository.getProviders()
                 .map { it.isNotEmpty() }
                 .collect { _hasProviders.value = it }
         }
+    }
+
+    // Debug-only seeding: when BuildConfig.XTREAM_DEV_* is populated via
+    // root/local.properties (gitignored) AND no provider exists yet, create
+    // one silently so the dev hot-path skips onboarding. Release builds see
+    // empty strings (see app/build.gradle.kts defaultConfig) and this is a no-op.
+    private suspend fun maybeSeedDevProvider() {
+        val server = BuildConfig.XTREAM_DEV_SERVER
+        val username = BuildConfig.XTREAM_DEV_USERNAME
+        val password = BuildConfig.XTREAM_DEV_PASSWORD
+        if (server.isBlank() || username.isBlank() || password.isBlank()) return
+        if (providerRepository.getProviders().first().isNotEmpty()) return
+
+        validateAndAddProvider.loginXtream(
+            XtreamProviderSetupCommand(
+                serverUrl = server,
+                username = username,
+                password = password,
+                name = BuildConfig.XTREAM_DEV_NAME.ifBlank { "Dev (seeded)" }
+            )
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Adds an **opt-in dev seeding flow** so contributors can skip the manual
onboarding form on every fresh install or after `pm clear`. Reads four
`BuildConfig` fields populated at compile time from the root
`local.properties` (gitignored, never committed):

```properties
xtream.dev.server=http://example.org:80
xtream.dev.username=...
xtream.dev.password=...
xtream.dev.name=Dev (label shown in UI)
```

No values are committed — the fields are empty unless a contributor
opts in by populating their own `local.properties`. The `.gitignore`
already excludes that file.

### How it works

**`app/build.gradle.kts`** declares the four fields with empty defaults
in `defaultConfig` and overrides them in the `debug` build type only,
reading from `rootProject/local.properties` when present:

```kotlin
defaultConfig {
    // Empty by default — release builds always see "" regardless of
    // the contributor's local.properties.
    buildConfigField("String", "XTREAM_DEV_SERVER",   "\"\"")
    buildConfigField("String", "XTREAM_DEV_USERNAME", "\"\"")
    buildConfigField("String", "XTREAM_DEV_PASSWORD", "\"\"")
    buildConfigField("String", "XTREAM_DEV_NAME",     "\"\"")
}
buildTypes {
    debug {
        // Reads from rootProject/local.properties — gitignored.
        buildConfigField("String", "XTREAM_DEV_SERVER",   "\"${localProp("xtream.dev.server")}\"")
        // ... same for the 3 others
    }
    release {
        // Inherits the empty defaults — credentials can never leak.
    }
}
```

**`WelcomeViewModel.maybeSeedDevProvider()`** runs once at boot, before
the existing `getProviders()` observation. It is a no-op when:

- any of the three required fields is blank (no `local.properties`
  populated), **or**
- the device already has at least one provider configured.

Otherwise it calls the regular
`ValidateAndAddProvider.loginXtream(XtreamProviderSetupCommand(...))`
— same code path as the onboarding form — so input validation, EPG
sync settings, and persistence are identical. On success the existing
`getProviders()` observation immediately reports non-empty and the
navigator skips straight to home.

### Safety

| Build type | `XTREAM_DEV_*` fields |
|---|---|
| `debug` with populated `local.properties` | actual values |
| `debug` without `local.properties` | `""` (empty) |
| `release` (any contributor, any state) | `""` always — `defaultConfig` override |

Release APKs are guaranteed to never carry credentials regardless of
the contributor's local state. `local.properties` is already in the
project's `.gitignore` (line 21).

### Usage for a new contributor

1. Add the 4 lines above to `local.properties` (auto-generated by
   Android Studio, already gitignored).
2. `./gradlew :app:installDebug` — onboarding is skipped, the seeded
   provider is auto-selected.
3. To re-test onboarding from scratch:
   `adb shell pm clear com.streamvault.app` then relaunch — same skip.

## Test plan

- [x] `./gradlew clean :app:assembleDebug` green on `master`
- [x] With populated `local.properties` + `pm clear` → app skips
      Welcome/Onboarding and lands directly on the home screen
- [x] Without `local.properties` → onboarding shows up normally
- [x] With `local.properties` populated but a provider already exists
      → no duplicate provider created, no behaviour change
- [x] `git status` confirms `local.properties` is not staged (gitignored)
- [x] Release build inspected via `./gradlew :app:assembleRelease` (when
      keystore is available locally) shows empty `XTREAM_DEV_*` constants
