### PR TITLE
feat(player): marquee channel name on focus + resolution badge in info overlay

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
@@ -2,6 +2,7 @@ package com.streamvault.app.ui.screens.epg
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -409,7 +410,17 @@ fun EpgRow(
                         style = MaterialTheme.typography.labelLarge,
                         color = if (isFocused) TextPrimary else OnSurface,
                         maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = if (isFocused) {
+                            Modifier.basicMarquee(
+                                iterations = Int.MAX_VALUE,
+                                initialDelayMillis = 900,
+                                repeatDelayMillis = 1200,
+                                velocity = 24.dp
+                            )
+                        } else {
+                            Modifier
+                        }
                     )
                     Text(
                         text = currentProgram?.title ?: stringResource(R.string.epg_no_schedule_short),

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
@@ -1355,7 +1355,8 @@ fun PlayerScreen(
                     onCast = { viewModel.castCurrentMedia { mainActivity?.openCastRouteChooser() } },
                     onStopCasting = viewModel::stopCasting,
                     timeshiftUiState = timeshiftUiState,
-                    onTransientPanelVisibilityChanged = { channelInfoSubPanelOpen = it }
+                    onTransientPanelVisibilityChanged = { channelInfoSubPanelOpen = it },
+                    resolutionLabel = videoFormat.resolutionLabel.takeIf { it.isNotBlank() && !videoFormat.isEmpty }
                 )
             }
         }

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerChannelInfoOverlay.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerChannelInfoOverlay.kt
@@ -1,6 +1,7 @@
 package com.streamvault.app.ui.screens.player.overlay
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -108,7 +109,8 @@ fun ChannelInfoOverlay(
     onCast: () -> Unit = {},
     onStopCasting: () -> Unit = {},
     timeshiftUiState: PlayerTimeshiftUiState = PlayerTimeshiftUiState(),
-    onTransientPanelVisibilityChanged: (Boolean) -> Unit = {}
+    onTransientPanelVisibilityChanged: (Boolean) -> Unit = {},
+    resolutionLabel: String? = null
 ) {
     val appTimeFormat = LocalAppTimeFormat.current
     val timeFormat = remember(appTimeFormat) { appTimeFormat.createTimeFormat() }
@@ -231,7 +233,20 @@ fun ChannelInfoOverlay(
                                     fontWeight = FontWeight.Bold,
                                     maxLines = 1,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f, fill = false)
+                                    modifier = Modifier
+                                        .weight(1f, fill = false)
+                                        .basicMarquee(
+                                            iterations = Int.MAX_VALUE,
+                                            initialDelayMillis = 900,
+                                            repeatDelayMillis = 1200,
+                                            velocity = 24.dp
+                                        )
+                                )
+                            }
+                            resolutionLabel?.takeIf { it.isNotBlank() }?.let { label ->
+                                StatusPill(
+                                    label = label,
+                                    containerColor = AppColors.SurfaceEmphasis
                                 )
                             }
                             currentChannel?.currentVariant


### PR DESCRIPTION
## Summary

Addresses two items from the TiviMate Comparison feedback in #19 (stevefxp1):
- **Channel name marquee** on the EPG guide rows when the row is focused — scrolls right-to-left when the name is truncated.
- **Channel name marquee** on the player `ChannelInfoOverlay`, so long names are fully readable while the info card is up.
- **Video resolution badge** rendered as a `StatusPill` next to the channel name in `ChannelInfoOverlay`, derived from `videoFormat.resolutionLabel`. The badge is persistent only while the info card is visible, complementing (not replacing) the transient top-end `PlayerResolutionBadge` that auto-hides after 3 s.

### Files

- `app/.../ui/screens/epg/EpgGridComponents.kt` — `basicMarquee` on the channel-name `Text` in `EpgRow`, gated on `isFocused`.
- `app/.../ui/screens/player/overlay/PlayerChannelInfoOverlay.kt` — `basicMarquee` on the channel-name `Text`; new optional `resolutionLabel: String?` parameter rendered as a `StatusPill`.
- `app/.../ui/screens/player/PlayerScreen.kt` — wires `videoFormat.resolutionLabel` to the new parameter, filtered on `!isEmpty && isNotBlank`.

### Out of scope (from #19)

- **Sort favourites A-Z**: the existing `FavoritesScreen` (with a built-in sort menu) appears to be present in the codebase but not wired into the navigation graph. Happy to either remove it or wire it depending on your intent — could be a separate discussion. No code change in this PR.
- Movie/series favourites: already shipped.
- Disable live shortcuts on Home: already documented (Settings → disable media session).

### Test plan

- [ ] EPG screen: focus a row with a long channel name → name scrolls; defocus → static + ellipsis.
- [ ] Player: switch channels → info card appears, channel-name marquee animates if truncated, resolution pill (e.g. \`1080p\`, \`4K\`) shown next to the name.
- [ ] Variant pill (when multi-bitrate stream) still appears after the resolution pill, as before.
- [ ] Build: \`./gradlew :app:assembleDebug\` ✅ (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)