### PR TITLE
Smooth live preview fullscreen handoff

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
@@ -1,0 +1,9 @@
+package com.streamvault.app.ui.screens.player
+
+import com.streamvault.player.PlaybackState
+import com.streamvault.player.PlayerStats
+
+internal fun shouldRenewAdoptedPreviewOnFullscreen(
+    playbackState: PlaybackState,
+    playerStats: PlayerStats
+): Boolean = playbackState != PlaybackState.READY || playerStats.ttffMs <= 0L

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
@@ -1052,6 +1052,10 @@ class PlayerViewModel @Inject constructor(
 
         val adoptedEngine = session.engine
         return runCatching {
+            val shouldRenewAdoptedPreview = shouldRenewAdoptedPreviewOnFullscreen(
+                playbackState = adoptedEngine.playbackState.value,
+                playerStats = adoptedEngine.playerStats.value
+            )
             // Detach the Home preview surface before Player binds its own.
             adoptedEngine.clearRenderBinding()
             // Media3 requires a globally unique session ID. Release the main engine's
@@ -1078,13 +1082,12 @@ class PlayerViewModel @Inject constructor(
                         url = session.streamInfo.url
                     )
                 )
-                // Re-prime the adopted engine against the fullscreen surface path.
-                // Preview-to-fullscreen handoff can temporarily leave the reused live
-                // player with an audio-only pipeline until the new render view binds.
-                // Refreshing the current live media source makes the handoff more
-                // robust without re-resolving provider URLs or abandoning the adopted
-                // engine instance.
-                playerEngine.renewStreamUrl(session.streamInfo)
+                if (shouldRenewAdoptedPreview) {
+                    // Re-prime when the preview has not produced video yet. This keeps
+                    // the previous audio-only/stale-surface recovery path without
+                    // rebuffering a preview that is already rendering.
+                    playerEngine.renewStreamUrl(session.streamInfo)
+                }
                 playerEngine.play()
                 startTokenRenewalMonitoring(session.streamInfo.expirationTime)
                 maybeStartLiveTimeshift(session.streamInfo)

--- a/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
@@ -1,0 +1,48 @@
+package com.streamvault.app.ui.screens.player
+
+import com.google.common.truth.Truth.assertThat
+import com.streamvault.player.PlaybackState
+import com.streamvault.player.PlayerStats
+import org.junit.Test
+
+class PlayerPreviewHandoffSupportTest {
+
+    @Test
+    fun `ready preview with rendered frame skips fullscreen renewal`() {
+        val shouldRenew = shouldRenewAdoptedPreviewOnFullscreen(
+            playbackState = PlaybackState.READY,
+            playerStats = PlayerStats(ttffMs = 250L)
+        )
+
+        assertThat(shouldRenew).isFalse()
+    }
+
+    @Test
+    fun `ready preview without rendered frame renews fullscreen stream`() {
+        val shouldRenew = shouldRenewAdoptedPreviewOnFullscreen(
+            playbackState = PlaybackState.READY,
+            playerStats = PlayerStats(ttffMs = 0L)
+        )
+
+        assertThat(shouldRenew).isTrue()
+    }
+
+    @Test
+    fun `non ready preview renews fullscreen stream`() {
+        val states = listOf(
+            PlaybackState.IDLE,
+            PlaybackState.BUFFERING,
+            PlaybackState.ENDED,
+            PlaybackState.ERROR
+        )
+
+        states.forEach { state ->
+            assertThat(
+                shouldRenewAdoptedPreviewOnFullscreen(
+                    playbackState = state,
+                    playerStats = PlayerStats(ttffMs = 250L)
+                )
+            ).isTrue()
+        }
+    }
+}


### PR DESCRIPTION
Skip the fullscreen stream renewal when an adopted live preview is already READY and has rendered its first frame. This keeps the existing renewStreamUrl fallback for previews that are still buffering or have not produced video, avoiding the visible rebuffer on warm preview handoff while preserving recovery for stale or audio-only preview sessions.

Add focused unit coverage for the handoff renewal decision.