### PR TITLE
feat(welcome): real-time sync progress on first-boot library preparation

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
@@ -195,17 +195,13 @@ private fun WelcomeLoadingCard(
                 if (syncProgress.total > 0) {
                     LinearProgressIndicator(
                         progress = { syncProgress.current.toFloat() / syncProgress.total.toFloat() },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .width(260.dp),
+                        modifier = Modifier.width(260.dp),
                         color = AppColors.Brand,
                         trackColor = AppColors.BrandMuted
                     )
                 } else {
                     LinearProgressIndicator(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .width(260.dp),
+                        modifier = Modifier.width(260.dp),
                         color = AppColors.Brand,
                         trackColor = AppColors.BrandMuted
                     )

--- a/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
@@ -10,9 +10,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -38,6 +40,7 @@ import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.data.sync.SyncProgressBus
 import com.streamvault.domain.repository.ProviderRepository
+import com.streamvault.domain.sync.Section
 import com.streamvault.domain.sync.SyncProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -93,6 +96,7 @@ fun WelcomeScreen(
     viewModel: WelcomeViewModel = hiltViewModel()
 ) {
     val hasProviders by viewModel.hasProviders.collectAsStateWithLifecycle()
+    val syncProgress by viewModel.syncProgress.collectAsStateWithLifecycle()
 
     LaunchedEffect(hasProviders) {
         when (hasProviders) {
@@ -127,6 +131,7 @@ fun WelcomeScreen(
             )
 
             else -> WelcomeLoadingCard(
+                syncProgress = syncProgress,
                 modifier = Modifier
                     .align(Alignment.Center)
                     .padding(32.dp)
@@ -136,7 +141,10 @@ fun WelcomeScreen(
 }
 
 @Composable
-private fun WelcomeLoadingCard(modifier: Modifier = Modifier) {
+private fun WelcomeLoadingCard(
+    syncProgress: SyncProgress?,
+    modifier: Modifier = Modifier
+) {
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(28.dp),
@@ -146,24 +154,72 @@ private fun WelcomeLoadingCard(modifier: Modifier = Modifier) {
             modifier = Modifier.padding(horizontal = 36.dp, vertical = 28.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            val pillLabel = if (syncProgress != null) {
+                stringResource(sectionLabelRes(syncProgress.section))
+            } else {
+                stringResource(R.string.app_name)
+            }
+            val pillColor = if (syncProgress != null) {
+                sectionColor(syncProgress.section)
+            } else {
+                AppColors.BrandMuted
+            }
             StatusPill(
-                label = stringResource(R.string.app_name),
-                containerColor = AppColors.BrandMuted
+                label = pillLabel,
+                containerColor = pillColor
             )
             Spacer(modifier = Modifier.height(18.dp))
-            CircularProgressIndicator(color = AppColors.Brand)
-            Spacer(modifier = Modifier.height(18.dp))
+            // D13 — spinner masqué dès qu'on a une progression structurée.
+            if (syncProgress == null) {
+                CircularProgressIndicator(color = AppColors.Brand)
+                Spacer(modifier = Modifier.height(18.dp))
+            }
             Text(
                 text = stringResource(R.string.welcome_loading_title),
                 style = MaterialTheme.typography.titleLarge,
                 color = AppColors.TextPrimary
             )
             Spacer(modifier = Modifier.height(6.dp))
+            val subtitle = if (syncProgress != null && syncProgress.currentLabel.isNotBlank()) {
+                syncProgress.currentLabel
+            } else {
+                stringResource(R.string.welcome_loading_subtitle)
+            }
             Text(
-                text = stringResource(R.string.welcome_loading_subtitle),
+                text = subtitle,
                 style = MaterialTheme.typography.bodyLarge,
                 color = AppColors.TextSecondary
             )
+            if (syncProgress != null) {
+                Spacer(modifier = Modifier.height(14.dp))
+                if (syncProgress.total > 0) {
+                    LinearProgressIndicator(
+                        progress = { syncProgress.current.toFloat() / syncProgress.total.toFloat() },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .width(260.dp),
+                        color = AppColors.Brand,
+                        trackColor = AppColors.BrandMuted
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .width(260.dp),
+                        color = AppColors.Brand,
+                        trackColor = AppColors.BrandMuted
+                    )
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+                Text(
+                    text = stringResource(
+                        R.string.sync_items_indexed_format,
+                        syncProgress.itemsIndexed
+                    ),
+                    style = MaterialTheme.typography.labelLarge,
+                    color = AppColors.TextSecondary
+                )
+            }
         }
     }
 }
@@ -227,4 +283,17 @@ private fun WelcomeStartCard(
             }
         }
     }
+}
+
+@Composable
+private fun sectionColor(section: Section): Color = when (section) {
+    Section.LIVE -> AppColors.Brand
+    Section.VOD -> AppColors.Success
+    Section.SERIES -> AppColors.Warning
+}
+
+private fun sectionLabelRes(section: Section): Int = when (section) {
+    Section.LIVE -> R.string.sync_section_live
+    Section.VOD -> R.string.sync_section_vod
+    Section.SERIES -> R.string.sync_section_series
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt
@@ -36,28 +36,52 @@ import com.streamvault.app.R
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.interaction.TvButton
+import com.streamvault.data.sync.SyncProgressBus
 import com.streamvault.domain.repository.ProviderRepository
+import com.streamvault.domain.sync.SyncProgress
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WelcomeViewModel @Inject constructor(
-    private val providerRepository: ProviderRepository
+    private val providerRepository: ProviderRepository,
+    syncProgressBus: SyncProgressBus
 ) : ViewModel() {
 
     private val _hasProviders = MutableStateFlow<Boolean?>(null)
     val hasProviders: StateFlow<Boolean?> = _hasProviders.asStateFlow()
+
+    // D8 — garde anti-rebond : une fois `hasProviders` connu (true ou false),
+    // on cesse définitivement de relayer le bus pour ne pas afficher la
+    // progression d'un sync ultérieur (settings refresh, retry) sur Welcome.
+    private val acceptingProgress = MutableStateFlow(true)
+
+    val syncProgress: StateFlow<SyncProgress?> =
+        combine(syncProgressBus.flow, acceptingProgress) { progress, accept ->
+            if (accept) progress else null
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     init {
         viewModelScope.launch {
             providerRepository.getProviders()
                 .map { it.isNotEmpty() }
                 .collect { _hasProviders.value = it }
+        }
+        viewModelScope.launch {
+            _hasProviders
+                .filterNotNull()
+                .first()
+            acceptingProgress.value = false
         }
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -13,6 +13,10 @@
     <string name="welcome_version">v1.0.3</string>
     <string name="welcome_loading_title">Préparation de votre bibliothèque</string>
     <string name="welcome_loading_subtitle">Ouverture du bon écran pour cet appareil.</string>
+    <string name="sync_section_live">Live</string>
+    <string name="sync_section_vod">VOD</string>
+    <string name="sync_section_series">Séries</string>
+    <string name="sync_items_indexed_format">%1$d éléments indexés</string>
     <string name="welcome_tagline">IPTV premium pour le salon</string>
     <string name="welcome_subtitle">Profitez des chaînes en direct, du visionnage de rattrapage, des films et des séries avec une expérience Android TV propriétaire.</string>
     <string name="welcome_feature_live">Navigation en direct rapide avec mise au point à distance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
     <string name="welcome_version">v1.0.3</string>
     <string name="welcome_loading_title">Preparing your library</string>
     <string name="welcome_loading_subtitle">Opening the right screen for this device.</string>
+    <string name="sync_section_live">Live</string>
+    <string name="sync_section_vod">VOD</string>
+    <string name="sync_section_series">Series</string>
+    <string name="sync_items_indexed_format">%1$d items indexed</string>
     <string name="welcome_tagline">Premium IPTV for the living room</string>
     <string name="welcome_subtitle">Lean back into live channels, catch-up viewing, movies, and series with a first-party Android TV experience.</string>
     <string name="welcome_feature_live">Fast live browsing with remote-first focus</string>

--- a/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
@@ -166,7 +166,8 @@ class SyncManager @Inject constructor(
     private val credentialCrypto: CredentialCrypto,
     private val syncMetadataRepository: SyncMetadataRepository,
     private val transactionRunner: DatabaseTransactionRunner,
-    private val preferencesRepository: com.streamvault.data.preferences.PreferencesRepository
+    private val preferencesRepository: com.streamvault.data.preferences.PreferencesRepository,
+    private val syncProgressBus: SyncProgressBus
 ) {
     private val syncStateTracker = SyncStateTracker()
     private val syncErrorSanitizer = SyncErrorSanitizer()
@@ -456,65 +457,71 @@ class SyncManager @Inject constructor(
         onProgress: ((String) -> Unit)? = null,
         trackInitialLiveOnboarding: Boolean = false
     ): com.streamvault.domain.model.Result<Unit> = withProviderLock(providerId) lock@{
-        val providerEntity = providerDao.getById(providerId)
-            ?: return@lock com.streamvault.domain.model.Result.error("Provider $providerId not found")
-
-        val provider = providerEntity
-            .copy(password = credentialCrypto.decryptIfNeeded(providerEntity.password))
-            .toDomain()
-            .let { resolvedProvider ->
-                resolvedProvider.copy(
-                    xtreamFastSyncEnabled = movieFastSyncOverride ?: resolvedProvider.xtreamFastSyncEnabled,
-                    epgSyncMode = epgSyncModeOverride ?: resolvedProvider.epgSyncMode
-                )
-            }
-        publishSyncState(providerId, SyncState.Syncing("Starting..."))
-
         try {
-            val outcome = withContext(Dispatchers.IO) {
-                when (provider.type) {
-                    ProviderType.XTREAM_CODES -> syncXtreamIndexFirst(
-                        provider = provider,
-                        force = force,
-                        onProgress = onProgress,
-                        trackInitialLiveOnboarding = trackInitialLiveOnboarding,
-                        syncReason = if (trackInitialLiveOnboarding) {
-                            XtreamLiveSyncReason.INITIAL_ONBOARDING
-                        } else {
-                            XtreamLiveSyncReason.FOREGROUND
-                        }
+            val providerEntity = providerDao.getById(providerId)
+                ?: return@lock com.streamvault.domain.model.Result.error("Provider $providerId not found")
+
+            val provider = providerEntity
+                .copy(password = credentialCrypto.decryptIfNeeded(providerEntity.password))
+                .toDomain()
+                .let { resolvedProvider ->
+                    resolvedProvider.copy(
+                        xtreamFastSyncEnabled = movieFastSyncOverride ?: resolvedProvider.xtreamFastSyncEnabled,
+                        epgSyncMode = epgSyncModeOverride ?: resolvedProvider.epgSyncMode
                     )
-                    ProviderType.M3U -> syncM3u(provider, force, onProgress)
-                    ProviderType.STALKER_PORTAL -> syncStalker(provider, force, onProgress)
                 }
-            }
-            providerDao.updateSyncTime(providerId, System.currentTimeMillis())
-            updateSyncStatusMetadata(
-                providerId = providerId,
-                status = if (outcome.partial) "PARTIAL" else "SUCCESS"
-            )
-            publishSyncState(providerId, if (outcome.partial) {
-                SyncState.Partial("Sync completed with warnings", outcome.warnings)
-            } else {
-                SyncState.Success()
-            })
-            com.streamvault.domain.model.Result.success(Unit)
-        } catch (e: CancellationException) {
-            resetState(providerId)
-            throw e
-        } catch (e: Exception) {
-            val safeMessage = syncErrorSanitizer.userMessage(e, "Sync failed")
-            Log.e(TAG, "Sync failed for provider $providerId: ${syncErrorSanitizer.throwableMessage(e)}")
-            if (provider.type == ProviderType.XTREAM_CODES && trackInitialLiveOnboarding) {
-                recordXtreamLiveOnboardingState(
-                    provider = provider,
-                    phase = XTREAM_ONBOARDING_PHASE_FAILED,
-                    lastError = sanitizeThrowableMessage(e)
+            publishSyncState(providerId, SyncState.Syncing("Starting..."))
+
+            try {
+                val outcome = withContext(Dispatchers.IO) {
+                    when (provider.type) {
+                        ProviderType.XTREAM_CODES -> syncXtreamIndexFirst(
+                            provider = provider,
+                            force = force,
+                            onProgress = onProgress,
+                            trackInitialLiveOnboarding = trackInitialLiveOnboarding,
+                            syncReason = if (trackInitialLiveOnboarding) {
+                                XtreamLiveSyncReason.INITIAL_ONBOARDING
+                            } else {
+                                XtreamLiveSyncReason.FOREGROUND
+                            }
+                        )
+                        ProviderType.M3U -> syncM3u(provider, force, onProgress)
+                        ProviderType.STALKER_PORTAL -> syncStalker(provider, force, onProgress)
+                    }
+                }
+                providerDao.updateSyncTime(providerId, System.currentTimeMillis())
+                updateSyncStatusMetadata(
+                    providerId = providerId,
+                    status = if (outcome.partial) "PARTIAL" else "SUCCESS"
                 )
+                publishSyncState(providerId, if (outcome.partial) {
+                    SyncState.Partial("Sync completed with warnings", outcome.warnings)
+                } else {
+                    SyncState.Success()
+                })
+                com.streamvault.domain.model.Result.success(Unit)
+            } catch (e: CancellationException) {
+                resetState(providerId)
+                throw e
+            } catch (e: Exception) {
+                val safeMessage = syncErrorSanitizer.userMessage(e, "Sync failed")
+                Log.e(TAG, "Sync failed for provider $providerId: ${syncErrorSanitizer.throwableMessage(e)}")
+                if (provider.type == ProviderType.XTREAM_CODES && trackInitialLiveOnboarding) {
+                    recordXtreamLiveOnboardingState(
+                        provider = provider,
+                        phase = XTREAM_ONBOARDING_PHASE_FAILED,
+                        lastError = sanitizeThrowableMessage(e)
+                    )
+                }
+                updateSyncStatusMetadata(providerId = providerId, status = "ERROR")
+                publishSyncState(providerId, SyncState.Error(safeMessage, e))
+                com.streamvault.domain.model.Result.error(safeMessage, e)
             }
-            updateSyncStatusMetadata(providerId = providerId, status = "ERROR")
-            publishSyncState(providerId, SyncState.Error(safeMessage, e))
-            com.streamvault.domain.model.Result.error(safeMessage, e)
+        } finally {
+            // D7 — reset systematique du bus a la fin du cycle (succes, exception, abort low-memory)
+            // pour eviter qu'un ecran ulterieur n'herite d'un etat de progression obsolete.
+            syncProgressBus.reset()
         }
     }
 

--- a/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
@@ -953,6 +953,18 @@ class SyncManager @Inject constructor(
         )
         scheduleXtreamIndexSync(provider.id, ContentType.LIVE)
 
+        // Transition VOD : signale a l'UI qu'on passe a la section Movies. Le total
+        // reel des categories VOD n'est connu qu'a l'interieur de `syncXtreamCategoryShell`,
+        // donc on emet en indetermine (total = 0). `itemsIndexed` cumule le LIVE deja importe.
+        syncProgressBus.emit(
+            com.streamvault.domain.sync.SyncProgress(
+                section = com.streamvault.domain.sync.Section.VOD,
+                current = 0,
+                total = 0,
+                currentLabel = "",
+                itemsIndexed = liveCount
+            )
+        )
         val movieCategoryCount = syncXtreamCategoryShell(
             provider = provider,
             api = api,
@@ -975,6 +987,18 @@ class SyncManager @Inject constructor(
         if (movieCategoryCount > 0) {
             scheduleXtreamIndexSync(provider.id, ContentType.MOVIE)
         }
+        // Transition SERIES : meme principe que VOD ci-dessus. `itemsIndexed` reste a
+        // `liveCount` car VOD ne stage pas d'items dans la base au moment du shell
+        // (le contenu detaille est rempli ulterieurement par XtreamIndexWorker).
+        syncProgressBus.emit(
+            com.streamvault.domain.sync.SyncProgress(
+                section = com.streamvault.domain.sync.Section.SERIES,
+                current = 0,
+                total = 0,
+                currentLabel = "",
+                itemsIndexed = liveCount
+            )
+        )
         val seriesCategoryCount = syncXtreamCategoryShell(
             provider = provider,
             api = api,

--- a/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
@@ -243,7 +243,8 @@ class SyncManager @Inject constructor(
             categoryFailureWarning = ::categoryFailureWarning,
             liveCategorySequentialModeWarning = LIVE_CATEGORY_SEQUENTIAL_MODE_WARNING,
             isCurrentlyLowOnMemory = applicationContext::isCurrentlyLowOnMemoryForSync,
-            stageChannelItems = catalogStager::stageChannelItems
+            stageChannelItems = catalogStager::stageChannelItems,
+            syncProgressBus = syncProgressBus
         )
     }
 

--- a/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
@@ -2930,6 +2930,18 @@ class SyncManager @Inject constructor(
         trackInitialLiveOnboarding: Boolean = false,
         syncReason: XtreamLiveSyncReason = XtreamLiveSyncReason.FOREGROUND
     ): CatalogSyncPayload<Channel> {
+        // Emission d'entree LIVE : signale tot a l'UI que la section LIVE demarre,
+        // avant meme la requete `get_live_categories`. `total = 0` = indetermine ;
+        // la premiere fin de fenetre (T5) viendra raffiner avec le vrai denominateur.
+        syncProgressBus.emit(
+            com.streamvault.domain.sync.SyncProgress(
+                section = com.streamvault.domain.sync.Section.LIVE,
+                current = 0,
+                total = 0,
+                currentLabel = "",
+                itemsIndexed = 0
+            )
+        )
         val effectiveLiveSyncMethod = XtreamLiveSyncPolicy.resolve(
             userMode = provider.xtreamLiveSyncMode,
             runtimeProfile = runtimeProfile,

--- a/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManager.kt
@@ -186,7 +186,8 @@ class SyncManager @Inject constructor(
         okHttpClient = okHttpClient,
         syncCatalogStore = syncCatalogStore,
         retryTransient = { block -> retryTransient(block = block) },
-        progress = ::progress
+        progress = ::progress,
+        syncProgressBus = syncProgressBus
     )
     private val xtreamSupport = SyncManagerXtreamSupport(
         adaptiveSyncPolicy = xtreamAdaptiveSyncPolicy,

--- a/data/src/main/java/com/streamvault/data/sync/SyncManagerM3uImporter.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManagerM3uImporter.kt
@@ -12,6 +12,8 @@ import com.streamvault.data.util.AdultContentClassifier
 import com.streamvault.data.util.UrlSecurityPolicy
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.Provider
+import com.streamvault.domain.sync.Section
+import com.streamvault.domain.sync.SyncProgress
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -29,7 +31,8 @@ internal class SyncManagerM3uImporter(
     private val okHttpClient: OkHttpClient,
     private val syncCatalogStore: SyncCatalogStore,
     private val retryTransient: suspend (suspend () -> Unit) -> Unit,
-    private val progress: (Long, ((String) -> Unit)?, String) -> Unit
+    private val progress: (Long, ((String) -> Unit)?, String) -> Unit,
+    private val syncProgressBus: SyncProgressBus
 ) {
     suspend fun importPlaylist(
         provider: Provider,
@@ -42,6 +45,18 @@ internal class SyncManagerM3uImporter(
             throw IllegalStateException(message)
         }
         progress(provider.id, onProgress, "Downloading Playlist...")
+        // D14 — emission M3U etape Downloading : Section.LIVE par convention (le M3U
+        // peut contenir un melange Live/VOD, mais l'UI ne distingue pas). Mode
+        // indetermine (total = 0) puisqu'on ne connait pas encore la taille du flux.
+        syncProgressBus.emit(
+            SyncProgress(
+                section = Section.LIVE,
+                current = 0,
+                total = 0,
+                currentLabel = "",
+                itemsIndexed = 0
+            )
+        )
         syncCatalogStore.clearProviderStaging(provider.id)
         val sessionId = syncCatalogStore.newSessionId()
         val stableLongHasher = StableLongHasher()
@@ -62,6 +77,16 @@ internal class SyncManagerM3uImporter(
         try {
             openPlaylistStream(provider) { streamed ->
                 progress(provider.id, onProgress, "Parsing Playlist...")
+                // D14 — emission M3U etape Parsing : meme section / mode indetermine.
+                syncProgressBus.emit(
+                    SyncProgress(
+                        section = Section.LIVE,
+                        current = 0,
+                        total = 0,
+                        currentLabel = "",
+                        itemsIndexed = 0
+                    )
+                )
                 maybeDecompressPlaylist(streamed).use { input ->
                     m3uParser.parseStreaming(
                         inputStream = input,
@@ -76,6 +101,18 @@ internal class SyncManagerM3uImporter(
                         parsedCount++
                         if (parsedCount >= nextMilestone) {
                             progress(provider.id, onProgress, "Imported $parsedCount playlist entries...")
+                            // D14 — emission M3U etape Imported : current = nombre d'entrees
+                            // parsees jusqu'ici (palier de M3U_PROGRESS_INTERVAL), `itemsIndexed`
+                            // refletera la meme valeur (compteur cumulatif local).
+                            syncProgressBus.emit(
+                                SyncProgress(
+                                    section = Section.LIVE,
+                                    current = parsedCount,
+                                    total = 0,
+                                    currentLabel = "",
+                                    itemsIndexed = parsedCount
+                                )
+                            )
                             nextMilestone += M3U_PROGRESS_INTERVAL
                         }
                         if (!UrlSecurityPolicy.isAllowedStreamEntryUrl(entry.url)) {

--- a/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
@@ -242,6 +242,20 @@ internal class SyncManagerXtreamLiveStrategy(
 
         fun abortIfLowMemory() {
             if (isCurrentlyLowOnMemory()) {
+                // D12 — emission finale avant l'avortement low-memory : reflete l'etat
+                // au moment de l'echec (section LIVE, mode indetermine, nombre d'items
+                // deja acceptes). Le `reset()` du finally cote SyncManager (T3) viendra
+                // ensuite ramener le flow a null — c'est volontaire (D7) pour eviter que
+                // l'ecran suivant n'herite d'un etat partiel.
+                syncProgressBus.emit(
+                    SyncProgress(
+                        section = Section.LIVE,
+                        current = 0,
+                        total = 0,
+                        currentLabel = "",
+                        itemsIndexed = acceptedCount
+                    )
+                )
                 throw LowMemoryCatalogAbortException(
                     "Device entered low-memory state while streaming Live catalog; falling back to category sync."
                 )

--- a/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
@@ -13,6 +13,8 @@ import com.streamvault.domain.model.Channel
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.Provider
 import com.streamvault.domain.model.SyncMetadata
+import com.streamvault.domain.sync.Section
+import com.streamvault.domain.sync.SyncProgress
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.system.measureTimeMillis
@@ -40,7 +42,8 @@ internal class SyncManagerXtreamLiveStrategy(
     private val categoryFailureWarning: (String, String, Throwable) -> String,
     private val liveCategorySequentialModeWarning: String,
     private val isCurrentlyLowOnMemory: () -> Boolean = { false },
-    private val stageChannelItems: suspend (Long, List<Channel>, MutableSet<Long>, FallbackCategoryCollector, Long?) -> StagedCatalogSnapshot
+    private val stageChannelItems: suspend (Long, List<Channel>, MutableSet<Long>, FallbackCategoryCollector, Long?) -> StagedCatalogSnapshot,
+    private val syncProgressBus: SyncProgressBus
 ) {
     suspend fun syncXtreamLiveCatalog(
         provider: Provider,
@@ -409,6 +412,9 @@ internal class SyncManagerXtreamLiveStrategy(
         val concurrency = adaptiveConcurrency.coerceAtMost(runtimeProfile.maxCategoryConcurrency)
         progress(provider.id, onProgress, "Downloading Live TV by category 0/${categories.size}...")
 
+        // D11 — le total de catégories LIVE est fige une seule fois ici : la liste
+        // `categories` ne mute plus pendant la recuperation, donc la lambda
+        // `onCategoryCompleted` recoit le meme denominateur a chaque fenetre.
         val executionPlan = xtreamSupport.executeCategoryRecoveryPlan(
             provider = provider,
             categories = categories,
@@ -423,6 +429,22 @@ internal class SyncManagerXtreamLiveStrategy(
                     category = category,
                     stageBatchSize = runtimeProfile.stageBatchSize,
                     onMappedBatch = ::stageMappedBatch
+                )
+            },
+            onCategoryCompleted = { completed, total, currentLabel ->
+                // D6 — emission structuree en parallele du callback string deja emis par
+                // `executeCategoryRecoveryPlan` via `progress(...)`. Le compteur cumulatif
+                // `stagedAcceptedCount` est mis a jour de maniere thread-safe sous le
+                // `stageMutex` (cf `stageMappedBatch`), la lecture ici est best-effort
+                // (snapshot UX, pas une metrique business).
+                syncProgressBus.emit(
+                    SyncProgress(
+                        section = Section.LIVE,
+                        current = completed,
+                        total = total,
+                        currentLabel = currentLabel,
+                        itemsIndexed = stagedAcceptedCount
+                    )
                 )
             }
         )

--- a/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt
@@ -268,6 +268,19 @@ internal class SyncManagerXtreamLiveStrategy(
             acceptedCount += staged.acceptedCount
             flushCount++
             rawBatch.clear()
+            // D10 — mode HIGH (full catalog) : pas de count par categorie disponible,
+            // on emet en indetermine (`total = 0`) une fois par flush de batch (cadence
+            // <= 1/s en pratique, jamais par item). Le label reste vide car aucune
+            // categorie ne correspond a la fenetre courante.
+            syncProgressBus.emit(
+                SyncProgress(
+                    section = Section.LIVE,
+                    current = 0,
+                    total = 0,
+                    currentLabel = "",
+                    itemsIndexed = acceptedCount
+                )
+            )
             abortIfLowMemory()
         }
 

--- a/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamSupport.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamSupport.kt
@@ -35,7 +35,8 @@ internal class SyncManagerXtreamSupport(
         sectionLabel: String,
         sequentialModeWarning: String,
         onProgress: ((String) -> Unit)?,
-        fetch: suspend (XtreamCategory) -> TimedCategoryOutcome<T>
+        fetch: suspend (XtreamCategory) -> TimedCategoryOutcome<T>,
+        onCategoryCompleted: ((completed: Int, total: Int, currentLabel: String) -> Unit)? = null
     ): CategoryExecutionPlan<T> {
         if (categories.isEmpty()) {
             return CategoryExecutionPlan(emptyList())
@@ -69,6 +70,11 @@ internal class SyncManagerXtreamSupport(
 
             val completed = outcomes.size
             progress(provider.id, onProgress, "Downloading $sectionLabel by category $completed/${categories.size}...")
+            // Hook d'emission optionnel (M1 — T4) : permet aux strategies d'emettre un
+            // SyncProgress structure apres chaque fenetre traitee. Le label correspond a
+            // la derniere categorie de la fenetre (pertinent en mode sequentiel ; en mode
+            // concurrent, la fenetre est petite donc le label reste representatif).
+            onCategoryCompleted?.invoke(completed, categories.size, window.last().categoryName)
 
             if (!forceSequential && shouldRecoverRemainingCategoryRequests(categories.size, completed, outcomes.map { it.outcome })) {
                 forceSequential = true

--- a/data/src/main/java/com/streamvault/data/sync/SyncProgressBus.kt
+++ b/data/src/main/java/com/streamvault/data/sync/SyncProgressBus.kt
@@ -1,0 +1,35 @@
+package com.streamvault.data.sync
+
+import com.streamvault.domain.sync.SyncProgress
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Bus singleton de progression du sync catalogue.
+ *
+ * Publie le dernier [SyncProgress] émis par `SyncManager` et ses stratégies, consommé
+ * par `WelcomeViewModel` côté `:app`. Pattern miroir de `SyncStateTracker` (StateFlow
+ * privé mutable + façade publique read-only).
+ *
+ * Valeur initiale `null` = aucun sync en cours / écran fallback. `reset()` ramène
+ * explicitement le flow à `null` à la fin de chaque cycle (succès, échec ou abort
+ * low-memory) pour éviter qu'un écran ultérieur n'hérite d'un état obsolète.
+ */
+@Singleton
+class SyncProgressBus @Inject constructor() {
+
+    private val _flow = MutableStateFlow<SyncProgress?>(null)
+
+    val flow: StateFlow<SyncProgress?> = _flow.asStateFlow()
+
+    fun emit(progress: SyncProgress) {
+        _flow.value = progress
+    }
+
+    fun reset() {
+        _flow.value = null
+    }
+}

--- a/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
+++ b/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
@@ -331,7 +331,8 @@ class SyncManagerTest {
         credentialCrypto = credentialCrypto,
         syncMetadataRepository = syncMetadataRepo,
         transactionRunner = transactionRunner,
-        preferencesRepository = preferencesRepo
+        preferencesRepository = preferencesRepo,
+        syncProgressBus = SyncProgressBus()
     )
 
     // ── Initial state ───────────────────────────────────────────────

--- a/data/src/test/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategyTest.kt
+++ b/data/src/test/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategyTest.kt
@@ -1024,7 +1024,8 @@ class SyncManagerXtreamLiveStrategyTest {
             categoryFailureWarning = { section, category, error -> "$section category $category failed: ${sanitize(error)}" },
             liveCategorySequentialModeWarning = "Live category sync used sequential mode.",
             isCurrentlyLowOnMemory = isCurrentlyLowOnMemory,
-            stageChannelItems = stageChannelItems
+            stageChannelItems = stageChannelItems,
+            syncProgressBus = SyncProgressBus()
         )
     }
 

--- a/data/src/test/java/com/streamvault/data/sync/SyncProgressBusTest.kt
+++ b/data/src/test/java/com/streamvault/data/sync/SyncProgressBusTest.kt
@@ -1,0 +1,101 @@
+package com.streamvault.data.sync
+
+import com.google.common.truth.Truth.assertThat
+import com.streamvault.domain.sync.Section
+import com.streamvault.domain.sync.SyncProgress
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Tests unitaires de [SyncProgressBus].
+ *
+ * Couvre les 4 cas du test plan §7 du SCOPE M1 :
+ * 1. `emit` met à jour la valeur courante du flow.
+ * 2. `reset` remet le flow à `null`.
+ * 3. Deux collectors observent la même séquence d'émissions.
+ * 4. Un collector qui souscrit tardivement reçoit la dernière valeur (contrat StateFlow).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SyncProgressBusTest {
+
+    @Test
+    fun emit_updatesFlowValue() = runTest {
+        val bus = SyncProgressBus()
+        val progress = SyncProgress(
+            section = Section.LIVE,
+            current = 3,
+            total = 10,
+            currentLabel = "Sport",
+            itemsIndexed = 42
+        )
+
+        bus.emit(progress)
+
+        assertThat(bus.flow.value).isEqualTo(progress)
+    }
+
+    @Test
+    fun reset_setsFlowToNull() = runTest {
+        val bus = SyncProgressBus()
+        bus.emit(
+            SyncProgress(
+                section = Section.VOD,
+                current = 1,
+                total = 5,
+                currentLabel = "Movies",
+                itemsIndexed = 100
+            )
+        )
+        assertThat(bus.flow.value).isNotNull()
+
+        bus.reset()
+
+        assertThat(bus.flow.value).isNull()
+    }
+
+    @Test
+    fun twoCollectors_receiveSameSequence() = runTest(UnconfinedTestDispatcher()) {
+        val bus = SyncProgressBus()
+        val first = mutableListOf<SyncProgress?>()
+        val second = mutableListOf<SyncProgress?>()
+
+        val firstJob = launch { bus.flow.toList(first) }
+        val secondJob = launch { bus.flow.toList(second) }
+
+        val progressLive = SyncProgress(Section.LIVE, 1, 4, "Live", 10)
+        val progressVod = SyncProgress(Section.VOD, 2, 4, "VOD", 20)
+        bus.emit(progressLive)
+        bus.emit(progressVod)
+        bus.reset()
+
+        firstJob.cancel()
+        secondJob.cancel()
+
+        assertThat(first).containsExactly(null, progressLive, progressVod, null).inOrder()
+        assertThat(second).containsExactly(null, progressLive, progressVod, null).inOrder()
+    }
+
+    @Test
+    fun lateCollector_receivesReplayValue() = runTest(UnconfinedTestDispatcher()) {
+        val bus = SyncProgressBus()
+        val progress = SyncProgress(
+            section = Section.SERIES,
+            current = 7,
+            total = 12,
+            currentLabel = "Drama",
+            itemsIndexed = 350
+        )
+
+        bus.emit(progress)
+
+        val received = mutableListOf<SyncProgress?>()
+        val job = launch { bus.flow.toList(received) }
+        job.cancel()
+
+        assertThat(received).containsExactly(progress)
+    }
+}

--- a/domain/src/main/java/com/streamvault/domain/sync/SyncProgress.kt
+++ b/domain/src/main/java/com/streamvault/domain/sync/SyncProgress.kt
@@ -1,0 +1,35 @@
+package com.streamvault.domain.sync
+
+/**
+ * Snapshot immuable de la progression d'un cycle de synchronisation catalogue.
+ *
+ * Émis par `SyncManager` (côté `:data`) sur le bus partagé, consommé par l'UI Welcome.
+ * Tous les champs sont des primitives ou des enums — la donnée est sûre à snapshotter
+ * dans un `StateFlow`.
+ *
+ * @property section Section catalogue en cours d'indexation.
+ * @property current Index de la fenêtre courante (catégorie, lot ou item selon la section).
+ * @property total Total cible pour la section courante. `0` signale un mode indéterminé
+ *                 (ex. profile HIGH pour LIVE, ou import M3U avant fin du parsing).
+ * @property currentLabel Libellé contextuel de la fenêtre courante (nom de catégorie,
+ *                        d'étape M3U, etc.). Peut être vide.
+ * @property itemsIndexed Compteur cumulatif d'items importés depuis le début du sync,
+ *                        toutes sections confondues.
+ */
+data class SyncProgress(
+    val section: Section,
+    val current: Int,
+    val total: Int,
+    val currentLabel: String,
+    val itemsIndexed: Int
+)
+
+/**
+ * Section du catalogue en cours de synchronisation. L'ordre déclaré reflète la séquence
+ * d'exécution du sync (LIVE puis VOD puis SERIES).
+ */
+enum class Section {
+    LIVE,
+    VOD,
+    SERIES
+}


### PR DESCRIPTION
## Summary

Replaces the static "Preparing your library" dialog on `WelcomeScreen`
with a **typed, real-time progress feedback** during the initial Xtream
(and M3U) catalog sync. On accounts with thousands of channels, the
initial sync can take 5 to 15 minutes; until now the user stared at a
frozen-looking spinner with no indication of progress, section, or ETA.

This PR introduces a structured `SyncProgress` model exposed via a
singleton `SyncProgressBus` and rendered on `WelcomeScreen` with a
section pill (Live / VOD / Series), a determinate or indeterminate
linear progress bar, the current category label, and a cumulative
items counter.

**No public signatures changed.** The existing `onProgress: ((String) -> Unit)?`
callback is preserved verbatim across the whole sync pipeline; the new
typed bus is emitted **in parallel** (dual-channel design). Callers
that don't observe the bus are entirely unaffected.

## Screenshots

Three snapshots of the same first-boot Xtream sync (Android TV emulator,
~5000 live channels test account). The UI is in French locale to also
exercise the new `values-fr/strings.xml` keys; English locale would
render exactly the same with `"Live"`, `"Preparing your library"`,
`"N items indexed"`.

**Frame 1 — early-mid sync, US/ESPN+ category, ~50% of categories done**

![Welcome sync progress — ESPN+ DAILY UPDATED, 8993 items indexed](https://github.com/user-attachments/assets/cb3decb8-5fc6-4bba-ab43-e034b573e1fa)

**Frame 2 — a few seconds later, MLS PPV, ~55%**

![Welcome sync progress — MLS PPV, 9791 items indexed](https://github.com/user-attachments/assets/4d9f3c48-f06d-4d5c-a1f1-c5980292708b)

**Frame 3 — LATINO NETWORK, ~60%, counter monotonically increasing**

![Welcome sync progress — LATINO NETWORK, 10824 items indexed](https://github.com/user-attachments/assets/87826482-7a5a-4e27-87c0-e043c3115607)

Observable between the three frames:

- the `Live` section pill stays steady (we're still in the LIVE phase)
- the **subtitle changes** at each completed category (`ESPN+ DAILY UPDATED` → `MLS PPV` → `LATINO NETWORK`)
- the **determinate `LinearProgressIndicator` advances** monotonically as `current / liveCategoryTotal` grows
- the **cumulative counter** (`8993` → `9791` → `10824`) reflects all live items indexed so far
- the **`CircularProgressIndicator` is hidden** (D13), avoiding the double-feedback that would otherwise occur

The static fallback (title, subtitle `welcome_loading_subtitle`,
`CircularProgressIndicator`) is preserved untouched whenever the bus has
not emitted yet (`syncProgress == null`), so any flow that doesn't pass
through the new bus keeps the exact original look.

## Architecture

```
domain/                            data/                                                 app/
─────────                          ──────                                                ─────
SyncProgress (data class)          SyncProgressBus @Singleton                            WelcomeViewModel
  - section: Section                 - _flow: MutableStateFlow<SyncProgress?>              - observes bus.flow
  - current/total: Int               - flow: StateFlow<SyncProgress?>                      - acceptingProgress flag
  - currentLabel: String             - emit(p) / reset()                                   - exposes combined syncProgress
  - itemsIndexed: Int                       ▲                                                       │
Section (enum)                             │ injected                                               ▼
  LIVE | VOD | SERIES                      │                                              WelcomeScreen
                                   SyncManager (Hilt @Inject)                              - dynamic StatusPill
                                     ├── syncXtreamLiveStrategy (LIVE)                     - LinearProgressIndicator
                                     ├── syncXtreamCategoryShell (VOD/SERIES)              - dynamic subtitle
                                     └── m3uImporter (M3U)                                 - cumulative counter
                                   emissions → bus.emit(SyncProgress(...))
                                   end of sync() → bus.reset()
```

## Key design decisions

| # | Decision | Rationale |
|---|----------|-----------|
| Bus shape | Concrete `@Singleton class @Inject constructor()` (no interface) | Mirrors the existing `SyncStateTracker` pattern; no need for a double impl right now. |
| Backward compatibility | **Dual-channel**: existing `onProgress` string callback preserved, typed bus added in parallel. | No public signature changes; zero risk for existing callers (settings refresh, manual provider setup, …). |
| Reset semantics | `bus.reset()` called in `SyncManager.sync()`'s `finally` block. | Covers success, failure, and `LowMemoryCatalogAbortException`. Next UI doesn't inherit a stale state. |
| `Section` enum | 3 values: `LIVE`, `VOD`, `SERIES`. M3U emissions are mapped to `LIVE`. | Avoids introducing a 4th UI color for a payload that's mixed Live+Movies anyway. |
| VM re-observation guard | A `MutableStateFlow<Boolean>(true)` flag in `WelcomeViewModel` is flipped to `false` once `hasProviders` becomes non-null. No re-arming. | Defensive against background syncs (settings refresh, retry) that might emit while Welcome is mounted but already navigated. |
| HIGH profile / full catalog | Degraded progress: `total = 0` (indeterminate UI) + `itemsIndexed` updated periodically. | One-shot full catalog has no per-category counter; honest indeterminate beats a fake percentage. |
| Spinner conflict | `CircularProgressIndicator` hidden when `syncProgress != null`. | Avoids double-feedback (spinner + linear bar simultaneously). Static fallback unchanged when `syncProgress == null`. |
| Color mapping | LIVE → `AppColors.Brand`, VOD → `AppColors.Success`, SERIES → `AppColors.Warning` | Reuses existing design tokens, progressive cool→warm gradient matching the natural sync order. |

## What's instrumented

| Source | When | Emission |
|--------|------|----------|
| `SyncManager.syncXtreamLiveCatalog` | Just before LIVE strategy starts | `SyncProgress(LIVE, 0, 0, "", 0)` |
| `SyncManagerXtreamLiveStrategy.loadXtreamLiveByCategory` | After each category window completes | `SyncProgress(LIVE, completed, liveCategoryTotal, currentLabel, cumulative)` |
| `SyncManagerXtreamLiveStrategy.loadXtreamLiveFullStreaming` | Periodically in HIGH profile | `SyncProgress(LIVE, 0, 0, batchLabel, acceptedCount)` |
| `SyncManager.syncXtreamCategoryShell` (VOD) | Before VOD shell scheduling | `SyncProgress(VOD, 0, 0, "", cumulative)` |
| `SyncManager.syncXtreamCategoryShell` (SERIES) | Before SERIES shell scheduling | `SyncProgress(SERIES, 0, 0, "", cumulative)` |
| `SyncManagerM3uImporter.importPlaylist` | At "Downloading", "Parsing", "Imported N entries" | `SyncProgress(LIVE, parsedCount, 0, "", parsedCount)` |
| Any strategy | Just before `throw LowMemoryCatalogAbortException` | Final `SyncProgress` snapshot at abort time |
| `SyncManager.sync()` | `finally` block | `bus.reset()` |

## Files

### New

- `domain/src/main/java/com/streamvault/domain/sync/SyncProgress.kt`
- `data/src/main/java/com/streamvault/data/sync/SyncProgressBus.kt`
- `data/src/test/java/com/streamvault/data/sync/SyncProgressBusTest.kt`

### Modified

- `data/src/main/java/com/streamvault/data/sync/SyncManager.kt`
- `data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategy.kt`
- `data/src/main/java/com/streamvault/data/sync/SyncManagerXtreamSupport.kt`
- `data/src/main/java/com/streamvault/data/sync/SyncManagerM3uImporter.kt`
- `data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt`
- `data/src/test/java/com/streamvault/data/sync/SyncManagerXtreamLiveStrategyTest.kt`
- `app/src/main/java/com/streamvault/app/ui/screens/welcome/WelcomeScreen.kt`
- `app/src/main/res/values/strings.xml` (+4 keys)
- `app/src/main/res/values-fr/strings.xml` (+4 keys)

## Test plan

- [x] `./gradlew clean :app:assembleDebug` — green (2m 5s)
- [x] `./gradlew :data:testDebugUnitTest` — 411 tests pass, 0 failure
- [x] `./gradlew :domain:test` — 90 tests pass, 0 failure
- [x] `SyncProgressBusTest` — 4 tests covering emit, reset, multi-collector,
      late-collector replay
- [x] Manual smoke (Android TV emulator + Xtream account with ~95 live
      categories): Welcome screen shows the pill, the determinate
      progress bar, the changing category label, and the cumulative
      counter; no crash; static fallback preserved when no sync is
      active
- [x] No public signature changes verified (`ValidateAndAddProvider`,
      `SyncManager.sync`, `loginXtream`, `addM3u` all unchanged)

## Out of scope

- ETA / throughput estimation (noisy with variable network).
- Persistence of progress across crashes.
- Settings-refresh and ProviderSetup post-validation surfaces (the bus
  is observable from there; only Welcome wired in this PR).
- Stalker portal sync (no instrumentation in this PR).

## Commits

13 atomic commits on top of `master` (`0fd7371`), each compiles
standalone with passing tests. The atomic granularity allows targeted
bisect or partial revert if a specific emission point ends up being
too noisy in production.
