### PR TITLE
fix(ui): preserve onLongClick on TvClickableSurface / TvIconButton (regression from d56079f)

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/interaction/TvComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/interaction/TvComponents.kt
@@ -48,8 +48,17 @@ fun TvClickableSurface(
     Surface(
         onClick = onClick,
         onLongClick = onLongClick,
+        // When a long-click handler is provided, we cannot consume the
+        // activation key events ourselves: the underlying TV Surface needs to
+        // observe the full DOWN → (hold) → UP sequence to recognise a
+        // long-press. Forwarding only onClick on ACTION_UP (as activateOnRemoteKey
+        // does) collapses every key press into a click and silently breaks
+        // onLongClick on the D-pad / Enter / Space / Button A.
         modifier = modifier
-            .activateOnRemoteKey(enabled = enabled, onClick = onClick)
+            .then(
+                if (onLongClick != null) Modifier
+                else Modifier.activateOnRemoteKey(enabled = enabled, onClick = onClick)
+            )
             .mouseClickable(onClick = onClick, enabled = enabled, onLongClick = onLongClick),
         enabled = enabled,
         shape = shape,
@@ -118,8 +127,14 @@ fun TvIconButton(
     IconButton(
         onClick = onClick,
         onLongClick = onLongClick,
+        // Same reason as TvClickableSurface: if a long-click handler is set,
+        // let the native TV IconButton see the full key sequence instead of
+        // collapsing it via activateOnRemoteKey.
         modifier = modifier
-            .activateOnRemoteKey(enabled = enabled, onClick = onClick)
+            .then(
+                if (onLongClick != null) Modifier
+                else Modifier.activateOnRemoteKey(enabled = enabled, onClick = onClick)
+            )
             .mouseClickable(onClick = onClick, enabled = enabled),
         enabled = enabled,
         scale = scale,


### PR DESCRIPTION
## Summary

`onLongClick` on `TvClickableSurface` and `TvIconButton` silently stops firing on D-pad / Enter / Space / Button A presses, while `onClick` still works. This breaks user-visible features like long-press on a category in `HomeScreen` (which is supposed to open `CategoryOptionsDialog`) and any other call site that wraps a TV long-press through these helpers.

The regression was introduced by #46 (commit d56079f, *"Add APK companion plugin framework"*, @jopsis), which added an `activateOnRemoteKey` `onPreviewKeyEvent` modifier to `TvClickableSurface`, `TvButton` and `TvIconButton`. The intent appears to have been making the Plugins screen's mouse / remote activation fire `onClick` more reliably; nothing in that PR signals the long-press side-effect.

## Why it breaks

`activateOnRemoteKey` returns `true` on both `ACTION_DOWN` and `ACTION_UP` of the activation keys, and synthesises an `onClick()` call on `ACTION_UP`:

```kotlin
if (nativeEvent.action == KeyEvent.ACTION_UP) {
    onClick()
}
nativeEvent.action == KeyEvent.ACTION_DOWN || nativeEvent.action == KeyEvent.ACTION_UP
```

Because it lives in `onPreviewKeyEvent`, it consumes the event before the underlying `androidx.tv.material3.Surface` / `IconButton` ever observes the "DOWN ‒ hold ‒ UP" pattern that the native long-press detector relies on. The result: every D-pad center press is collapsed into an instant click, and `onLongClick` is unreachable.

`LiveChannelRowSurface` in `AppMediaCards.kt` uses the bare TV `Surface` without the `TvClickableSurface` wrapper, which is why long-press on a channel still works — and is the empirical evidence that the native `Surface` handles the gesture correctly when it's allowed to.

## Fix

When the caller provides a non-null `onLongClick`, skip `activateOnRemoteKey` and let the native TV Surface / IconButton see the full key sequence. The `mouseClickable` path is untouched (it already handles phone/tablet pointer correctly and supports long-press there).

For call sites that don't use `onLongClick` (the majority — plain buttons, plain clickables), `activateOnRemoteKey` is preserved unchanged, so the original benefit on the Plugins screen and elsewhere is kept.

`TvButton` doesn't expose an `onLongClick` parameter and is left untouched.

## Files touched

- `app/src/main/java/com/streamvault/app/ui/interaction/TvComponents.kt`
    - `TvClickableSurface`: conditional `activateOnRemoteKey`.
    - `TvIconButton`: conditional `activateOnRemoteKey`.

17 net lines (2 small `then()` blocks + 2 explanatory comments). No behaviour change for call sites that did not set `onLongClick`.

## Verification

Reproduced on Android TV emulator (1080p, Google APIs):

- Before the fix on `master` tip (d2873e5): long-press DPAD_CENTER on a category in the Live TV sidebar — nothing happens. `viewModel.showCategoryOptions(category)` is never called.
- After the fix: long-press DPAD_CENTER on a category — `CategoryOptionsDialog` opens as expected.
- Long-press on a channel (`LiveChannelRowSurface`) — still works (never broken).

`./gradlew :app:assembleDebug` → green.

cc @jopsis for visibility on the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
