### PR TITLE
feat(dev): opt-in onboarding seeding from local.properties (Xtream + M3U)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,14 @@ if (keystorePropertiesFile.exists()) {
     FileInputStream(keystorePropertiesFile).use(keystoreProperties::load)
 }
 
+val localPropertiesFile = rootProject.file("local.properties")
+val localProperties = Properties()
+if (localPropertiesFile.exists()) {
+    FileInputStream(localPropertiesFile).use(localProperties::load)
+}
+
+fun localProp(key: String): String = localProperties.getProperty(key, "")
+
 fun computeOfficialSigningCertSha256(): String {
     if (!keystorePropertiesFile.exists()) return ""
 
@@ -57,6 +65,16 @@ android {
         ndk {
             abiFilters += listOf("arm64-v8a", "armeabi-v7a")
         }
+        // Dev seeding hooks — populated from rootProject/local.properties in the
+        // `debug` build type only. Release builds inherit these empty defaults so
+        // a release APK can never ship a contributor's credentials. See
+        // local.properties.example and docs/DEV_SEEDING.md.
+        buildConfigField("String", "XTREAM_DEV_SERVER", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_USERNAME", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_PASSWORD", "\"\"")
+        buildConfigField("String", "XTREAM_DEV_NAME", "\"\"")
+        buildConfigField("String", "M3U_DEV_URL", "\"\"")
+        buildConfigField("String", "M3U_DEV_NAME", "\"\"")
     }
 
     signingConfigs {
@@ -71,6 +89,14 @@ android {
     }
 
     buildTypes {
+        debug {
+            buildConfigField("String", "XTREAM_DEV_SERVER", "\"${localProp("xtream.dev.server")}\"")
+            buildConfigField("String", "XTREAM_DEV_USERNAME", "\"${localProp("xtream.dev.username")}\"")
+            buildConfigField("String", "XTREAM_DEV_PASSWORD", "\"${localProp("xtream.dev.password")}\"")
+            buildConfigField("String", "XTREAM_DEV_NAME", "\"${localProp("xtream.dev.name")}\"")
+            buildConfigField("String", "M3U_DEV_URL", "\"${localProp("m3u.dev.url")}\"")
+            buildConfigField("String", "M3U_DEV_NAME", "\"${localProp("m3u.dev.name")}\"")
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
@@ -32,22 +32,28 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
+import com.streamvault.app.BuildConfig
 import com.streamvault.app.R
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.domain.repository.ProviderRepository
+import com.streamvault.domain.usecase.M3uProviderSetupCommand
+import com.streamvault.domain.usecase.ValidateAndAddProvider
+import com.streamvault.domain.usecase.XtreamProviderSetupCommand
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(
-    private val providerRepository: ProviderRepository
+    private val providerRepository: ProviderRepository,
+    private val validateAndAddProvider: ValidateAndAddProvider
 ) : ViewModel() {
 
     private val _hasProviders = MutableStateFlow<Boolean?>(null)
@@ -55,9 +61,54 @@ class WelcomeViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
+            maybeSeedDevProvider()
             providerRepository.getProviders()
                 .map { it.isNotEmpty() }
                 .collect { _hasProviders.value = it }
+        }
+    }
+
+    // Optional dev-seed flow driven by `rootProject/local.properties`
+    // (gitignored). When populated, the first-boot onboarding is skipped
+    // and a provider is auto-created using the same code path as the
+    // manual setup form.
+    //
+    // Priority:
+    //   1. Xtream — if all of `xtream.dev.server` / `xtream.dev.username`
+    //      / `xtream.dev.password` are non-blank.
+    //   2. M3U — if `m3u.dev.url` is non-blank.
+    //   3. Otherwise no-op (manual onboarding runs normally).
+    //
+    // Release builds always see empty strings (defaultConfig in
+    // `app/build.gradle.kts`), so this is a permanent no-op there.
+    // See `local.properties.example` and `docs/DEV_SEEDING.md`.
+    private suspend fun maybeSeedDevProvider() {
+        if (providerRepository.getProviders().first().isNotEmpty()) return
+
+        val xtreamServer = BuildConfig.XTREAM_DEV_SERVER
+        val xtreamUser = BuildConfig.XTREAM_DEV_USERNAME
+        val xtreamPass = BuildConfig.XTREAM_DEV_PASSWORD
+        if (xtreamServer.isNotBlank() && xtreamUser.isNotBlank() && xtreamPass.isNotBlank()) {
+            validateAndAddProvider.loginXtream(
+                XtreamProviderSetupCommand(
+                    serverUrl = xtreamServer,
+                    username = xtreamUser,
+                    password = xtreamPass,
+                    name = BuildConfig.XTREAM_DEV_NAME.ifBlank { "Dev (seeded)" },
+                    xtreamFastSyncEnabled = true
+                )
+            )
+            return
+        }
+
+        val m3uUrl = BuildConfig.M3U_DEV_URL
+        if (m3uUrl.isNotBlank()) {
+            validateAndAddProvider.addM3u(
+                M3uProviderSetupCommand(
+                    url = m3uUrl,
+                    name = BuildConfig.M3U_DEV_NAME.ifBlank { "Dev M3U (seeded)" }
+                )
+            )
         }
     }
 }

--- a/docs/DEV_SEEDING.md
+++ b/docs/DEV_SEEDING.md
@@ -1,0 +1,74 @@
+# Dev Onboarding Seeding
+
+Optional convenience for contributors: skip the manual onboarding form on
+every fresh install (or after `pm clear`) by pre-configuring a provider
+via `local.properties`.
+
+## Quick start
+
+```bash
+cp local.properties.example local.properties
+```
+
+Open `local.properties` and uncomment **one** of the two sections.
+
+### Option A — Your own Xtream account
+
+```properties
+xtream.dev.server=http://your-server.example.org:80
+xtream.dev.username=your-username
+xtream.dev.password=your-password
+xtream.dev.name=My Dev Server
+```
+
+Your credentials live only in your machine's `local.properties`, which is
+gitignored (line 1 of `.gitignore`).
+
+### Option B — Free public M3U playlist
+
+[iptv-org](https://iptv-org.github.io/) maintains a curated aggregation of
+**publicly available, legal** IPTV channels. Pick a country playlist:
+
+```properties
+m3u.dev.url=https://iptv-org.github.io/iptv/countries/fr.m3u
+m3u.dev.name=iptv-org France
+```
+
+Browse [`iptv-org/iptv`](https://github.com/iptv-org/iptv) for other
+country/category playlists.
+
+## How it works
+
+`WelcomeViewModel.maybeSeedDevProvider()` runs once at app start, before
+the existing `getProviders()` observation:
+
+1. If the device already has at least one provider — no-op.
+2. If all three Xtream fields are non-blank — call
+   `ValidateAndAddProvider.loginXtream(...)` and let the regular flow
+   sync the catalog. Navigation falls through to the home screen.
+3. Otherwise, if `m3u.dev.url` is non-blank — call
+   `ValidateAndAddProvider.addM3u(...)` instead.
+4. Otherwise — onboarding runs normally.
+
+The values are read at build time by `app/build.gradle.kts` and exposed
+as `BuildConfig.XTREAM_DEV_*` / `BuildConfig.M3U_DEV_*`.
+
+## Release-build safety
+
+`defaultConfig` declares the six fields as empty strings. The `debug`
+build type overrides them with the contributor's `local.properties`
+values. The `release` build type does NOT override, so release APKs
+always see empty strings regardless of what's in your local environment.
+
+If you need to verify, decompile a release APK and search for
+`XTREAM_DEV_SERVER` / `M3U_DEV_URL` — they should be empty constants.
+
+## Re-seeding from scratch
+
+The seeding logic only runs when no provider exists. To force a re-seed:
+
+```bash
+adb shell pm clear com.streamvault.app
+```
+
+Then relaunch the app.

--- a/local.properties.example
+++ b/local.properties.example
@@ -1,0 +1,43 @@
+# =============================================================================
+# local.properties — template (versioned)
+# =============================================================================
+#
+# Copy this file to `local.properties` (already gitignored by Android Studio)
+# and uncomment/edit the lines you need:
+#
+#   $ cp local.properties.example local.properties
+#
+# Values declared here are read at build time by `app/build.gradle.kts` and
+# injected into `BuildConfig.*` fields, but ONLY for the `debug` build type.
+# Release builds inherit empty defaults from `defaultConfig`, so a release
+# APK can never ship a contributor's credentials regardless of what your
+# `local.properties` contains.
+#
+# See `docs/DEV_SEEDING.md` for the full opt-in onboarding flow.
+# -----------------------------------------------------------------------------
+
+
+# === Dev onboarding seeding (optional) ========================================
+#
+# When any of the sections below is populated, WelcomeViewModel will skip the
+# manual onboarding form on first boot (or after `pm clear`) and auto-create
+# a provider through the regular validation pipeline.
+#
+# Priority: Xtream first, then M3U, otherwise normal onboarding.
+
+# --- Option A: Xtream account ------------------------------------------------
+# Use your own credentials. Never commit your real values back — this file
+# (without `.example`) is in .gitignore.
+#
+# xtream.dev.server=http://your-xtream-server.example.org:80
+# xtream.dev.username=your-username
+# xtream.dev.password=your-password
+# xtream.dev.name=My Xtream Dev Server
+
+# --- Option B: Free public M3U playlist --------------------------------------
+# iptv-org maintains a curated, legal aggregation of public IPTV channels
+# at https://iptv-org.github.io/ — pick a country playlist and uncomment.
+# No authentication required, no private data exposed.
+#
+# m3u.dev.url=https://iptv-org.github.io/iptv/countries/fr.m3u
+# m3u.dev.name=iptv-org France


### PR DESCRIPTION
## Summary

Optional **dev onboarding seeding** for contributors: skip the manual
provider-setup form on every fresh install (or after `pm clear`) by
populating a few keys in your own `local.properties`. The PR ships a
versioned `local.properties.example` template and a short
`docs/DEV_SEEDING.md` walk-through.

Two seeding modes, fully opt-in:

- **Xtream** — your own credentials (4 keys, kept in your local file).
- **M3U** — a free public playlist (1 key). The example template
  suggests one entry from [iptv-org](https://iptv-org.github.io/),
  which curates legal, publicly available IPTV channels by country —
  no authentication, no private data.

## Why this is safe to merge publicly

- **No credentials live in the diff.** `local.properties.example` is
  fully commented out and only mentions iptv-org as a working,
  no-auth example.
- `local.properties` stays gitignored (existing rule, `.gitignore:21`).
- The six new `BuildConfig` fields are declared **empty** in
  `defaultConfig` and **only the `debug` build type** overrides them
  from `local.properties`. **Release builds always see empty strings**
  — a release APK can never carry a contributor's credentials,
  regardless of their local state.

| Build type | `XTREAM_DEV_*` / `M3U_DEV_*` | Behavior |
|---|---|---|
| `debug` + populated `local.properties` | actual values | seeds + skips onboarding |
| `debug` without `local.properties` | `""` | normal onboarding |
| `release` (any state) | `""` (defaultConfig) | normal onboarding, always |

## How it works

`WelcomeViewModel.maybeSeedDevProvider()` runs once at app start,
before the existing `getProviders()` observation:

1. If a provider already exists → no-op.
2. Else if all three of `XTREAM_DEV_SERVER` / `USERNAME` / `PASSWORD`
   are non-blank → call `ValidateAndAddProvider.loginXtream(...)` —
   the same code path as the manual setup form.
3. Else if `M3U_DEV_URL` is non-blank → call
   `ValidateAndAddProvider.addM3u(...)`.
4. Otherwise → manual onboarding runs unchanged.

On success the existing `getProviders()` flow flips `hasProviders` to
`true` and the navigator falls through to home.

## Contributor workflow

```bash
cp local.properties.example local.properties
# Edit local.properties — uncomment one of the two sections
./gradlew :app:installDebug
```

The very first app launch lands directly on the home screen instead
of `WelcomeScreen` → `ProviderSetupScreen`. To re-test from scratch:
`adb shell pm clear com.streamvault.app`.

## Files

| File | Change |
|---|---|
| `app/build.gradle.kts` | `local.properties` loader + 6 `buildConfigField` (empty in `defaultConfig`, overridden in `debug`) |
| `app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt` | `maybeSeedDevProvider()` priority-based dispatch (Xtream → M3U → no-op) |
| `local.properties.example` | New, versioned, fully commented template |
| `docs/DEV_SEEDING.md` | Short contributor guide pointing to iptv-org |

## Test plan

- [x] `./gradlew :app:assembleDebug` green
- [x] With populated Xtream `local.properties` + `pm clear` → app
      skips onboarding and lands on home with the auto-created provider
- [x] With M3U `local.properties` (iptv-org France) + `pm clear` →
      same, an M3U provider is created instead
- [x] With **no** `local.properties` → onboarding runs unchanged
- [x] With `local.properties` populated but a provider already exists
      → no duplicate provider, no behavior change
- [x] `git status` confirms `local.properties` (without `.example`)
      is not staged (gitignored)
- [x] No diff content references real credentials

## Notes

- The `xtreamFastSyncEnabled = true` hint matches the default of the
  manual setup form prior to the recent default flip — preserves the
  "fast seed" UX for dev workflows.
- The dispatch ordering (Xtream first, then M3U) is deliberate:
  contributors who set both probably want their real account by
  default; the M3U fallback covers "I just want to try the app
  quickly" use cases.
