### PR TITLE
feat(backup): restore provider credentials through Drive sync

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
@@ -7,7 +7,6 @@ import com.streamvault.data.remote.xtream.XtreamNetworkException
 import com.streamvault.data.remote.xtream.XtreamParsingException
 import com.streamvault.data.remote.xtream.XtreamRequestException
 import com.streamvault.data.remote.xtream.XtreamResponseTooLargeException
-import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.security.CredentialDecryptionException
 import com.streamvault.domain.manager.BackupConflictStrategy
 import com.streamvault.domain.manager.DriveAuthState
@@ -56,7 +55,6 @@ class ProviderSetupViewModel @Inject constructor(
     private val validateAndAddProvider: ValidateAndAddProvider,
     private val importBackup: ImportBackup,
     private val driveBackupSyncManager: DriveBackupSyncManager,
-    private val credentialCrypto: CredentialCrypto,
 ) : ViewModel() {
 
     enum class OnboardingCompletion {
@@ -172,17 +170,12 @@ class ProviderSetupViewModel @Inject constructor(
     private suspend fun applyPendingDriveCredentials() {
         val pending = _uiState.value.pendingDriveCredentials.orEmpty()
         if (pending.isEmpty()) return
-        val providers = providerRepository.getProviders().first()
         pending.forEach { cred ->
-            val match = providers.firstOrNull { provider ->
-                provider.serverUrl == cred.serverUrl &&
-                    credentialCrypto.decryptIfNeeded(provider.username) == cred.username
-            } ?: return@forEach
-            val updated = match.copy(
-                username = credentialCrypto.encryptIfNeeded(cred.username),
-                password = credentialCrypto.encryptIfNeeded(cred.password),
+            providerRepository.updateProviderPassword(
+                serverUrl = cred.serverUrl,
+                username = cred.username,
+                cleartextPassword = cred.password,
             )
-            providerRepository.updateProvider(updated)
         }
         _uiState.update { it.copy(pendingDriveCredentials = null) }
     }

--- a/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModel.kt
@@ -7,10 +7,12 @@ import com.streamvault.data.remote.xtream.XtreamNetworkException
 import com.streamvault.data.remote.xtream.XtreamParsingException
 import com.streamvault.data.remote.xtream.XtreamRequestException
 import com.streamvault.data.remote.xtream.XtreamResponseTooLargeException
+import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.security.CredentialDecryptionException
 import com.streamvault.domain.manager.BackupConflictStrategy
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveBackupSyncManager
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.Result as DomainResult
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupPreview
@@ -53,7 +55,8 @@ class ProviderSetupViewModel @Inject constructor(
     private val combinedM3uRepository: CombinedM3uRepository,
     private val validateAndAddProvider: ValidateAndAddProvider,
     private val importBackup: ImportBackup,
-    private val driveBackupSyncManager: DriveBackupSyncManager
+    private val driveBackupSyncManager: DriveBackupSyncManager,
+    private val credentialCrypto: CredentialCrypto,
 ) : ViewModel() {
 
     enum class OnboardingCompletion {
@@ -142,7 +145,14 @@ class ProviderSetupViewModel @Inject constructor(
             }
             when (val pullResult = driveBackupSyncManager.pullBackup()) {
                 is DomainResult.Success -> {
-                    _uiState.update { it.copy(isImportingBackup = false) }
+                    // Best-effort companion fetch (M3). Failures are non-fatal.
+                    val credentials = (driveBackupSyncManager.pullCredentials() as? DomainResult.Success)?.data
+                    _uiState.update {
+                        it.copy(
+                            isImportingBackup = false,
+                            pendingDriveCredentials = credentials,
+                        )
+                    }
                     inspectBackup(pullResult.data.localUriString)
                 }
                 is DomainResult.Error -> {
@@ -157,6 +167,24 @@ class ProviderSetupViewModel @Inject constructor(
                 is DomainResult.Loading -> Unit
             }
         }
+    }
+
+    private suspend fun applyPendingDriveCredentials() {
+        val pending = _uiState.value.pendingDriveCredentials.orEmpty()
+        if (pending.isEmpty()) return
+        val providers = providerRepository.getProviders().first()
+        pending.forEach { cred ->
+            val match = providers.firstOrNull { provider ->
+                provider.serverUrl == cred.serverUrl &&
+                    credentialCrypto.decryptIfNeeded(provider.username) == cred.username
+            } ?: return@forEach
+            val updated = match.copy(
+                username = credentialCrypto.encryptIfNeeded(cred.username),
+                password = credentialCrypto.encryptIfNeeded(cred.password),
+            )
+            providerRepository.updateProvider(updated)
+        }
+        _uiState.update { it.copy(pendingDriveCredentials = null) }
     }
 
     fun loadProvider(id: Long) {
@@ -584,6 +612,9 @@ class ProviderSetupViewModel @Inject constructor(
         val plan = capturedPlan ?: return
         viewModelScope.launch {
             val result = importBackup.confirm(ImportBackupCommand(uriString, plan))
+            if (result is ImportBackupResult.Success) {
+                applyPendingDriveCredentials()
+            }
             val hasProviders = if (result is ImportBackupResult.Success) {
                 providerRepository.getProviders().first().isNotEmpty()
             } else {
@@ -781,6 +812,7 @@ data class ProviderSetupState(
     val backupPreview: BackupPreview? = null,
     val pendingBackupUri: String? = null,
     val backupImportPlan: BackupImportPlan = BackupImportPlan(),
+    val pendingDriveCredentials: List<ProviderCredentials>? = null,
     val driveSignedIn: Boolean = false,
     val epgSyncMode: ProviderEpgSyncMode = ProviderEpgSyncMode.BACKGROUND,
     val xtreamLiveSyncMode: ProviderXtreamLiveSyncMode = ProviderXtreamLiveSyncMode.AUTO,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBackupActions.kt
@@ -99,7 +99,10 @@ internal class SettingsBackupActions(
         uiState.update { it.copy(backupImportPlan = it.backupImportPlan.copy(importRecordingSchedules = enabled)) }
     }
 
-    fun confirmBackupImport(scope: CoroutineScope) {
+    fun confirmBackupImport(
+        scope: CoroutineScope,
+        onSuccess: (suspend () -> Unit)? = null,
+    ) {
         // Atomically capture uri+plan and mark in-flight so rapid double-taps cannot both
         // pass the guard before the flag is written. MutableStateFlow.update {} is a CAS
         // loop, so only one call wins the transition isImportingBackup=false→true.
@@ -134,6 +137,9 @@ internal class SettingsBackupActions(
                     pendingBackupUri = null,
                     backupImportPlan = BackupImportPlan()
                 )
+            }
+            if (result is ImportBackupResult.Success) {
+                onSuccess?.invoke()
             }
         }
     }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
@@ -3,11 +3,9 @@ package com.streamvault.app.ui.screens.settings
 import androidx.activity.result.ActivityResultLauncher
 import android.content.Intent
 import android.util.Log
-import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.manager.DriveSyncStatus
-import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.Result
 import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.usecase.ImportBackup
@@ -16,7 +14,6 @@ import com.streamvault.domain.usecase.InspectBackupResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -33,7 +30,6 @@ internal class SettingsDriveBackupActions(
     private val driveManager: DriveBackupSyncManager,
     private val importBackup: ImportBackup,
     private val providerRepository: ProviderRepository,
-    private val credentialCrypto: CredentialCrypto,
     private val uiState: MutableStateFlow<SettingsUiState>
 ) {
 
@@ -161,18 +157,10 @@ internal class SettingsDriveBackupActions(
                 }
                 return@launch
             }
-            // Chain credentials push (M3). Decrypt local-DB ciphertexts before
-            // uploading: the Drive copy lives in appDataFolder cleartext.
-            val providers = providerRepository.getProviders().first()
-            val credentials = providers
-                .filter { it.username.isNotBlank() && it.password.isNotBlank() }
-                .map { provider ->
-                    ProviderCredentials(
-                        serverUrl = provider.serverUrl,
-                        username = credentialCrypto.decryptIfNeeded(provider.username),
-                        password = credentialCrypto.decryptIfNeeded(provider.password),
-                    )
-                }
+            // Chain credentials push (M3). The repository handles decryption
+            // internally so the cleartext never crosses the data layer except
+            // via the typed ProviderCredentials payload returned here.
+            val credentials = providerRepository.getAllProviderCredentials()
             val credsResult = driveManager.pushCredentials(credentials)
             uiState.update { state ->
                 when (credsResult) {
@@ -246,19 +234,16 @@ internal class SettingsDriveBackupActions(
         scope.launch {
             val pending = uiState.value.pendingDriveCredentials.orEmpty()
             if (pending.isEmpty()) return@launch
-            val providers = providerRepository.getProviders().first()
             var applied = 0
             pending.forEach { cred ->
-                val match = providers.firstOrNull { provider ->
-                    provider.serverUrl == cred.serverUrl &&
-                        credentialCrypto.decryptIfNeeded(provider.username) == cred.username
-                } ?: return@forEach
-                val updated = match.copy(
-                    username = credentialCrypto.encryptIfNeeded(cred.username),
-                    password = credentialCrypto.encryptIfNeeded(cred.password),
-                )
-                providerRepository.updateProvider(updated)
-                applied++
+                if (providerRepository.updateProviderPassword(
+                        serverUrl = cred.serverUrl,
+                        username = cred.username,
+                        cleartextPassword = cred.password,
+                    )
+                ) {
+                    applied++
+                }
             }
             Log.d("DriveSync", "applyPendingCredentials: $applied / ${pending.size} matched")
             uiState.update { it.copy(pendingDriveCredentials = null) }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDriveBackupActions.kt
@@ -2,16 +2,21 @@ package com.streamvault.app.ui.screens.settings
 
 import androidx.activity.result.ActivityResultLauncher
 import android.content.Intent
+import android.util.Log
+import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.manager.DriveSyncStatus
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.Result
+import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.usecase.ImportBackup
 import com.streamvault.domain.usecase.InspectBackupCommand
 import com.streamvault.domain.usecase.InspectBackupResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -27,6 +32,8 @@ import kotlinx.coroutines.launch
 internal class SettingsDriveBackupActions(
     private val driveManager: DriveBackupSyncManager,
     private val importBackup: ImportBackup,
+    private val providerRepository: ProviderRepository,
+    private val credentialCrypto: CredentialCrypto,
     private val uiState: MutableStateFlow<SettingsUiState>
 ) {
 
@@ -144,16 +151,38 @@ internal class SettingsDriveBackupActions(
                 return@launch
             }
             uiState.update { it.copy(driveIsBusy = true) }
-            val result = driveManager.pushBackup()
+            val backupResult = driveManager.pushBackup()
+            if (backupResult is Result.Error) {
+                uiState.update {
+                    it.copy(
+                        driveIsBusy = false,
+                        userMessage = "Drive push failed: ${backupResult.message}"
+                    )
+                }
+                return@launch
+            }
+            // Chain credentials push (M3). Decrypt local-DB ciphertexts before
+            // uploading: the Drive copy lives in appDataFolder cleartext.
+            val providers = providerRepository.getProviders().first()
+            val credentials = providers
+                .filter { it.username.isNotBlank() && it.password.isNotBlank() }
+                .map { provider ->
+                    ProviderCredentials(
+                        serverUrl = provider.serverUrl,
+                        username = credentialCrypto.decryptIfNeeded(provider.username),
+                        password = credentialCrypto.decryptIfNeeded(provider.password),
+                    )
+                }
+            val credsResult = driveManager.pushCredentials(credentials)
             uiState.update { state ->
-                when (result) {
+                when (credsResult) {
                     is Result.Success -> state.copy(
                         driveIsBusy = false,
                         userMessage = "Backup uploaded to Google Drive"
                     )
                     is Result.Error -> state.copy(
                         driveIsBusy = false,
-                        userMessage = "Drive push failed: ${result.message}"
+                        userMessage = "Backup uploaded but credentials failed: ${credsResult.message}"
                     )
                     is Result.Loading -> state.copy(driveIsBusy = false)
                 }
@@ -179,6 +208,13 @@ internal class SettingsDriveBackupActions(
                 return@launch
             }
             val artifact = (pullResult as Result.Success).data
+            // Best-effort companion fetch (M3). Failures here are non-fatal —
+            // the user can still complete the import without credentials.
+            val credentialsResult = driveManager.pullCredentials()
+            val pendingCredentials = (credentialsResult as? Result.Success)?.data
+            if (credentialsResult is Result.Error) {
+                Log.w("DriveSync", "pullCredentials failed (non-fatal): ${credentialsResult.message}")
+            }
             val inspectResult = importBackup.inspect(InspectBackupCommand(artifact.localUriString))
             uiState.update { state ->
                 when (inspectResult) {
@@ -186,7 +222,8 @@ internal class SettingsDriveBackupActions(
                         driveIsBusy = false,
                         pendingBackupUri = inspectResult.uriString,
                         backupPreview = inspectResult.preview,
-                        backupImportPlan = inspectResult.defaultPlan
+                        backupImportPlan = inspectResult.defaultPlan,
+                        pendingDriveCredentials = pendingCredentials,
                     )
                     is InspectBackupResult.Error -> state.copy(
                         driveIsBusy = false,
@@ -194,6 +231,37 @@ internal class SettingsDriveBackupActions(
                     )
                 }
             }
+        }
+    }
+
+    /**
+     * Applies the credentials downloaded by [pullBackup] to the providers that
+     * were just restored by the SAF import dialog. Match key is
+     * `(serverUrl, username)` so the row ids reshuffled by import don't matter.
+     * Re-encrypts via [CredentialCrypto] before writing to the local DB.
+     *
+     * Call this from the ViewModel **after** the import confirm succeeds.
+     */
+    fun applyPendingCredentials(scope: CoroutineScope) {
+        scope.launch {
+            val pending = uiState.value.pendingDriveCredentials.orEmpty()
+            if (pending.isEmpty()) return@launch
+            val providers = providerRepository.getProviders().first()
+            var applied = 0
+            pending.forEach { cred ->
+                val match = providers.firstOrNull { provider ->
+                    provider.serverUrl == cred.serverUrl &&
+                        credentialCrypto.decryptIfNeeded(provider.username) == cred.username
+                } ?: return@forEach
+                val updated = match.copy(
+                    username = credentialCrypto.encryptIfNeeded(cred.username),
+                    password = credentialCrypto.encryptIfNeeded(cred.password),
+                )
+                providerRepository.updateProvider(updated)
+                applied++
+            }
+            Log.d("DriveSync", "applyPendingCredentials: $applied / ${pending.size} matched")
+            uiState.update { it.copy(pendingDriveCredentials = null) }
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -8,6 +8,7 @@ import com.streamvault.domain.manager.BackupPreview
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveSignInRequest
 import com.streamvault.domain.manager.DriveSyncStatus
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.ActiveLiveSource
 import com.streamvault.domain.model.AppTimeFormat
 import com.streamvault.domain.model.AudioOutputPreference
@@ -93,6 +94,9 @@ data class SettingsUiState(
     val driveLastPullAt: Long? = null,
     val drivePendingSignIn: DriveSignInRequest? = null,
     val driveIsBusy: Boolean = false,
+    // M3 — credentials downloaded by pullBackup, waiting to be applied
+    // to providers once the import confirm completes.
+    val pendingDriveCredentials: List<ProviderCredentials>? = null,
     val recordingItems: List<RecordingItem> = emptyList(),
     val recordingStorageState: RecordingStorageState = RecordingStorageState(),
     val wifiOnlyRecording: Boolean = false,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -23,7 +23,6 @@ import com.streamvault.data.local.dao.XtreamIndexJobDao
 import com.streamvault.data.local.dao.XtreamLiveOnboardingDao
 import com.streamvault.data.local.entity.XtreamIndexJobEntity
 import com.streamvault.data.preferences.PreferencesRepository
-import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.sync.SyncManager
 import com.streamvault.data.sync.SyncRepairSection
 import com.streamvault.domain.manager.BackupConflictStrategy
@@ -95,7 +94,6 @@ class SettingsViewModel @Inject constructor(
     private val internetSpeedTestRunner: InternetSpeedTestRunner,
     private val backupManager: BackupManager,
     private val driveBackupSyncManager: DriveBackupSyncManager,
-    private val credentialCrypto: CredentialCrypto,
     private val recordingManager: RecordingManager,
     private val parentalControlManager: ParentalControlManager,
     private val syncManager: SyncManager,
@@ -136,7 +134,6 @@ class SettingsViewModel @Inject constructor(
         driveManager = driveBackupSyncManager,
         importBackup = importBackup,
         providerRepository = providerRepository,
-        credentialCrypto = credentialCrypto,
         uiState = _uiState
     )
     private val recordingActions = SettingsRecordingActions(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -23,6 +23,7 @@ import com.streamvault.data.local.dao.XtreamIndexJobDao
 import com.streamvault.data.local.dao.XtreamLiveOnboardingDao
 import com.streamvault.data.local.entity.XtreamIndexJobEntity
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.sync.SyncManager
 import com.streamvault.data.sync.SyncRepairSection
 import com.streamvault.domain.manager.BackupConflictStrategy
@@ -94,6 +95,7 @@ class SettingsViewModel @Inject constructor(
     private val internetSpeedTestRunner: InternetSpeedTestRunner,
     private val backupManager: BackupManager,
     private val driveBackupSyncManager: DriveBackupSyncManager,
+    private val credentialCrypto: CredentialCrypto,
     private val recordingManager: RecordingManager,
     private val parentalControlManager: ParentalControlManager,
     private val syncManager: SyncManager,
@@ -133,6 +135,8 @@ class SettingsViewModel @Inject constructor(
     private val driveBackupActions = SettingsDriveBackupActions(
         driveManager = driveBackupSyncManager,
         importBackup = importBackup,
+        providerRepository = providerRepository,
+        credentialCrypto = credentialCrypto,
         uiState = _uiState
     )
     private val recordingActions = SettingsRecordingActions(
@@ -943,7 +947,9 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun confirmBackupImport() {
-        backupActions.confirmBackupImport(viewModelScope)
+        backupActions.confirmBackupImport(viewModelScope) {
+            driveBackupActions.applyPendingCredentials(viewModelScope)
+        }
     }
 
     fun beginDriveSignIn(launcher: ActivityResultLauncher<Intent>) {

--- a/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
@@ -10,7 +10,6 @@ import com.streamvault.domain.repository.CombinedM3uRepository
 import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupImportResult
-import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.usecase.ImportBackup
@@ -29,7 +28,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
-import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -43,10 +41,6 @@ class ProviderSetupViewModelTest {
     private val validateAndAddProvider: ValidateAndAddProvider = mock()
     private val importBackup: ImportBackup = mock()
     private val driveBackupSyncManager: DriveBackupSyncManager = mock()
-    private val credentialCrypto: CredentialCrypto = mock {
-        on { encryptIfNeeded(any()) } doAnswer { it.getArgument(0) }
-        on { decryptIfNeeded(any()) } doAnswer { it.getArgument(0) }
-    }
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -88,7 +82,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -123,7 +116,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.loginXtream("https://example.com", "alice", "secret", "Premium", "", "")
@@ -156,7 +148,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
         val field = ProviderSetupViewModel::class.java.getDeclaredField("_uiState").apply { isAccessible = true }
         @Suppress("UNCHECKED_CAST")
@@ -183,7 +174,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         val seededState = viewModel.uiState.value.copy(
@@ -235,7 +225,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -257,7 +246,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.STALKER)
@@ -275,7 +263,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.XTREAM)
@@ -293,7 +280,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.M3U)
@@ -311,7 +297,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.updateEpgSyncMode(ProviderEpgSyncMode.SKIP)
@@ -344,7 +329,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         // Simulate being in edit mode for provider 7.
@@ -377,7 +361,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist", "", "")
@@ -402,7 +385,6 @@ class ProviderSetupViewModelTest {
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
             driveBackupSyncManager = driveBackupSyncManager,
-            credentialCrypto = credentialCrypto,
         )
 
         viewModel.loginStalker(

--- a/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/provider/ProviderSetupViewModelTest.kt
@@ -10,6 +10,7 @@ import com.streamvault.domain.repository.CombinedM3uRepository
 import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupImportResult
+import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.domain.manager.DriveAuthState
 import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.usecase.ImportBackup
@@ -28,6 +29,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -41,6 +43,10 @@ class ProviderSetupViewModelTest {
     private val validateAndAddProvider: ValidateAndAddProvider = mock()
     private val importBackup: ImportBackup = mock()
     private val driveBackupSyncManager: DriveBackupSyncManager = mock()
+    private val credentialCrypto: CredentialCrypto = mock {
+        on { encryptIfNeeded(any()) } doAnswer { it.getArgument(0) }
+        on { decryptIfNeeded(any()) } doAnswer { it.getArgument(0) }
+    }
     private val testDispatcher = StandardTestDispatcher()
 
     @Before
@@ -81,7 +87,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -115,7 +122,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.loginXtream("https://example.com", "alice", "secret", "Premium", "", "")
@@ -147,7 +155,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
         val field = ProviderSetupViewModel::class.java.getDeclaredField("_uiState").apply { isAccessible = true }
         @Suppress("UNCHECKED_CAST")
@@ -173,7 +182,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         val seededState = viewModel.uiState.value.copy(
@@ -224,7 +234,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist 7", "", "")
@@ -245,7 +256,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.STALKER)
@@ -262,7 +274,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.XTREAM)
@@ -279,7 +292,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.applySourceDefaults(ProviderSetupViewModel.SetupSourceType.M3U)
@@ -296,7 +310,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.updateEpgSyncMode(ProviderEpgSyncMode.SKIP)
@@ -328,7 +343,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         // Simulate being in edit mode for provider 7.
@@ -360,7 +376,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.addM3u("https://example.com/list.m3u", "Playlist", "", "")
@@ -384,7 +401,8 @@ class ProviderSetupViewModelTest {
             combinedM3uRepository = combinedM3uRepository,
             validateAndAddProvider = validateAndAddProvider,
             importBackup = importBackup,
-            driveBackupSyncManager = driveBackupSyncManager
+            driveBackupSyncManager = driveBackupSyncManager,
+            credentialCrypto = credentialCrypto,
         )
 
         viewModel.loginStalker(

--- a/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
+++ b/data/src/main/java/com/streamvault/data/manager/GoogleDriveBackupSyncManager.kt
@@ -21,6 +21,7 @@ import com.streamvault.domain.manager.DriveBackupSyncManager
 import com.streamvault.domain.manager.DriveSignInRequest
 import com.streamvault.domain.manager.DriveSyncError
 import com.streamvault.domain.manager.DriveSyncStatus
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.Result
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
@@ -174,7 +175,7 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         }
 
         val uploadOk = try {
-            uploadAppDataFile(token, tempFile)
+            uploadAppDataFile(token, tempFile, BACKUP_FILE_NAME)
         } catch (io: IOException) {
             return@withContext Result.Error(DriveSyncError.NETWORK, io)
         } finally {
@@ -205,7 +206,7 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         Log.d("DriveSync", "pullBackup: token OK, looking up remote backup id")
 
         val fileId = try {
-            findRemoteBackupId(token)
+            findRemoteFileId(token, BACKUP_FILE_NAME)
         } catch (io: IOException) {
             Log.e("DriveSync", "pullBackup: NETWORK error while finding remote id", io)
             return@withContext Result.Error(DriveSyncError.NETWORK, io)
@@ -242,6 +243,91 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         )
     }
 
+    override suspend fun pushCredentials(
+        credentials: List<ProviderCredentials>,
+    ): Result<Unit> = withContext(Dispatchers.IO) {
+        Log.d("DriveSync", "pushCredentials: start (count=${credentials.size})")
+        val account = requireSignedInAccount() ?: return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
+        val token = fetchAccessToken(account) ?: return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+
+        val json = JSONArray().apply {
+            credentials.forEach { cred ->
+                put(
+                    JSONObject().apply {
+                        put("serverUrl", cred.serverUrl)
+                        put("username", cred.username)
+                        put("password", cred.password)
+                    },
+                )
+            }
+        }.toString()
+
+        val tempFile = File(context.cacheDir, TEMP_CREDENTIALS_FILE_NAME).apply { delete() }
+        tempFile.writeText(json)
+
+        val uploadOk = try {
+            uploadAppDataFile(token, tempFile, CREDENTIALS_FILE_NAME)
+        } catch (io: IOException) {
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        } finally {
+            tempFile.delete()
+        }
+        if (!uploadOk) {
+            Log.w("DriveSync", "pushCredentials: upload failed")
+            return@withContext Result.Error(DriveSyncError.NETWORK)
+        }
+        Log.d("DriveSync", "pushCredentials: SUCCESS")
+        Result.Success(Unit)
+    }
+
+    override suspend fun pullCredentials(): Result<List<ProviderCredentials>> = withContext(Dispatchers.IO) {
+        Log.d("DriveSync", "pullCredentials: start")
+        val account = requireSignedInAccount() ?: return@withContext Result.Error(DriveSyncError.NOT_SIGNED_IN)
+        val token = fetchAccessToken(account) ?: return@withContext Result.Error(DriveSyncError.AUTH_FAILED)
+
+        val fileId = try {
+            findRemoteFileId(token, CREDENTIALS_FILE_NAME)
+        } catch (io: IOException) {
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        }
+        if (fileId == null) {
+            Log.d("DriveSync", "pullCredentials: no remote credentials file (pre-M3 backup), returning empty list")
+            return@withContext Result.Success(emptyList())
+        }
+
+        val target = File(context.cacheDir, TEMP_CREDENTIALS_FILE_NAME).apply { delete() }
+        val downloadOk = try {
+            downloadAppDataFile(token, fileId, target)
+        } catch (io: IOException) {
+            target.delete()
+            return@withContext Result.Error(DriveSyncError.NETWORK, io)
+        }
+        if (!downloadOk || !target.exists() || target.length() == 0L) {
+            target.delete()
+            return@withContext Result.Error(DriveSyncError.NETWORK)
+        }
+
+        val parsed = try {
+            val array = JSONArray(target.readText())
+            (0 until array.length()).map { idx ->
+                val obj = array.getJSONObject(idx)
+                ProviderCredentials(
+                    serverUrl = obj.getString("serverUrl"),
+                    username = obj.getString("username"),
+                    password = obj.getString("password"),
+                )
+            }
+        } catch (t: Throwable) {
+            Log.e("DriveSync", "pullCredentials: JSON parse error", t)
+            target.delete()
+            return@withContext Result.Error(DriveSyncError.IMPORT_FAILED, t)
+        } finally {
+            target.delete()
+        }
+        Log.d("DriveSync", "pullCredentials: SUCCESS (count=${parsed.size})")
+        Result.Success(parsed)
+    }
+
     // ── Internals ─────────────────────────────────────────────────────────────
 
     private fun buildClient(): GoogleSignInClient {
@@ -272,10 +358,10 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         null
     }
 
-    private fun findRemoteBackupId(authToken: String): String? {
+    private fun findRemoteFileId(authToken: String, fileName: String): String? {
         val url = "https://www.googleapis.com/drive/v3/files" +
             "?spaces=appDataFolder" +
-            "&q=" + uriEncode("name='$BACKUP_FILE_NAME'") +
+            "&q=" + uriEncode("name='$fileName'") +
             "&fields=files(id,modifiedTime,size)"
         val request = Request.Builder()
             .url(url)
@@ -291,8 +377,8 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         }
     }
 
-    private fun uploadAppDataFile(authToken: String, payload: File): Boolean {
-        val existingId = findRemoteBackupId(authToken)
+    private fun uploadAppDataFile(authToken: String, payload: File, fileName: String): Boolean {
+        val existingId = findRemoteFileId(authToken, fileName)
         val boundary = "streamvault-${System.nanoTime()}"
         val (httpMethod, endpoint) = if (existingId != null) {
             "PATCH" to "https://www.googleapis.com/upload/drive/v3/files/$existingId?uploadType=multipart"
@@ -301,7 +387,7 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         }
 
         val metadata = JSONObject().apply {
-            put("name", BACKUP_FILE_NAME)
+            put("name", fileName)
             if (existingId == null) {
                 put("parents", JSONArray().put("appDataFolder"))
             }
@@ -345,6 +431,8 @@ class GoogleDriveBackupSyncManager @Inject constructor(
         const val SCOPE_APP_DATA = "https://www.googleapis.com/auth/drive.appdata"
         const val BACKUP_FILE_NAME = "streamvault_backup.json"
         const val TEMP_BACKUP_FILE_NAME = "drive_sync_backup.json"
+        const val CREDENTIALS_FILE_NAME = "streamvault_credentials.json"
+        const val TEMP_CREDENTIALS_FILE_NAME = "drive_sync_credentials.json"
     }
 }
 

--- a/data/src/main/java/com/streamvault/data/repository/ProviderRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/ProviderRepositoryImpl.kt
@@ -18,6 +18,7 @@ import com.streamvault.data.sync.SyncManager
 import com.streamvault.data.sync.hasUsableLiveCatalogForActivation
 import com.streamvault.data.util.ProviderInputSanitizer
 import com.streamvault.data.util.UrlSecurityPolicy
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.*
 import com.streamvault.domain.provider.IptvProvider
 import com.streamvault.domain.repository.LiveStreamProgramRequest
@@ -84,6 +85,35 @@ class ProviderRepositoryImpl @Inject constructor(
         Result.success(Unit)
     } catch (e: Exception) {
         Result.error("Failed to update provider: ${e.message}", e)
+    }
+
+    override suspend fun getAllProviderCredentials(): List<ProviderCredentials> {
+        return providerDao.getAllSync()
+            .map { entity ->
+                ProviderCredentials(
+                    serverUrl = entity.serverUrl,
+                    username = entity.username,
+                    password = try {
+                        credentialCrypto.decryptIfNeeded(entity.password)
+                    } catch (e: Throwable) {
+                        ""
+                    },
+                )
+            }
+            .filter { it.username.isNotBlank() && it.password.isNotBlank() }
+    }
+
+    override suspend fun updateProviderPassword(
+        serverUrl: String,
+        username: String,
+        cleartextPassword: String,
+    ): Boolean {
+        val entity = providerDao.getAllSync().firstOrNull {
+            it.serverUrl == serverUrl && it.username == username
+        } ?: return false
+        val encrypted = credentialCrypto.encryptIfNeeded(cleartextPassword)
+        providerDao.update(entity.copy(password = encrypted))
+        return true
     }
 
     override suspend fun deleteProvider(id: Long): Result<Unit> = try {

--- a/docs/GOOGLE_DRIVE_SETUP.md
+++ b/docs/GOOGLE_DRIVE_SETUP.md
@@ -97,6 +97,43 @@ screen's *Test users* list.
 
 - The backup payload reuses the existing `BackupManager` JSON v5 export. Provider
   passwords are already stripped (`BackupManagerImpl.exportConfig`, see the
-  `password = ""` line) — they are never uploaded to Drive.
+  `password = ""` line).
 - Auth tokens fetched via `GoogleAuthUtil.getToken` are never logged.
 - The scope `drive.appdata` cannot read files outside the app's private folder.
+
+## Credentials storage (fork extension, M3)
+
+`drive-backup.json` carries the configuration *minus* passwords. The fork
+ships a **second sibling file** in the same `appDataFolder`:
+
+- **`streamvault_credentials.json`** — `[{serverUrl, username, password}]`,
+  cleartext.
+
+Why cleartext on Drive:
+
+- The file is invisible to the OS and to the standard Drive UI (the
+  `drive.appdata` scope is the only path that can read it).
+- Access is gated by the user's Google account + OAuth consent.
+- It is purged automatically when the app is uninstalled.
+- Cross-device-by-design — a per-device Keystore key would defeat the
+  purpose (the file would be unreadable on a fresh install, which is
+  precisely the use case it solves).
+- A passphrase-protected variant was considered and rejected: it adds
+  significant UX friction (user must remember a passphrase across
+  devices) for a small additional security margin given the threat
+  model above.
+
+The local DB still stores credentials encrypted via
+`AndroidKeystoreCredentialCrypto`. Cleartext only exists inside the
+Drive `appDataFolder` and inside the in-memory pull result up to the
+moment of import confirm.
+
+Matching at pull time is by `(serverUrl, username)` so the provider
+ids reshuffled by the SAF import do not break the restore. Providers
+present locally but absent from the credentials file are left
+untouched.
+
+Pre-M3 backups (no `streamvault_credentials.json` in `appDataFolder`)
+are handled gracefully: `pullCredentials` returns an empty list and
+the import path falls back to the master behavior (providers
+restored without passwords, user must re-enter them manually).

--- a/domain/src/main/java/com/streamvault/domain/manager/DriveBackupSyncManager.kt
+++ b/domain/src/main/java/com/streamvault/domain/manager/DriveBackupSyncManager.kt
@@ -58,7 +58,38 @@ interface DriveBackupSyncManager {
      * nothing has been pushed yet.
      */
     suspend fun pullBackup(): Result<DriveBackupArtifact>
+
+    /**
+     * Uploads the provider credentials list to a private sibling file
+     * (`streamvault_credentials.json`) in the same Drive `appDataFolder`.
+     * Companion to [pushBackup] — credentials are stripped from the main
+     * backup JSON by design, so this restores the round-trip.
+     *
+     * Pure overwrite (last-write-wins). Matching at pull time uses
+     * `(serverUrl, username)` so provider id reshuffling on import does
+     * not invalidate the restore.
+     */
+    suspend fun pushCredentials(credentials: List<ProviderCredentials>): Result<Unit>
+
+    /**
+     * Downloads `streamvault_credentials.json` from Drive `appDataFolder`.
+     * Returns an empty list if the file is absent (graceful backwards
+     * compatibility with backups produced before M3).
+     */
+    suspend fun pullCredentials(): Result<List<ProviderCredentials>>
 }
+
+/**
+ * Cleartext credentials for a single provider, transported alongside the main
+ * backup JSON. Storage relies on the `drive.appdata` scope + Google account
+ * ACL for confidentiality — the file is invisible to the OS and purged on
+ * uninstall. Matching on pull uses `(serverUrl, username)`.
+ */
+data class ProviderCredentials(
+    val serverUrl: String,
+    val username: String,
+    val password: String,
+)
 
 /** Public Sign-In state for the UI. */
 sealed class DriveAuthState {

--- a/domain/src/main/java/com/streamvault/domain/repository/ProviderRepository.kt
+++ b/domain/src/main/java/com/streamvault/domain/repository/ProviderRepository.kt
@@ -1,5 +1,6 @@
 package com.streamvault.domain.repository
 
+import com.streamvault.domain.manager.ProviderCredentials
 import com.streamvault.domain.model.Program
 import com.streamvault.domain.model.Provider
 import com.streamvault.domain.model.ProviderEpgSyncMode
@@ -19,6 +20,26 @@ interface ProviderRepository {
     suspend fun addProvider(provider: Provider): Result<Long>
     suspend fun updateProvider(provider: Provider): Result<Unit>
     suspend fun deleteProvider(id: Long): Result<Unit>
+
+    /**
+     * Returns cleartext credentials for all providers that have both a
+     * username and a password. Used by the Drive credentials sync path
+     * (M3). Decryption happens inside the `:data` layer — the cleartext
+     * payload is only ever exposed via this single typed method.
+     */
+    suspend fun getAllProviderCredentials(): List<ProviderCredentials>
+
+    /**
+     * Applies a cleartext password to the provider matched by
+     * `(serverUrl, username)`. Encryption happens inside the `:data`
+     * layer. Returns true if a matching provider was found and updated.
+     */
+    suspend fun updateProviderPassword(
+        serverUrl: String,
+        username: String,
+        cleartextPassword: String,
+    ): Boolean
+
     suspend fun setActiveProvider(id: Long): Result<Unit>
     suspend fun loginXtream(serverUrl: String, username: String, password: String, name: String, httpUserAgent: String = "", httpHeaders: String = "", xtreamFastSyncEnabled: Boolean, epgSyncMode: ProviderEpgSyncMode = ProviderEpgSyncMode.BACKGROUND, xtreamLiveSyncMode: ProviderXtreamLiveSyncMode = ProviderXtreamLiveSyncMode.AUTO, onProgress: ((String) -> Unit)? = null, id: Long? = null): Result<Provider>
     suspend fun validateM3u(url: String, name: String, httpUserAgent: String = "", httpHeaders: String = "", epgSyncMode: ProviderEpgSyncMode = ProviderEpgSyncMode.BACKGROUND, m3uVodClassificationEnabled: Boolean = false, onProgress: ((String) -> Unit)? = null, id: Long? = null): Result<Provider>


### PR DESCRIPTION
Follow-up to #43 (Drive sync). Addresses option (4) of #44 (backup import leaves providers without credentials).

## Summary

The main backup JSON intentionally strips passwords (`BackupManagerImpl.exportConfig`). After a Drive Pull + import, providers are restored but unable to sync — silent failure for the user. This PR closes that gap by storing a **second private file** in the same Drive `appDataFolder`:

- **`streamvault_credentials.json`** — `[{serverUrl, username, password}]`, cleartext

On Push the credentials list is uploaded alongside the main backup. On Pull both files are downloaded; after `BackupImportResult.Success` the credentials are applied to the freshly restored providers by `(serverUrl, username)` matching and re-encrypted via the existing `CredentialCrypto` (Android Keystore AES-GCM) before being written to the local DB.

## Why cleartext on Drive

- The file is invisible to the OS and to the standard Drive UI — only the `drive.appdata` scope can read it.
- Access is gated by the user's Google account + OAuth consent.
- It is purged automatically when the app is uninstalled.
- **Cross-device by design** — a per-device Keystore key was rejected because it would defeat the very use case this solves (the file would be unreadable on a fresh install, which is exactly when the user needs the restore).
- A passphrase-protected variant was considered and rejected for the UX cost (user has to remember a passphrase across devices) vs the marginal security gain given the threat model above.

Documented at length in the new "Credentials storage" section of `docs/GOOGLE_DRIVE_SETUP.md`.

## What's in / what's out

In scope:
- Push uploads both files sequentially. Best-effort atomicity: if the second upload fails, the user sees `"Backup uploaded but credentials failed: …"`.
- Pull downloads both files, parks the credentials list in UI state, and applies them post-confirm. The existing `BackupImportPreviewDialog` still drives the import — no UX change.
- Same flow wired into the onboarding `ProviderSetupViewModel.importBackupFromDrive` so a fresh-device restore works end-to-end.
- Backwards compatible: a pre-M3 backup with no credentials sibling makes `pullCredentials` return an empty list and the import falls back to the master behavior (providers restored without passwords, user re-enters them manually). No crash, no breaking change.

Out of scope (and intentionally so):
- WorkManager / periodic auto-sync — manual buttons only (same as #43).
- Conflict resolution multi-device — last-write-wins on Push, same as #43.
- A user-facing toggle to disable credentials sync — discussed and dropped. If demand surfaces it can come as a follow-up.

## Repository surface

To avoid leaking `CredentialCrypto` (which lives in `:data`) into `:app`, two narrow typed accessors were added to `ProviderRepository`:

- `getAllProviderCredentials(): List<ProviderCredentials>` — decrypts internally, returns the cleartext payload.
- `updateProviderPassword(serverUrl, username, cleartextPassword): Boolean` — re-encrypts internally, matches by `(serverUrl, username)`. Returns `false` if no match (safe no-op).

Cleartext credentials only ever transit `:data` and the typed `ProviderCredentials` value object. The `:app` helpers (`SettingsDriveBackupActions`, `ProviderSetupViewModel`) no longer need to inject `CredentialCrypto`.

## A note on the discovery

The first end-to-end smoke uncovered that `ProviderRepository.getProviders()` returns providers via `toPublicDomain()`, which strips the `password` field — a deliberate security boundary on `master`. The naive M3 push therefore uploaded an empty credentials list. The fix is exactly the two accessors above: they preserve the existing boundary (no other call site gets cleartext) while exposing a single explicit, typed path for this use case. The commit message of `fix(repo): expose decrypted credentials through ProviderRepository` carries the full trace.

## Tests

- `./gradlew :app:assembleDebug` → green
- `./gradlew test` → green (existing `ProviderSetupViewModelTest` updated for the M3 constructor surface; mocks reverted to identity)
- Manual smoke on TV `.103` (BeyondTV4 4K, Android 11):
    - Push → `appDataFolder` contains both `streamvault_backup.json` and `streamvault_credentials.json` (verified in Drive Cloud Console).
    - `pm clear com.streamvault.app` → onboarding → Drive sign-in → import from Drive → confirm.
    - Settings → Providers → "Sync" → 15+ Xtream live categories completed in a row with **no HTTP 511 / auth errors**, contrary to the master behavior.
- Compat ascendante validated: pulling a pre-M3 backup (no sibling file in Drive) hits the `pullCredentials → emptyList()` fallback cleanly, no crash, providers restored without passwords as on master.

## Files

```
:domain
  ~ manager/DriveBackupSyncManager.kt           (+ ProviderCredentials data class, + 2 suspend methods)
  ~ repository/ProviderRepository.kt            (+ 2 typed accessors)

:data
  ~ manager/GoogleDriveBackupSyncManager.kt     (impl push/pull + fileName-parameterized REST plumbing)
  ~ repository/ProviderRepositoryImpl.kt        (impl accessors via providerDao + credentialCrypto)

:app
  ~ ui/screens/settings/SettingsUiStateModel.kt    (+ pendingDriveCredentials)
  ~ ui/screens/settings/SettingsBackupActions.kt   (+ optional onSuccess suspend callback)
  ~ ui/screens/settings/SettingsDriveBackupActions.kt (chain push + chain pull + apply)
  ~ ui/screens/settings/SettingsViewModel.kt       (wire post-import callback)
  ~ ui/screens/provider/ProviderSetupViewModel.kt  (chain pull + apply for onboarding)
  ~ test/ProviderSetupViewModelTest.kt              (mock cleanup)

:docs
  ~ docs/GOOGLE_DRIVE_SETUP.md                  (+ "Credentials storage" section)
```

Closes #44 if you pick this direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)