### PR TITLE
feat(backup): Google Drive sync (Push/Pull) for Android TV

### DIFF
--- a/app/src/main/java/com/streamvault/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/streamvault/app/di/RepositoryModule.kt
@@ -76,6 +76,9 @@ abstract class RepositoryModule {
     abstract fun bindBackupManager(impl: com.streamvault.data.manager.BackupManagerImpl): com.streamvault.domain.manager.BackupManager
 
     @Binds @Singleton
+    abstract fun bindDriveBackupSyncManager(impl: com.streamvault.data.manager.GoogleDriveBackupSyncManager): com.streamvault.domain.manager.DriveBackupSyncManager
+
+    @Binds @Singleton
     abstract fun bindRecordingManager(impl: com.streamvault.data.manager.RecordingManagerImpl): com.streamvault.domain.manager.RecordingManager
 
     @Binds @Singleton

--- a/app/src/main/java/com/streamvault/app/ui/components/SyncProgressUtil.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/SyncProgressUtil.kt
@@ -1,0 +1,11 @@
+package com.streamvault.app.ui.components
+
+private val progressRatioRegex = Regex("(\\d+)\\s*/\\s*(\\d+)")
+
+fun extractProgressFraction(message: String): Float? {
+    val match = progressRatioRegex.find(message) ?: return null
+    val current = match.groupValues[1].toIntOrNull() ?: return null
+    val total = match.groupValues[2].toIntOrNull() ?: return null
+    if (total <= 0) return null
+    return (current.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+}

--- a/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.TextButton
@@ -64,6 +65,7 @@ import com.streamvault.app.R
 import com.streamvault.app.device.rememberIsTelevisionDevice
 import com.streamvault.app.ui.components.dialogs.PremiumDialog
 import com.streamvault.app.ui.components.dialogs.PremiumDialogFooterButton
+import com.streamvault.app.ui.components.extractProgressFraction
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.screens.settings.BackupImportPreviewDialog
 import com.streamvault.app.ui.theme.*
@@ -164,6 +166,10 @@ fun ProviderSetupScreen(
     val backupImportLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri: android.net.Uri? -> uri?.let { viewModel.inspectBackup(it.toString()) } }
+
+    val driveSignInLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result -> viewModel.completeDriveSignIn(result.data) }
 
     // ?? Effects ???????????????????????????????????????????????????????????????
     LaunchedEffect(knownLocalM3uUrls) {
@@ -321,6 +327,9 @@ fun ProviderSetupScreen(
                         showImportBackupButton = !uiState.isEditing,
                         isImportingBackup = uiState.isImportingBackup || uiState.syncProgress != null,
                         onImportBackup = { backupImportLauncher.launch(arrayOf("application/json")) },
+                        driveSignedIn = uiState.driveSignedIn,
+                        onImportFromDrive = { viewModel.importBackupFromDrive() },
+                        onDriveSignIn = { viewModel.beginDriveSignIn(driveSignInLauncher) },
                         modifier = Modifier.weight(1f).fillMaxHeight()
                     )
                 }
@@ -360,6 +369,9 @@ fun ProviderSetupScreen(
                         showImportBackupButton = !uiState.isEditing,
                         isImportingBackup = uiState.isImportingBackup || uiState.syncProgress != null,
                         onImportBackup = { backupImportLauncher.launch(arrayOf("application/json")) },
+                        driveSignedIn = uiState.driveSignedIn,
+                        onImportFromDrive = { viewModel.importBackupFromDrive() },
+                        onDriveSignIn = { viewModel.beginDriveSignIn(driveSignInLauncher) },
                         modifier = Modifier.weight(1f).fillMaxWidth()
                     )
                 }
@@ -510,6 +522,9 @@ private fun ProviderFormContent(
     showImportBackupButton: Boolean,
     isImportingBackup: Boolean,
     onImportBackup: () -> Unit,
+    driveSignedIn: Boolean,
+    onImportFromDrive: () -> Unit,
+    onDriveSignIn: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val scrollState = rememberScrollState()
@@ -731,6 +746,19 @@ private fun ProviderFormContent(
                     isLoading = isImportingBackup,
                     onClick = onImportBackup
                 )
+                if (driveSignedIn) {
+                    SmallActionButton(
+                        text = androidx.compose.ui.res.stringResource(R.string.setup_import_from_drive),
+                        isLoading = isImportingBackup,
+                        onClick = onImportFromDrive
+                    )
+                } else {
+                    SmallActionButton(
+                        text = androidx.compose.ui.res.stringResource(R.string.settings_drive_signin),
+                        isLoading = false,
+                        onClick = onDriveSignIn
+                    )
+                }
             }
         }
     }
@@ -1629,6 +1657,12 @@ private fun PasswordVisibilityGlyph(
 
 @Composable
 fun SyncProgressDialog(message: String) {
+    val fraction = extractProgressFraction(message)
+    val animatedFraction by animateFloatAsState(
+        targetValue = fraction ?: 0f,
+        animationSpec = tween(durationMillis = 400),
+        label = "syncFraction"
+    )
     PremiumDialog(
         title = androidx.compose.ui.res.stringResource(R.string.settings_syncing_title),
         subtitle = androidx.compose.ui.res.stringResource(R.string.settings_syncing_subtitle),
@@ -1646,6 +1680,18 @@ fun SyncProgressDialog(message: String) {
                     label = androidx.compose.ui.res.stringResource(R.string.settings_syncing_btn),
                     containerColor = PrimaryGlow
                 )
+                if (fraction != null) {
+                    LinearProgressIndicator(
+                        progress = { animatedFraction },
+                        color = Primary,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        color = Primary,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
                 Text(
                     text = message,
                     style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
@@ -9,6 +9,9 @@ import com.streamvault.data.remote.xtream.XtreamRequestException
 import com.streamvault.data.remote.xtream.XtreamResponseTooLargeException
 import com.streamvault.data.security.CredentialDecryptionException
 import com.streamvault.domain.manager.BackupConflictStrategy
+import com.streamvault.domain.manager.DriveAuthState
+import com.streamvault.domain.manager.DriveBackupSyncManager
+import com.streamvault.domain.model.Result as DomainResult
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupPreview
 import com.streamvault.domain.model.ActiveLiveSource
@@ -49,7 +52,8 @@ class ProviderSetupViewModel @Inject constructor(
     private val providerRepository: ProviderRepository,
     private val combinedM3uRepository: CombinedM3uRepository,
     private val validateAndAddProvider: ValidateAndAddProvider,
-    private val importBackup: ImportBackup
+    private val importBackup: ImportBackup,
+    private val driveBackupSyncManager: DriveBackupSyncManager
 ) : ViewModel() {
 
     enum class OnboardingCompletion {
@@ -84,6 +88,73 @@ class ProviderSetupViewModel @Inject constructor(
                         provider.m3uUrl.takeIf { it.startsWith("file://") }
                     }
                     .toSet()
+            }
+        }
+        viewModelScope.launch {
+            driveBackupSyncManager.authState.collect { state ->
+                _uiState.update {
+                    it.copy(driveSignedIn = state is DriveAuthState.SignedIn)
+                }
+            }
+        }
+    }
+
+    fun beginDriveSignIn(launcher: androidx.activity.result.ActivityResultLauncher<android.content.Intent>) {
+        viewModelScope.launch {
+            when (val request = driveBackupSyncManager.beginSignIn()) {
+                is DomainResult.Success -> {
+                    val intent = request.data.intent as? android.content.Intent ?: return@launch
+                    runCatching { launcher.launch(intent) }
+                }
+                is DomainResult.Error -> {
+                    _uiState.update {
+                        it.copy(error = "Drive sign-in unavailable: ${request.message}")
+                    }
+                }
+                is DomainResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun completeDriveSignIn(intentData: android.content.Intent?) {
+        viewModelScope.launch {
+            when (val signIn = driveBackupSyncManager.completeSignIn(intentData)) {
+                is DomainResult.Success -> Unit
+                is DomainResult.Error -> {
+                    _uiState.update {
+                        it.copy(error = "Drive sign-in failed: ${signIn.message}")
+                    }
+                }
+                is DomainResult.Loading -> Unit
+            }
+        }
+    }
+
+    fun importBackupFromDrive() {
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isImportingBackup = true,
+                    syncProgress = "Downloading from Drive...",
+                    validationError = null,
+                    error = null
+                )
+            }
+            when (val pullResult = driveBackupSyncManager.pullBackup()) {
+                is DomainResult.Success -> {
+                    _uiState.update { it.copy(isImportingBackup = false) }
+                    inspectBackup(pullResult.data.localUriString)
+                }
+                is DomainResult.Error -> {
+                    _uiState.update {
+                        it.copy(
+                            isImportingBackup = false,
+                            syncProgress = null,
+                            error = "Drive pull failed: ${pullResult.message}"
+                        )
+                    }
+                }
+                is DomainResult.Loading -> Unit
             }
         }
     }
@@ -710,6 +781,7 @@ data class ProviderSetupState(
     val backupPreview: BackupPreview? = null,
     val pendingBackupUri: String? = null,
     val backupImportPlan: BackupImportPlan = BackupImportPlan(),
+    val driveSignedIn: Boolean = false,
     val epgSyncMode: ProviderEpgSyncMode = ProviderEpgSyncMode.BACKGROUND,
     val xtreamLiveSyncMode: ProviderXtreamLiveSyncMode = ProviderXtreamLiveSyncMode.AUTO,
     val hasCustomizedEpgSyncMode: Boolean = false,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
@@ -22,6 +22,7 @@ import androidx.tv.material3.Text
 import com.streamvault.app.BuildConfig
 import com.streamvault.app.R
 import com.streamvault.app.ui.interaction.TvClickableSurface
+import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
 import com.streamvault.app.ui.theme.Secondary
@@ -101,6 +102,10 @@ internal fun LazyListScope.settingsDriveBackupSection(
                     val accountLabel = auth.account.email
                         ?: auth.account.displayName
                         ?: stringResource(R.string.settings_drive_signin)
+                    DriveAccountRow(
+                        accountLabel = accountLabel,
+                        onSignOut = onSignOut
+                    )
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(16.dp),
                         modifier = Modifier.fillMaxWidth()
@@ -122,16 +127,43 @@ internal fun LazyListScope.settingsDriveBackupSection(
                             modifier = Modifier.weight(1f)
                         )
                     }
-                    BackupActionCard(
-                        icon = "✕",
-                        title = stringResource(R.string.settings_drive_signout),
-                        subtitle = accountLabel,
-                        accent = OnSurfaceDim,
-                        onClick = onSignOut,
-                        modifier = Modifier.fillMaxWidth()
-                    )
                 }
             }
+        }
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun DriveAccountRow(
+    accountLabel: String,
+    onSignOut: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = accountLabel,
+            style = MaterialTheme.typography.bodyLarge,
+            color = OnSurface,
+            fontWeight = FontWeight.Medium,
+            modifier = Modifier.weight(1f)
+        )
+        TvClickableSurface(
+            onClick = onSignOut,
+            shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(10.dp)),
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = Color.White.copy(alpha = 0.06f),
+                focusedContainerColor = Color.White.copy(alpha = 0.18f)
+            ),
+            scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
+        ) {
+            Text(
+                text = stringResource(R.string.settings_drive_signout),
+                modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                style = MaterialTheme.typography.labelLarge,
+                color = OnSurface
+            )
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
@@ -25,6 +25,7 @@ import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
 import com.streamvault.app.ui.theme.Secondary
+import com.streamvault.domain.manager.DriveAuthState
 
 internal fun LazyListScope.settingsBackupSection(
     onCreateBackup: () -> Unit,
@@ -65,6 +66,72 @@ internal fun LazyListScope.settingsBackupSection(
                 onClick = onRestoreBackup,
                 modifier = Modifier.fillMaxWidth()
             )
+        }
+    }
+}
+
+internal fun LazyListScope.settingsDriveBackupSection(
+    uiState: SettingsUiState,
+    onSignIn: () -> Unit,
+    onSignOut: () -> Unit,
+    onPush: () -> Unit,
+    onPull: () -> Unit
+) {
+    item(key = "settings_drive_section") {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            SettingsSectionHeader(
+                title = stringResource(R.string.settings_drive_section_title),
+                subtitle = stringResource(R.string.settings_drive_section_subtitle)
+            )
+            when (val auth = uiState.driveAuthState) {
+                is DriveAuthState.SignedOut, is DriveAuthState.Pending -> {
+                    BackupActionCard(
+                        icon = "☁",
+                        title = stringResource(R.string.settings_drive_signin),
+                        subtitle = stringResource(R.string.settings_drive_signin_description),
+                        accent = Primary,
+                        onClick = onSignIn,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                is DriveAuthState.SignedIn -> {
+                    val accountLabel = auth.account.email
+                        ?: auth.account.displayName
+                        ?: stringResource(R.string.settings_drive_signin)
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        BackupActionCard(
+                            icon = "↑",
+                            title = stringResource(R.string.settings_drive_push),
+                            subtitle = stringResource(R.string.settings_drive_push_subtitle),
+                            accent = Primary,
+                            onClick = onPush,
+                            modifier = Modifier.weight(1f)
+                        )
+                        BackupActionCard(
+                            icon = "↓",
+                            title = stringResource(R.string.settings_drive_pull),
+                            subtitle = stringResource(R.string.settings_drive_pull_subtitle),
+                            accent = Secondary,
+                            onClick = onPull,
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                    BackupActionCard(
+                        icon = "✕",
+                        title = stringResource(R.string.settings_drive_signout),
+                        subtitle = accountLabel,
+                        accent = OnSurfaceDim,
+                        onClick = onSignOut,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupAboutSections.kt
@@ -104,6 +104,8 @@ internal fun LazyListScope.settingsDriveBackupSection(
                         ?: stringResource(R.string.settings_drive_signin)
                     DriveAccountRow(
                         accountLabel = accountLabel,
+                        lastPushAtMs = uiState.driveSyncStatus.lastPushAtMs,
+                        lastPullAtMs = uiState.driveSyncStatus.lastPullAtMs,
                         onSignOut = onSignOut
                     )
                     Row(
@@ -136,19 +138,28 @@ internal fun LazyListScope.settingsDriveBackupSection(
 @androidx.compose.runtime.Composable
 private fun DriveAccountRow(
     accountLabel: String,
+    lastPushAtMs: Long?,
+    lastPullAtMs: Long?,
     onSignOut: () -> Unit
 ) {
+    val syncSummary = formatLastSync(lastPushAtMs, lastPullAtMs)
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(
-            text = accountLabel,
-            style = MaterialTheme.typography.bodyLarge,
-            color = OnSurface,
-            fontWeight = FontWeight.Medium,
-            modifier = Modifier.weight(1f)
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = accountLabel,
+                style = MaterialTheme.typography.bodyLarge,
+                color = OnSurface,
+                fontWeight = FontWeight.Medium
+            )
+            Text(
+                text = syncSummary,
+                style = MaterialTheme.typography.bodySmall,
+                color = OnSurfaceDim
+            )
+        }
         TvClickableSurface(
             onClick = onSignOut,
             shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(10.dp)),
@@ -166,6 +177,21 @@ private fun DriveAccountRow(
             )
         }
     }
+}
+
+@androidx.compose.runtime.Composable
+private fun formatLastSync(pushMs: Long?, pullMs: Long?): String {
+    if (pushMs == null && pullMs == null) {
+        return stringResource(R.string.settings_drive_never_synced)
+    }
+    val df = java.text.DateFormat.getDateTimeInstance(
+        java.text.DateFormat.SHORT,
+        java.text.DateFormat.SHORT
+    )
+    val parts = mutableListOf<String>()
+    pushMs?.let { parts += stringResource(R.string.settings_drive_last_push, df.format(java.util.Date(it))) }
+    pullMs?.let { parts += stringResource(R.string.settings_drive_last_pull, df.format(java.util.Date(it))) }
+    return parts.joinToString("  ·  ")
 }
 
 @androidx.compose.runtime.Composable

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
@@ -29,6 +29,10 @@ internal fun SettingsContentPane(
     onShareCrashReport: () -> Unit,
     onDeleteCrashReport: () -> Unit,
     onRestoreBackup: () -> Unit,
+    onDriveSignIn: () -> Unit,
+    onDriveSignOut: () -> Unit,
+    onDrivePush: () -> Unit,
+    onDrivePull: () -> Unit,
     onOpenUri: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -138,6 +142,13 @@ internal fun SettingsContentPane(
                 onCreateBackup = onCreateBackup,
                 onShareBackup = onShareBackup,
                 onRestoreBackup = onRestoreBackup
+            )
+            settingsDriveBackupSection(
+                uiState = uiState,
+                onSignIn = onDriveSignIn,
+                onSignOut = onDriveSignOut,
+                onPush = onDrivePush,
+                onPull = onDrivePull
             )
         } else if (dialogState.selectedCategory == 6) {
             epgSourcesSection(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
@@ -1,0 +1,199 @@
+package com.streamvault.app.ui.screens.settings
+
+import androidx.activity.result.ActivityResultLauncher
+import android.content.Intent
+import com.streamvault.domain.manager.DriveAuthState
+import com.streamvault.domain.manager.DriveBackupSyncManager
+import com.streamvault.domain.manager.DriveSyncStatus
+import com.streamvault.domain.model.Result
+import com.streamvault.domain.usecase.ImportBackup
+import com.streamvault.domain.usecase.InspectBackupCommand
+import com.streamvault.domain.usecase.InspectBackupResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Drive backup orchestration helper. Mirrors the [SettingsBackupActions] pattern:
+ * internal class, [MutableStateFlow] uiState injected, methods take the caller
+ * [CoroutineScope] and run their body in `scope.launch { uiState.update { ... } }`.
+ *
+ * Pull deliberately goes through the [ImportBackup.inspect] usecase rather than
+ * calling [com.streamvault.domain.manager.BackupManager.inspectBackup] directly,
+ * so the existing David SAF preview dialog is reused unchanged (decision D2).
+ */
+internal class SettingsDriveBackupActions(
+    private val driveManager: DriveBackupSyncManager,
+    private val importBackup: ImportBackup,
+    private val uiState: MutableStateFlow<SettingsUiState>
+) {
+
+    /**
+     * Collects [DriveBackupSyncManager.authState] into [SettingsUiState.driveAuthState].
+     * Call once from the owning ViewModel `init` block.
+     */
+    fun observeAuthState(scope: CoroutineScope) {
+        scope.launch {
+            driveManager.authState.collect { state ->
+                uiState.update { it.copy(driveAuthState = state) }
+            }
+        }
+        scope.launch {
+            driveManager.syncStatus.collect { status ->
+                uiState.update {
+                    it.copy(
+                        driveSyncStatus = status,
+                        driveLastPushAt = status.lastPushAtMs ?: it.driveLastPushAt,
+                        driveLastPullAt = status.lastPullAtMs ?: it.driveLastPullAt
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Requests a Sign-In intent from the manager then forwards it to the
+     * Activity-bound [launcher]. The result is sent back via [completeSignIn].
+     */
+    fun beginSignIn(scope: CoroutineScope, launcher: ActivityResultLauncher<Intent>) {
+        scope.launch {
+            uiState.update { it.copy(driveIsBusy = true) }
+            val result = driveManager.beginSignIn()
+            uiState.update { state ->
+                when (result) {
+                    is Result.Success -> {
+                        val intent = result.data.intent as? Intent
+                        if (intent != null) {
+                            runCatching { launcher.launch(intent) }
+                                .onFailure {
+                                    return@update state.copy(
+                                        driveIsBusy = false,
+                                        userMessage = "Drive sign-in failed: ${it.message ?: "unable to launch"}"
+                                    )
+                                }
+                            state.copy(driveIsBusy = false, drivePendingSignIn = result.data)
+                        } else {
+                            state.copy(
+                                driveIsBusy = false,
+                                userMessage = "Drive sign-in failed: missing intent"
+                            )
+                        }
+                    }
+                    is Result.Error -> state.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive sign-in failed: ${result.message}"
+                    )
+                    is Result.Loading -> state.copy(driveIsBusy = false)
+                }
+            }
+        }
+    }
+
+    fun completeSignIn(scope: CoroutineScope, intentData: Intent?) {
+        scope.launch {
+            uiState.update { it.copy(driveIsBusy = true) }
+            val result = driveManager.completeSignIn(intentData)
+            uiState.update { state ->
+                when (result) {
+                    is Result.Success -> state.copy(
+                        driveIsBusy = false,
+                        drivePendingSignIn = null,
+                        userMessage = result.data.email?.let { "Signed in as $it" }
+                            ?: "Signed in to Google Drive"
+                    )
+                    is Result.Error -> state.copy(
+                        driveIsBusy = false,
+                        drivePendingSignIn = null,
+                        userMessage = "Drive sign-in failed: ${result.message}"
+                    )
+                    is Result.Loading -> state.copy(driveIsBusy = false)
+                }
+            }
+        }
+    }
+
+    fun signOut(scope: CoroutineScope) {
+        scope.launch {
+            uiState.update { it.copy(driveIsBusy = true) }
+            val result = driveManager.signOut()
+            uiState.update { state ->
+                when (result) {
+                    is Result.Success -> state.copy(
+                        driveIsBusy = false,
+                        driveSyncStatus = DriveSyncStatus(),
+                        driveLastPushAt = null,
+                        driveLastPullAt = null,
+                        userMessage = "Signed out of Google Drive"
+                    )
+                    is Result.Error -> state.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive sign-out failed: ${result.message}"
+                    )
+                    is Result.Loading -> state.copy(driveIsBusy = false)
+                }
+            }
+        }
+    }
+
+    fun pushBackup(scope: CoroutineScope) {
+        scope.launch {
+            if (uiState.value.driveAuthState !is DriveAuthState.SignedIn) {
+                uiState.update { it.copy(userMessage = "Sign in to Google Drive first") }
+                return@launch
+            }
+            uiState.update { it.copy(driveIsBusy = true) }
+            val result = driveManager.pushBackup()
+            uiState.update { state ->
+                when (result) {
+                    is Result.Success -> state.copy(
+                        driveIsBusy = false,
+                        userMessage = "Backup uploaded to Google Drive"
+                    )
+                    is Result.Error -> state.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive push failed: ${result.message}"
+                    )
+                    is Result.Loading -> state.copy(driveIsBusy = false)
+                }
+            }
+        }
+    }
+
+    fun pullBackup(scope: CoroutineScope) {
+        scope.launch {
+            if (uiState.value.driveAuthState !is DriveAuthState.SignedIn) {
+                uiState.update { it.copy(userMessage = "Sign in to Google Drive first") }
+                return@launch
+            }
+            uiState.update { it.copy(driveIsBusy = true) }
+            val pullResult = driveManager.pullBackup()
+            if (pullResult is Result.Error) {
+                uiState.update {
+                    it.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive pull failed: ${pullResult.message}"
+                    )
+                }
+                return@launch
+            }
+            val artifact = (pullResult as Result.Success).data
+            val inspectResult = importBackup.inspect(InspectBackupCommand(artifact.localUriString))
+            uiState.update { state ->
+                when (inspectResult) {
+                    is InspectBackupResult.Success -> state.copy(
+                        driveIsBusy = false,
+                        pendingBackupUri = inspectResult.uriString,
+                        backupPreview = inspectResult.preview,
+                        backupImportPlan = inspectResult.defaultPlan
+                    )
+                    is InspectBackupResult.Error -> state.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive import failed: ${inspectResult.message}"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreen.kt
@@ -96,6 +96,12 @@ fun SettingsScreen(
             .onFailure { viewModel.showUserMessage(context.getString(R.string.settings_crash_report_share_failed)) }
     }
 
+    val driveSignInLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        viewModel.completeDriveSignIn(result.data)
+    }
+
     val recordingFolderLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocumentTree()
     ) { uri ->
@@ -189,6 +195,10 @@ fun SettingsScreen(
                             arrayOf("application/json", "text/json", "application/x-json", "application/octet-stream", "*/*")
                         )
                     },
+                    onDriveSignIn = { viewModel.beginDriveSignIn(driveSignInLauncher) },
+                    onDriveSignOut = viewModel::signOutDrive,
+                    onDrivePush = viewModel::pushToDrive,
+                    onDrivePull = viewModel::pullFromDrive,
                     onOpenUri = uriHandler::openUri,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncOverlay.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncOverlay.kt
@@ -4,10 +4,14 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -20,9 +24,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.getValue
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.streamvault.app.R
+import com.streamvault.app.ui.components.extractProgressFraction
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
@@ -50,9 +57,17 @@ internal fun SyncingOverlay(
             .onKeyEvent { true },
         contentAlignment = Alignment.Center
     ) {
+        val fraction = progress?.let { extractProgressFraction(it) }
+        val animatedFraction by animateFloatAsState(
+            targetValue = fraction ?: 0f,
+            animationSpec = tween(durationMillis = 400),
+            label = "syncFraction"
+        )
+
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.widthIn(min = 360.dp, max = 520.dp)
         ) {
             CircularProgressIndicator(color = Primary)
             Text(
@@ -66,6 +81,18 @@ internal fun SyncingOverlay(
                 color = OnSurfaceDim
             )
             progress?.let { message ->
+                if (fraction != null) {
+                    LinearProgressIndicator(
+                        progress = { animatedFraction },
+                        color = Primary,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                } else {
+                    LinearProgressIndicator(
+                        color = Primary,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
                 Text(
                     text = message,
                     style = MaterialTheme.typography.bodySmall,
@@ -75,3 +102,4 @@ internal fun SyncingOverlay(
         }
     }
 }
+

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -5,6 +5,9 @@ import com.streamvault.app.ui.model.LiveTvQuickFilterVisibilityMode
 import com.streamvault.app.ui.model.VodViewMode
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupPreview
+import com.streamvault.domain.manager.DriveAuthState
+import com.streamvault.domain.manager.DriveSignInRequest
+import com.streamvault.domain.manager.DriveSyncStatus
 import com.streamvault.domain.model.ActiveLiveSource
 import com.streamvault.domain.model.AppTimeFormat
 import com.streamvault.domain.model.Category
@@ -80,6 +83,13 @@ data class SettingsUiState(
     val backupPreview: BackupPreview? = null,
     val pendingBackupUri: String? = null,
     val backupImportPlan: BackupImportPlan = BackupImportPlan(),
+    // --- Drive sync (M2) ---
+    val driveAuthState: DriveAuthState = DriveAuthState.SignedOut,
+    val driveSyncStatus: DriveSyncStatus = DriveSyncStatus(),
+    val driveLastPushAt: Long? = null,
+    val driveLastPullAt: Long? = null,
+    val drivePendingSignIn: DriveSignInRequest? = null,
+    val driveIsBusy: Boolean = false,
     val recordingItems: List<RecordingItem> = emptyList(),
     val recordingStorageState: RecordingStorageState = RecordingStorageState(),
     val wifiOnlyRecording: Boolean = false,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -1,6 +1,8 @@
 package com.streamvault.app.ui.screens.settings
 
 import android.app.Application
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.streamvault.app.R
@@ -27,6 +29,7 @@ import com.streamvault.domain.manager.BackupConflictStrategy
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupManager
 import com.streamvault.domain.manager.BackupPreview
+import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.manager.ParentalControlManager
 import com.streamvault.domain.manager.RecordingManager
 import com.streamvault.domain.model.Category
@@ -88,6 +91,7 @@ class SettingsViewModel @Inject constructor(
     private val preferencesRepository: PreferencesRepository,
     private val internetSpeedTestRunner: InternetSpeedTestRunner,
     private val backupManager: BackupManager,
+    private val driveBackupSyncManager: DriveBackupSyncManager,
     private val recordingManager: RecordingManager,
     private val parentalControlManager: ParentalControlManager,
     private val syncManager: SyncManager,
@@ -120,6 +124,11 @@ class SettingsViewModel @Inject constructor(
     )
     private val backupActions = SettingsBackupActions(
         exportBackup = exportBackup,
+        importBackup = importBackup,
+        uiState = _uiState
+    )
+    private val driveBackupActions = SettingsDriveBackupActions(
+        driveManager = driveBackupSyncManager,
         importBackup = importBackup,
         uiState = _uiState
     )
@@ -195,6 +204,7 @@ class SettingsViewModel @Inject constructor(
             epgSourceRepository = epgSourceRepository,
             uiState = _uiState
         )
+        driveBackupActions.observeAuthState(viewModelScope)
     }
 
     fun refreshCrashReport() {
@@ -912,6 +922,26 @@ class SettingsViewModel @Inject constructor(
 
     fun confirmBackupImport() {
         backupActions.confirmBackupImport(viewModelScope)
+    }
+
+    fun beginDriveSignIn(launcher: ActivityResultLauncher<Intent>) {
+        driveBackupActions.beginSignIn(viewModelScope, launcher)
+    }
+
+    fun completeDriveSignIn(intentData: Intent?) {
+        driveBackupActions.completeSignIn(viewModelScope, intentData)
+    }
+
+    fun signOutDrive() {
+        driveBackupActions.signOut(viewModelScope)
+    }
+
+    fun pushToDrive() {
+        driveBackupActions.pushBackup(viewModelScope)
+    }
+
+    fun pullFromDrive() {
+        driveBackupActions.pullBackup(viewModelScope)
     }
 
     fun stopRecording(recordingId: String) {

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1423,4 +1423,15 @@
     <string name="setup_stalker">Stalker</string>
     <string name="vod_sync_needed_subtitle">Actualisez ce fournisseur pour importer des films et séries dans la bibliothèque.</string>
     <string name="vod_sync_needed_title">Synchronisation requise</string>
+
+    <!-- M2 : sauvegarde Google Drive -->
+    <string name="settings_drive_section_title">Sauvegarde Google Drive</string>
+    <string name="settings_drive_section_subtitle">Envoyez et récupérez la configuration StreamVault dans un dossier Drive privé.</string>
+    <string name="settings_drive_signin">Se connecter à Google Drive</string>
+    <string name="settings_drive_signin_description">Connectez un compte Google pour activer la sauvegarde dans le cloud.</string>
+    <string name="settings_drive_signout">Se déconnecter</string>
+    <string name="settings_drive_push">Envoyer vers Drive</string>
+    <string name="settings_drive_push_subtitle">Téléverse la configuration actuelle dans votre sauvegarde Drive.</string>
+    <string name="settings_drive_pull">Récupérer depuis Drive</string>
+    <string name="settings_drive_pull_subtitle">Télécharge la dernière sauvegarde Drive et prévisualise l’import.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1437,4 +1437,5 @@
     <string name="settings_drive_last_push">Envoyé : %1$s</string>
     <string name="settings_drive_last_pull">Récupéré : %1$s</string>
     <string name="settings_drive_never_synced">Jamais synchronisé</string>
+    <string name="setup_import_from_drive">Importer depuis Drive</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1434,4 +1434,7 @@
     <string name="settings_drive_push_subtitle">Téléverse la configuration actuelle dans votre sauvegarde Drive.</string>
     <string name="settings_drive_pull">Récupérer depuis Drive</string>
     <string name="settings_drive_pull_subtitle">Télécharge la dernière sauvegarde Drive et prévisualise l’import.</string>
+    <string name="settings_drive_last_push">Envoyé : %1$s</string>
+    <string name="settings_drive_last_pull">Récupéré : %1$s</string>
+    <string name="settings_drive_never_synced">Jamais synchronisé</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1496,5 +1496,16 @@
     <string name="tv_input_setup_try_scan_again">Try Auto Scan Again</string>
     <string name="tv_input_setup_retry_scan">Retry Auto Scan</string>
     <string name="tv_input_setup_success_hint">Android TV Live TV can now open your StreamVault channels.</string>
+
+    <!-- M2: Google Drive backup sync -->
+    <string name="settings_drive_section_title">Google Drive backup</string>
+    <string name="settings_drive_section_subtitle">Push and pull your StreamVault configuration to a private Drive folder.</string>
+    <string name="settings_drive_signin">Sign in to Google Drive</string>
+    <string name="settings_drive_signin_description">Connect a Google account to enable cloud backup.</string>
+    <string name="settings_drive_signout">Sign out</string>
+    <string name="settings_drive_push">Send to Drive</string>
+    <string name="settings_drive_push_subtitle">Upload the current configuration to your Drive backup.</string>
+    <string name="settings_drive_pull">Restore from Drive</string>
+    <string name="settings_drive_pull_subtitle">Download the latest Drive backup and preview the import.</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1510,5 +1510,6 @@
     <string name="settings_drive_last_push">Pushed: %1$s</string>
     <string name="settings_drive_last_pull">Pulled: %1$s</string>
     <string name="settings_drive_never_synced">Never synced yet</string>
+    <string name="setup_import_from_drive">Import from Drive</string>
 </resources>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1507,5 +1507,8 @@
     <string name="settings_drive_push_subtitle">Upload the current configuration to your Drive backup.</string>
     <string name="settings_drive_pull">Restore from Drive</string>
     <string name="settings_drive_pull_subtitle">Download the latest Drive backup and preview the import.</string>
+    <string name="settings_drive_last_push">Pushed: %1$s</string>
+    <string name="settings_drive_last_pull">Pulled: %1$s</string>
+    <string name="settings_drive_never_synced">Never synced yet</string>
 </resources>
 

--- a/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
@@ -10,6 +10,8 @@ import com.streamvault.domain.repository.CombinedM3uRepository
 import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupImportResult
+import com.streamvault.domain.manager.DriveAuthState
+import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.usecase.ImportBackup
 import com.streamvault.domain.usecase.ImportBackupResult
 import com.streamvault.domain.usecase.ValidateAndAddProvider
@@ -38,6 +40,7 @@ class ProviderSetupViewModelTest {
     private val combinedM3uRepository: CombinedM3uRepository = mock()
     private val validateAndAddProvider: ValidateAndAddProvider = mock()
     private val importBackup: ImportBackup = mock()
+    private val driveBackupSyncManager: DriveBackupSyncManager = mock()
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -46,6 +49,7 @@ class ProviderSetupViewModelTest {
         whenever(providerRepository.getActiveProvider()).thenReturn(flowOf(null))
         whenever(providerRepository.getProviders()).thenReturn(flowOf(emptyList()))
         whenever(combinedM3uRepository.getActiveLiveSource()).thenReturn(flowOf(null))
+        whenever(driveBackupSyncManager.authState).thenReturn(flowOf(DriveAuthState.SignedOut))
     }
 
     @After
@@ -76,7 +80,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -109,7 +114,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.loginXtream("https://example.com", "alice", "secret", "Premium", "", "")
@@ -140,7 +146,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
         val field = ProviderSetupViewModel::class.java.getDeclaredField("_uiState").apply { isAccessible = true }
         @Suppress("UNCHECKED_CAST")
@@ -165,7 +172,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         val seededState = viewModel.uiState.value.copy(
@@ -215,7 +223,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -235,7 +244,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.STALKER)
@@ -251,7 +261,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.XTREAM)
@@ -267,7 +278,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.M3U)
@@ -283,7 +295,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.updateEpgSyncMode(ProviderEpgSyncMode.SKIP)
@@ -314,7 +327,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         // Simulate being in edit mode for provider 7.
@@ -345,7 +359,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist", "", "")
@@ -368,7 +383,8 @@ class ProviderSetupViewModelTest {
             providerRepository = providerRepository,
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
-            importBackup = importBackup
+            importBackup = importBackup,
+            driveBackupSyncManager = driveBackupSyncManager
         )
 
         viewModel.loginStalker(

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.kotlinx.serialization.json)
 
+    // Google Sign-In (Drive sync)
+    implementation(libs.play.services.auth)
+
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
@@ -1,0 +1,348 @@
+package com.streamvault.data.manager
+
+import android.content.Context
+import androidx.core.net.toUri
+import com.google.android.gms.auth.GoogleAuthUtil
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount
+import com.google.android.gms.auth.api.signin.GoogleSignInClient
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailability
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.Scope
+import com.google.android.gms.tasks.Task
+import com.streamvault.domain.manager.BackupManager
+import com.streamvault.domain.manager.DriveAccount
+import com.streamvault.domain.manager.DriveAuthState
+import com.streamvault.domain.manager.DriveBackupArtifact
+import com.streamvault.domain.manager.DriveBackupSyncManager
+import com.streamvault.domain.manager.DriveSignInRequest
+import com.streamvault.domain.manager.DriveSyncError
+import com.streamvault.domain.manager.DriveSyncStatus
+import com.streamvault.domain.model.Result
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.BufferedSink
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Implementation backed by Google Sign-In + the Drive REST `appDataFolder` scope.
+ *
+ * - **No OAuth Client ID lives in this file** — Google Play Services resolves the
+ *   client by matching the running app's `(packageName, signing SHA-1)` against
+ *   the OAuth credentials registered in the Google Cloud Console project. Each
+ *   maintainer / signing key must register its own OAuth client (see
+ *   `docs/GOOGLE_DRIVE_SETUP.md`).
+ * - The backup payload is the existing [BackupManager] JSON v5 export — we just
+ *   pipe it through a temp file under [Context.getCacheDir] and upload/download
+ *   via multipart REST. No extra format, no extra schema.
+ * - Sensitive provider passwords are already stripped by [BackupManager.exportConfig].
+ */
+@Singleton
+class GoogleDriveBackupSyncManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val backupManager: BackupManager,
+) : DriveBackupSyncManager {
+
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
+        .writeTimeout(60, TimeUnit.SECONDS)
+        .build()
+
+    private val _authState = MutableStateFlow<DriveAuthState>(DriveAuthState.SignedOut)
+    override val authState: StateFlow<DriveAuthState> = _authState.asStateFlow()
+
+    private val _syncStatus = MutableStateFlow(DriveSyncStatus())
+    override val syncStatus: StateFlow<DriveSyncStatus> = _syncStatus.asStateFlow()
+
+    init {
+        // Restore last known account silently on cold start.
+        val cached = GoogleSignIn.getLastSignedInAccount(context)
+        if (cached != null && hasAppDataScope(cached)) {
+            _authState.value = DriveAuthState.SignedIn(cached.toDriveAccount())
+        }
+    }
+
+    override suspend fun beginSignIn(): Result<DriveSignInRequest> = withContext(Dispatchers.IO) {
+        val availability = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(context)
+        if (availability != ConnectionResult.SUCCESS) {
+            return@withContext Result.Error(
+                message = DriveSyncError.PLAY_SERVICES_UNAVAILABLE,
+                exception = null,
+            )
+        }
+        _authState.value = DriveAuthState.Pending
+        Result.Success(DriveSignInRequest(intent = buildClient().signInIntent))
+    }
+
+    override suspend fun completeSignIn(signInData: Any?): Result<DriveAccount> =
+        withContext(Dispatchers.IO) {
+            try {
+                val data = signInData as? android.content.Intent
+                val account = GoogleSignIn.getSignedInAccountFromIntent(data).awaitTask()
+                if (account == null || !hasAppDataScope(account)) {
+                    _authState.value = DriveAuthState.SignedOut
+                    return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+                }
+                val driveAccount = account.toDriveAccount()
+                _authState.value = DriveAuthState.SignedIn(driveAccount)
+                Result.Success(driveAccount)
+            } catch (apiError: ApiException) {
+                _authState.value = DriveAuthState.SignedOut
+                Result.Error(DriveSyncError.AUTH_FAILED, apiError)
+            } catch (t: Throwable) {
+                _authState.value = DriveAuthState.SignedOut
+                Result.Error(DriveSyncError.AUTH_FAILED, t)
+            }
+        }
+
+    override suspend fun signOut(): Result<Unit> = withContext(Dispatchers.IO) {
+        try {
+            buildClient().signOut().awaitTask()
+            _authState.value = DriveAuthState.SignedOut
+            Result.Success(Unit)
+        } catch (t: Throwable) {
+            Result.Error(DriveSyncError.AUTH_FAILED, t)
+        }
+    }
+
+    /**
+     * Lightweight `await()` shim for `Task<T>` — avoids adding the
+     * `kotlinx-coroutines-play-services` artifact just to bridge two callbacks.
+     */
+    private suspend fun <T> Task<T>.awaitTask(): T? = suspendCancellableCoroutine { cont ->
+        if (isComplete) {
+            val exception = exception
+            if (exception == null) {
+                @Suppress("UNCHECKED_CAST")
+                if (isCanceled) cont.resume(null) else cont.resume(result as T)
+            } else {
+                cont.resumeWithException(exception)
+            }
+            return@suspendCancellableCoroutine
+        }
+        addOnSuccessListener { cont.resume(it) }
+        addOnFailureListener { cont.resumeWithException(it) }
+        addOnCanceledListener { cont.resume(null) }
+    }
+
+    override suspend fun pushBackup(): Result<DriveSyncStatus> = withContext(Dispatchers.IO) {
+        val account = requireSignedInAccount() ?: return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
+        val token = fetchAccessToken(account) ?: return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+
+        val tempFile = File(context.cacheDir, TEMP_BACKUP_FILE_NAME).apply { delete() }
+        val exportUri = tempFile.toUri().toString()
+
+        val exportResult = backupManager.exportConfig(exportUri)
+        if (exportResult is Result.Error) {
+            return@withContext Result.Error(DriveSyncError.EXPORT_FAILED, exportResult.exception)
+        }
+        if (!tempFile.exists() || tempFile.length() == 0L) {
+            return@withContext Result.Error(DriveSyncError.EXPORT_FAILED)
+        }
+
+        val uploadOk = try {
+            uploadAppDataFile(token, tempFile)
+        } catch (io: IOException) {
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        } finally {
+            tempFile.delete()
+        }
+        if (!uploadOk) {
+            return@withContext Result.Error(DriveSyncError.NETWORK)
+        }
+
+        val updated = _syncStatus.value.copy(
+            lastPushAtMs = System.currentTimeMillis(),
+            lastErrorMessage = null,
+        )
+        _syncStatus.value = updated
+        Result.Success(updated)
+    }
+
+    override suspend fun pullBackup(): Result<DriveBackupArtifact> = withContext(Dispatchers.IO) {
+        val account = requireSignedInAccount() ?: return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
+        val token = fetchAccessToken(account) ?: return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+
+        val fileId = try {
+            findRemoteBackupId(token)
+        } catch (io: IOException) {
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        } ?: return@withContext Result.Error(DriveSyncError.NO_REMOTE_BACKUP)
+
+        val target = File(context.cacheDir, TEMP_BACKUP_FILE_NAME).apply { delete() }
+        val downloadOk = try {
+            downloadAppDataFile(token, fileId, target)
+        } catch (io: IOException) {
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        }
+        if (!downloadOk || !target.exists() || target.length() == 0L) {
+            target.delete()
+            return@withContext Result.Error(DriveSyncError.NETWORK)
+        }
+
+        _syncStatus.value = _syncStatus.value.copy(
+            lastPullAtMs = System.currentTimeMillis(),
+            lastErrorMessage = null,
+        )
+        Result.Success(
+            DriveBackupArtifact(
+                localUriString = target.toUri().toString(),
+                sizeBytes = target.length(),
+            ),
+        )
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────────
+
+    private fun buildClient(): GoogleSignInClient {
+        val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+            .requestEmail()
+            .requestScopes(Scope(SCOPE_APP_DATA))
+            .build()
+        return GoogleSignIn.getClient(context, options)
+    }
+
+    private fun hasAppDataScope(account: GoogleSignInAccount): Boolean =
+        GoogleSignIn.hasPermissions(account, Scope(SCOPE_APP_DATA))
+
+    private fun requireSignedInAccount(): GoogleSignInAccount? {
+        val cached = GoogleSignIn.getLastSignedInAccount(context) ?: return null
+        if (!hasAppDataScope(cached)) return null
+        return cached
+    }
+
+    /**
+     * Synchronous OAuth2 token retrieval. Must be called off the main thread.
+     * The token is never logged.
+     */
+    private fun fetchAccessToken(account: GoogleSignInAccount): String? = try {
+        val androidAccount = account.account ?: return null
+        GoogleAuthUtil.getToken(context, androidAccount, "oauth2:$SCOPE_APP_DATA")
+    } catch (t: Throwable) {
+        null
+    }
+
+    private fun findRemoteBackupId(authToken: String): String? {
+        val url = "https://www.googleapis.com/drive/v3/files" +
+            "?spaces=appDataFolder" +
+            "&q=" + uriEncode("name='$BACKUP_FILE_NAME'") +
+            "&fields=files(id,modifiedTime,size)"
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer $authToken")
+            .get()
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return null
+            val body = response.body?.string().orEmpty()
+            val files = JSONObject(body).optJSONArray("files") ?: return null
+            if (files.length() == 0) return null
+            return files.getJSONObject(0).getString("id")
+        }
+    }
+
+    private fun uploadAppDataFile(authToken: String, payload: File): Boolean {
+        val existingId = findRemoteBackupId(authToken)
+        val boundary = "streamvault-${System.nanoTime()}"
+        val (httpMethod, endpoint) = if (existingId != null) {
+            "PATCH" to "https://www.googleapis.com/upload/drive/v3/files/$existingId?uploadType=multipart"
+        } else {
+            "POST" to "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"
+        }
+
+        val metadata = JSONObject().apply {
+            put("name", BACKUP_FILE_NAME)
+            if (existingId == null) {
+                put("parents", JSONArray().put("appDataFolder"))
+            }
+        }.toString()
+
+        val body = MultipartRelatedBody(boundary, metadata, payload)
+        val request = Request.Builder()
+            .url(endpoint)
+            .addHeader("Authorization", "Bearer $authToken")
+            .method(httpMethod, body)
+            .build()
+
+        httpClient.newCall(request).execute().use { response ->
+            return response.isSuccessful
+        }
+    }
+
+    private fun downloadAppDataFile(authToken: String, fileId: String, target: File): Boolean {
+        val request = Request.Builder()
+            .url("https://www.googleapis.com/drive/v3/files/$fileId?alt=media")
+            .addHeader("Authorization", "Bearer $authToken")
+            .get()
+            .build()
+        httpClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) return false
+            val source = response.body?.byteStream() ?: return false
+            target.outputStream().use { sink -> source.copyTo(sink) }
+            return true
+        }
+    }
+
+    private fun GoogleSignInAccount.toDriveAccount(): DriveAccount =
+        DriveAccount(email = email, displayName = displayName)
+
+    private fun uriEncode(value: String): String =
+        java.net.URLEncoder.encode(value, Charsets.UTF_8)
+
+    private companion object {
+        const val SCOPE_APP_DATA = "https://www.googleapis.com/auth/drive.appdata"
+        const val BACKUP_FILE_NAME = "streamvault_backup.json"
+        const val TEMP_BACKUP_FILE_NAME = "drive_sync_backup.json"
+    }
+}
+
+/**
+ * `multipart/related` body the Drive REST API expects for a single-shot create
+ * or update — metadata part first, then the JSON payload, separated by the
+ * given [boundary]. Streams the payload from disk to avoid loading the full
+ * backup in memory.
+ */
+private class MultipartRelatedBody(
+    private val boundary: String,
+    private val metadataJson: String,
+    private val payload: File,
+) : okhttp3.RequestBody() {
+
+    override fun contentType(): okhttp3.MediaType =
+        "multipart/related; boundary=$boundary".toMediaTypeOrNull()!!
+
+    override fun writeTo(sink: BufferedSink) {
+        sink.writeUtf8("--$boundary\r\n")
+        sink.writeUtf8("Content-Type: application/json; charset=UTF-8\r\n\r\n")
+        sink.writeUtf8(metadataJson)
+        sink.writeUtf8("\r\n--$boundary\r\n")
+        sink.writeUtf8("Content-Type: application/json\r\n\r\n")
+        val payloadBody = payload.asRequestBody("application/json".toMediaTypeOrNull())
+        payloadBody.writeTo(sink)
+        sink.writeUtf8("\r\n--$boundary--\r\n")
+    }
+
+    @Suppress("unused")
+    private fun emptyRequestBody() = "".toRequestBody(null)
+}

--- a/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
@@ -1,6 +1,7 @@
 package com.streamvault.data.manager
 
 import android.content.Context
+import android.util.Log
 import androidx.core.net.toUri
 import com.google.android.gms.auth.GoogleAuthUtil
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -99,18 +100,29 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         withContext(Dispatchers.IO) {
             try {
                 val data = signInData as? android.content.Intent
+                Log.d("DriveSync", "completeSignIn intent=$data extras=${data?.extras}")
                 val account = GoogleSignIn.getSignedInAccountFromIntent(data).awaitTask()
-                if (account == null || !hasAppDataScope(account)) {
+                Log.d("DriveSync", "account=$account email=${account?.email} grantedScopes=${account?.grantedScopes}")
+                if (account == null) {
+                    Log.w("DriveSync", "completeSignIn: account is null (user cancelled or sign-in failed silently)")
+                    _authState.value = DriveAuthState.SignedOut
+                    return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+                }
+                if (!hasAppDataScope(account)) {
+                    Log.w("DriveSync", "completeSignIn: drive.appdata scope NOT granted, grantedScopes=${account.grantedScopes}")
                     _authState.value = DriveAuthState.SignedOut
                     return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
                 }
                 val driveAccount = account.toDriveAccount()
+                Log.d("DriveSync", "completeSignIn: SUCCESS for ${driveAccount.email}")
                 _authState.value = DriveAuthState.SignedIn(driveAccount)
                 Result.Success(driveAccount)
             } catch (apiError: ApiException) {
+                Log.e("DriveSync", "completeSignIn: ApiException statusCode=${apiError.statusCode} message=${apiError.message}", apiError)
                 _authState.value = DriveAuthState.SignedOut
                 Result.Error(DriveSyncError.AUTH_FAILED, apiError)
             } catch (t: Throwable) {
+                Log.e("DriveSync", "completeSignIn: Throwable", t)
                 _authState.value = DriveAuthState.SignedOut
                 Result.Error(DriveSyncError.AUTH_FAILED, t)
             }
@@ -181,25 +193,42 @@ class GoogleDriveBackupSyncManager @Inject constructor(
     }
 
     override suspend fun pullBackup(): Result<DriveBackupArtifact> = withContext(Dispatchers.IO) {
-        val account = requireSignedInAccount() ?: return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
-        val token = fetchAccessToken(account) ?: return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+        Log.d("DriveSync", "pullBackup: start")
+        val account = requireSignedInAccount() ?: run {
+            Log.w("DriveSync", "pullBackup: NOT_SIGNED_IN (account is null)")
+            return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
+        }
+        val token = fetchAccessToken(account) ?: run {
+            Log.w("DriveSync", "pullBackup: AUTH_FAILED (no token)")
+            return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+        }
+        Log.d("DriveSync", "pullBackup: token OK, looking up remote backup id")
 
         val fileId = try {
             findRemoteBackupId(token)
         } catch (io: IOException) {
+            Log.e("DriveSync", "pullBackup: NETWORK error while finding remote id", io)
             return@withContext Result.Error(DriveSyncError.NETWORK, io)
-        } ?: return@withContext Result.Error(DriveSyncError.NO_REMOTE_BACKUP)
+        }
+        if (fileId == null) {
+            Log.w("DriveSync", "pullBackup: NO_REMOTE_BACKUP (no file found in appDataFolder)")
+            return@withContext Result.Error(DriveSyncError.NO_REMOTE_BACKUP)
+        }
+        Log.d("DriveSync", "pullBackup: remote fileId=$fileId, downloading")
 
         val target = File(context.cacheDir, TEMP_BACKUP_FILE_NAME).apply { delete() }
         val downloadOk = try {
             downloadAppDataFile(token, fileId, target)
         } catch (io: IOException) {
+            Log.e("DriveSync", "pullBackup: NETWORK error during download", io)
             return@withContext Result.Error(DriveSyncError.NETWORK, io)
         }
         if (!downloadOk || !target.exists() || target.length() == 0L) {
+            Log.w("DriveSync", "pullBackup: download failed or empty file (ok=$downloadOk exists=${target.exists()} size=${target.length()})")
             target.delete()
             return@withContext Result.Error(DriveSyncError.NETWORK)
         }
+        Log.d("DriveSync", "pullBackup: downloaded ${target.length()} bytes to ${target.absolutePath}")
 
         _syncStatus.value = _syncStatus.value.copy(
             lastPullAtMs = System.currentTimeMillis(),
@@ -308,7 +337,9 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         DriveAccount(email = email, displayName = displayName)
 
     private fun uriEncode(value: String): String =
-        java.net.URLEncoder.encode(value, Charsets.UTF_8)
+        // URLEncoder.encode(String, Charset) is API 33+ only.
+        // We support minSdk 28, so use the String charset name overload.
+        java.net.URLEncoder.encode(value, "UTF-8")
 
     private companion object {
         const val SCOPE_APP_DATA = "https://www.googleapis.com/auth/drive.appdata"

--- a/docs/GOOGLE_DRIVE_SETUP.md
+++ b/docs/GOOGLE_DRIVE_SETUP.md
@@ -1,0 +1,102 @@
+# Google Drive backup sync — setup guide
+
+StreamVault can sync its backup file to a private folder of your Google Drive
+(scope `drive.appdata`). The folder is owned by the app, **invisible** in the
+standard Drive UI, and **wiped automatically** when the user uninstalls the app.
+
+This page targets **maintainers and contributors** who want to build/debug the
+feature locally. End users don't need to do anything — they just sign in from
+*Settings → Backup & Restore → Google Drive sync*.
+
+## Why per-build setup is required
+
+The Google Sign-In Android SDK authenticates a running app by matching the
+pair `(packageName, signing certificate SHA-1)` against the **OAuth client IDs**
+registered in a Google Cloud Console project. There is **no client secret in
+the code** — every fork/maintainer/release channel must register its own pair.
+
+That means:
+
+| Build flavour | Needs its own OAuth client | Why |
+|---|---|---|
+| `master` debug, local on dev machine | yes | each developer signs with their own debug keystore (different SHA-1) |
+| Official release on Play Store | yes | Davidona's release key SHA-1 |
+| CI build | yes (or share the dev one) | depending on signing strategy |
+
+The code in `data/manager/GoogleDriveBackupSyncManager.kt` never references an
+OAuth client ID — it just asks Play Services for the locally-installed client
+matching its `(packageName, SHA-1)`. If no client is registered, sign-in fails
+silently with `ApiException` status `DEVELOPER_ERROR (10)`.
+
+## One-time setup (Google Cloud Console)
+
+### 1. Create a Cloud project
+
+Open <https://console.cloud.google.com/projectcreate> and create a project of
+your choice (e.g. `streamvault-dev-<your-handle>`). Select it.
+
+### 2. Enable the Google Drive API
+
+<https://console.cloud.google.com/apis/library/drive.googleapis.com> →
+**Enable**.
+
+### 3. Configure the OAuth consent screen
+
+<https://console.cloud.google.com/apis/credentials/consent>
+
+- **User type** → External
+- **App name** → `StreamVault` (or your fork name)
+- **User support email** + **Developer contact** → your email
+- **Scopes** → add `https://www.googleapis.com/auth/drive.appdata`
+- **Test users** → add the Google account(s) you'll sign in with on the device
+
+While the project stays in *Testing* state, only the listed test users can
+sign in — that's fine for development. For a Play Store release you'd later
+move the project to *Production* (and likely go through Google's verification
+since `drive.appdata` is considered a sensitive scope).
+
+### 4. Create the OAuth Android client(s)
+
+<https://console.cloud.google.com/apis/credentials> → **Create credentials** →
+**OAuth client ID** → **Android**.
+
+| Field | Value |
+|---|---|
+| Name | `StreamVault — debug (<your handle>)` |
+| Package name | `com.streamvault.app` |
+| SHA-1 certificate fingerprint | from `keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android` |
+
+Repeat the step for every signing certificate that will run the feature
+(release key, CI key, …). You don't need to copy any returned ID anywhere —
+the runtime resolves it transparently.
+
+### 5. Add a Google account to the test device
+
+The device or emulator that runs the build must have a Google account added
+in **Settings → Accounts**, and that account must be in the OAuth consent
+screen's *Test users* list.
+
+## Verifying the setup
+
+1. Install the debug APK.
+2. *Settings → Backup & Restore → Google Drive sync → Connect to Google Drive*.
+3. Pick the test user account in the system picker. The consent screen must
+   ask only for the `drive.appdata` scope — if it asks for more (or fails
+   with "Developer error"), you have a SHA-1 / package name mismatch.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Sign-in dialog closes immediately, `ApiException(10)` in logcat | OAuth Android client missing or wrong SHA-1 / package name |
+| Sign-in succeeds but push/pull errors with `drive_auth_failed` | Drive API not enabled, or scope not granted in consent screen |
+| `Google Play Services required` snackbar | Emulator built with AOSP images (no GMS). Use a "Google APIs"/"Google Play" emulator image |
+| Push works, pull says `drive_no_remote_backup` | Drive `appDataFolder` is empty for this account — push first |
+
+## Privacy notes
+
+- The backup payload reuses the existing `BackupManager` JSON v5 export. Provider
+  passwords are already stripped (`BackupManagerImpl.exportConfig`, see the
+  `password = ""` line) — they are never uploaded to Drive.
+- Auth tokens fetched via `GoogleAuthUtil.getToken` are never logged.
+- The scope `drive.appdata` cannot read files outside the app's private folder.

--- a/domain/src/main/java/com/streamvault/domain/manager/DriveBackupSyncManager.kt
+++ b/domain/src/main/java/com/streamvault/domain/manager/DriveBackupSyncManager.kt
@@ -1,0 +1,103 @@
+package com.streamvault.domain.manager
+
+import com.streamvault.domain.model.Result
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Backs up and restores the local configuration (providers, favorites, groups,
+ * preferences) to a private Google Drive `appDataFolder`. The folder is owned
+ * by the app on Drive — invisible to the user in the standard Drive UI — and
+ * is wiped automatically by Google when the app is uninstalled.
+ *
+ * The payload reuses the existing [BackupManager] JSON format, so a Drive push
+ * is functionally equivalent to a local `Export to file` and a Drive pull
+ * feeds the same `Inspect/Import` flow (with preview + conflict resolution).
+ *
+ * All operations are suspend and return [Result]; UI layers should never see
+ * an exception escape.
+ */
+interface DriveBackupSyncManager {
+
+    /** Last published auth state. UI observes this to render the sign-in section. */
+    val authState: Flow<DriveAuthState>
+
+    /** Last sync timestamps + outcome. UI observes this to show "Last push" / "Last pull". */
+    val syncStatus: Flow<DriveSyncStatus>
+
+    /**
+     * Builds the platform-specific Sign-In intent the caller must launch with an
+     * `ActivityResultLauncher`. The resulting `Intent` data is forwarded back to
+     * [completeSignIn].
+     *
+     * Returns [Result.Error] if Google Play Services is missing.
+     */
+    suspend fun beginSignIn(): Result<DriveSignInRequest>
+
+    /**
+     * Completes the OAuth flow with the data returned by the launched Sign-In
+     * intent. On success, [authState] emits [DriveAuthState.SignedIn].
+     */
+    suspend fun completeSignIn(signInData: Any?): Result<DriveAccount>
+
+    /** Revokes scopes and clears cached account locally. */
+    suspend fun signOut(): Result<Unit>
+
+    /**
+     * Exports the current configuration to a temporary local file, uploads it
+     * to Drive `appDataFolder` (overwriting the previous backup if any).
+     */
+    suspend fun pushBackup(): Result<DriveSyncStatus>
+
+    /**
+     * Downloads the latest backup from Drive `appDataFolder` to a temporary
+     * local file, then hands the URI back to the caller — typically wired into
+     * the existing [BackupManager.inspectBackup] flow so the preview + conflict
+     * resolution UI is reused unchanged.
+     *
+     * Returns [Result.Error] with code [DriveSyncError.NO_REMOTE_BACKUP] if
+     * nothing has been pushed yet.
+     */
+    suspend fun pullBackup(): Result<DriveBackupArtifact>
+}
+
+/** Public Sign-In state for the UI. */
+sealed class DriveAuthState {
+    /** Not signed in (initial, after sign-out, after explicit revoke). */
+    data object SignedOut : DriveAuthState()
+    /** Sign-In is mid-flight (intent launched but not completed yet). */
+    data object Pending : DriveAuthState()
+    /** Active account. `email` may be null on platforms where the API hides it. */
+    data class SignedIn(val account: DriveAccount) : DriveAuthState()
+}
+
+data class DriveAccount(
+    val email: String?,
+    val displayName: String?,
+)
+
+data class DriveSyncStatus(
+    val lastPushAtMs: Long? = null,
+    val lastPullAtMs: Long? = null,
+    val lastErrorMessage: String? = null,
+)
+
+/** Carries the intent the UI must launch. Kept opaque (`Any?`) for platform independence. */
+data class DriveSignInRequest(val intent: Any?)
+
+/** Local artifact produced by [DriveBackupSyncManager.pullBackup]. */
+data class DriveBackupArtifact(
+    /** SAF-compatible `file://` URI string the existing [BackupManager.inspectBackup] can read. */
+    val localUriString: String,
+    val sizeBytes: Long,
+)
+
+/** Stable identifiers UI may match against to localize messages. */
+object DriveSyncError {
+    const val PLAY_SERVICES_UNAVAILABLE = "drive_play_services_unavailable"
+    const val NOT_SIGNED_IN = "drive_not_signed_in"
+    const val NO_REMOTE_BACKUP = "drive_no_remote_backup"
+    const val NETWORK = "drive_network"
+    const val AUTH_FAILED = "drive_auth_failed"
+    const val EXPORT_FAILED = "drive_export_failed"
+    const val IMPORT_FAILED = "drive_import_failed"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ work = "2.11.1"
 appcompat = "1.7.1"
 mediarouter = "1.8.1"
 play-services-cast-framework = "22.1.0"
+play-services-auth = "21.4.0"
 # Test
 junit = "4.13.2"
 truth = "1.4.4"
@@ -108,6 +109,7 @@ work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 mediarouter = { group = "androidx.mediarouter", name = "mediarouter", version.ref = "mediarouter" }
 play-services-cast-framework = { group = "com.google.android.gms", name = "play-services-cast-framework", version.ref = "play-services-cast-framework" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "play-services-auth" }
 
 # Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary

Adds an opt-in Google Drive Push/Pull backup flow next to the existing SAF backup UI. The current SAF flow is unusable on Android TV (no system DocumentsProvider, intent intercepted by `frameworkpackagestubs`) which is the issue documented in #42. Drive sync bypasses SAF entirely by uploading the same JSON produced by `ExportBackup` to a private `appDataFolder` via the Drive REST v3 API + Google Sign-In with the minimal `drive.appdata` scope.

The full configuration JSON written by `BackupManager` is reused verbatim on both sides — no new serialization format. The Pull path downloads to `cacheDir/drive-backup.json` and then routes through `ImportBackup.inspect/confirm`, so the existing `SettingsBackupImportPreviewDialog` is shown unchanged (no duplicate UX).

A small CTA is also exposed in `ProviderSetupScreen` so a fresh device (or post-clear-data device) can import a backup from Drive without having to recreate a provider manually.

## Screenshots

### Settings → Backup — Drive section

**Signed-out** — a single "Connect to Google Drive" card sits under the existing Backup primitives. Decision D4 of the local SCOPE: no new primitive, the card reuses `BackupActionCard`.

<img width="800" alt="Settings → Backup with Drive section signed-out" src="https://github.com/user-attachments/assets/e42c306d-d7e1-45ab-a348-ba76a88f58b9" />

**Signed-in** — `DriveAccountRow` shows the account label and the last push timestamp, with a trailing "Sign out" pill kept visually light. Below it the two action cards `Push to Drive` / `Pull from Drive` reuse the same primitive as the SAF actions.

<img width="800" alt="Settings → Backup with Drive section signed-in" src="https://github.com/user-attachments/assets/be258ec6-0d34-424d-abeb-ce8e13c7534f" />

### Drive Pull reuses the existing import preview dialog

The Pull path hands the downloaded backup to `ImportBackup.inspect`, so the existing `SettingsBackupImportPreviewDialog` opens unchanged — no new dialog, no duplicate UX, no extra surface to maintain.

<img width="800" alt="Existing backup import preview dialog opened from Drive Pull" src="https://github.com/user-attachments/assets/62d61608-d933-4f16-92e9-b62e66ad906b" />

## What's in / what's out

In scope:
- Settings → Backup → new Drive section: Sign-in, Push, Pull, Sign-out
- Last push/pull timestamps shown in the Drive account row (trailing sign-out pill, kept visually light)
- Onboarding CTA "Sign in to Google Drive" / "Import from Drive" in `ProviderSetupScreen`
- Linear progress indicator in `SyncingOverlay` + onboarding `SyncProgressDialog` (parses `N/total` from progress messages → determinate bar; falls back to indeterminate on init/finalize phases). Removes the "frozen dialog" perception during long syncs.
- Setup guide for maintainers (`docs/GOOGLE_DRIVE_SETUP.md`): how to register the OAuth client, SHA-1 fingerprints, publishing requirements.

Out of scope (kept for follow-ups):
- WorkManager / periodic auto-sync — manual buttons only
- Refresh token stored in keystore — `GoogleAuthUtil.getToken` per-call (~1h), transparent re-issue
- Sync inside Drive (last-write-wins on Push, no merge)
- Credential restore — see "Known limitation" below

## Key design decisions

- **No OAuth Client ID committed**. Token resolution is fully runtime via `(packageName, SHA-1)` registered in the Cloud Console. The doc explains how a downstream maintainer (or this repo) registers their own debug + release SHA-1.
- **Scope `drive.appdata` only** — invisible private folder, file is lost on uninstall (assumed and documented). No sensitive scope review needed for the OAuth consent screen.
- **Play Services unavailable** is handled gracefully via `DriveSyncError.PLAY_SERVICES_UNAVAILABLE` — no crash, the section degrades cleanly.
- **No public API of the existing backup pipeline modified** — additive only (one new Hilt binding, new UI state fields with defaults, new helper in `SettingsDriveBackupActions` mirroring the existing `SettingsBackupActions` pattern).

## Known limitation (not a regression, applies to existing SAF backup too)

`BackupManager.exportConfig` strips `password` from provider rows for security (line 109 in `BackupManagerImpl`). After Pull + import, providers are restored but credentials are empty, so the next sync silently fails. This is identical to the existing SAF behavior and is **not** addressed in this PR — see #44 for a discussion of options (prompt user to re-enter passwords after import, or store credentials separately in Drive under an encrypted file). Happy to follow up with whichever direction you prefer.

## Tests

- `./gradlew :app:assembleDebug` → green
- `./gradlew test` → green (existing `ProviderSetupViewModelTest` updated to stub the new `DriveBackupSyncManager` dependency)
- Manual smoke on TV hardware (BeyondTV4 4K, Android 11, sdk_google_atv64_arm64): Sign-in → Push → Pull → Sign-out validated end-to-end across three sessions. Onboarding Drive CTA also validated on a fresh `pm clear` device.

## API 28 compatibility fix

`URLEncoder.encode(String, Charset)` is API 33+ only. The implementation uses `URLEncoder.encode(value, "UTF-8")` (String charset name overload, API 1+) so the minSdk 28 contract holds. Caught on the TV (Android 11) live test.

## Files

```
:domain
  + manager/DriveBackupSyncManager.kt           (interface + sealed states)

:data
  + manager/GoogleDriveBackupSyncManager.kt     (OkHttp + GoogleSignIn impl, API 28 safe)

:app
  + di/RepositoryModule.kt                      (+ @Binds @Singleton)
  + ui/screens/settings/SettingsUiStateModel.kt (+ 5 Drive state fields)
  + ui/screens/settings/SettingsDriveBackupActions.kt (helper mirroring SettingsBackupActions)
  + ui/screens/settings/SettingsViewModel.kt    (+ driveManager injection + 5 delegated methods)
  + ui/screens/settings/SettingsBackupAboutSections.kt (+ settingsDriveBackupSection)
  + ui/screens/settings/SettingsScreen.kt       (+ sign-in launcher + section call site)
  + ui/screens/settings/SettingsSyncOverlay.kt  (LinearProgressIndicator + N/total parsing)
  + ui/screens/provider/ProviderSetupScreen.kt  (Drive CTA + progress bar in SyncProgressDialog)
  + ui/screens/provider/ProviderSetupViewModel.kt (+ driveManager injection + 3 methods)
  + ui/components/SyncProgressUtil.kt           (shared N/total parser)
  + res/values/strings.xml                      (+ 13 EN strings)
  + res/values-fr/strings.xml                   (+ 13 FR strings, typographic apostrophes)

:docs
  + docs/GOOGLE_DRIVE_SETUP.md                  (maintainer setup guide)

:gradle
  gradle/libs.versions.toml                     (play-services-auth 21.4.0)
  app/build.gradle.kts, data/build.gradle.kts   (dep wired)
```

Closes #42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
