### PR TITLE
Add offline VOD download management

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-feature
         android:name="android.software.leanback"

--- a/app/src/main/java/com/streamvault/app/download/OfflineVodDownloadManager.kt
+++ b/app/src/main/java/com/streamvault/app/download/OfflineVodDownloadManager.kt
@@ -1,0 +1,318 @@
+package com.streamvault.app.download
+
+import android.app.DownloadManager
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import android.os.Environment
+import com.streamvault.domain.model.StreamInfo
+import com.streamvault.domain.model.StreamType
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class OfflineVodDownloadManager @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    private val preferences: SharedPreferences =
+        context.getSharedPreferences("offline_vod_downloads", Context.MODE_PRIVATE)
+
+    fun enqueue(
+        title: String,
+        streamInfo: StreamInfo,
+        lookupUrl: String = streamInfo.url,
+        restartPaused: Boolean = false
+    ): OfflineDownloadResult {
+        if (streamInfo.drmInfo != null) {
+            return OfflineDownloadResult.Unsupported("DRM protected streams cannot be saved for offline playback.")
+        }
+        if (streamInfo.streamType in setOf(StreamType.HLS, StreamType.DASH, StreamType.SMOOTH_STREAMING)) {
+            return OfflineDownloadResult.Unsupported("This provider uses an adaptive stream for this title. Offline download currently supports direct video files such as MP4, MKV, AVI, and TS.")
+        }
+        findBySourceUrl(lookupUrl.ifBlank { streamInfo.url })?.takeIf { it.status.isKeptDownload }?.let { existing ->
+            if (restartPaused && existing.status == OfflineDownloadStatus.PAUSED) {
+                delete(existing.id)
+            } else {
+                return OfflineDownloadResult.AlreadyExists(existing)
+            }
+        }
+
+        val extension = streamInfo.containerExtension
+            ?.trim()
+            ?.trimStart('.')
+            ?.takeIf { it.isNotBlank() }
+            ?: Uri.parse(streamInfo.url).lastPathSegment
+                ?.substringAfterLast('.', missingDelimiterValue = "")
+                ?.takeIf { it.length in 2..5 }
+            ?: "mp4"
+        val fileName = "${safeFileName(title)}.$extension"
+
+        val request = DownloadManager.Request(Uri.parse(streamInfo.url))
+            .setTitle(title)
+            .setDescription("Saved by StreamVault for offline playback")
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(false)
+            .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_MOVIES, "StreamVault/$fileName")
+
+        streamInfo.userAgent?.takeIf { it.isNotBlank() }?.let { userAgent ->
+            request.addRequestHeader("User-Agent", userAgent)
+        }
+        streamInfo.headers.forEach { (name, value) ->
+            if (name.isNotBlank() && value.isNotBlank()) {
+                request.addRequestHeader(name, value)
+            }
+        }
+
+        val downloadManager = context.getSystemService(DownloadManager::class.java)
+            ?: return OfflineDownloadResult.Error("Android Download Manager is unavailable on this device.")
+        return try {
+            val id = downloadManager.enqueue(request)
+            rememberDownload(id, lookupUrl.ifBlank { streamInfo.url })
+            OfflineDownloadResult.Queued(id, fileName)
+        } catch (error: Exception) {
+            OfflineDownloadResult.Error(error.message ?: "Android could not start this download.")
+        }
+    }
+
+    fun snapshot(): List<OfflineDownloadItem> {
+        val ids = storedDownloadIds()
+        if (ids.isEmpty()) return emptyList()
+        val downloadManager = context.getSystemService(DownloadManager::class.java) ?: return emptyList()
+        val seenIds = mutableSetOf<Long>()
+        val items = mutableListOf<OfflineDownloadItem>()
+
+        val cursor = runCatching {
+            downloadManager.query(DownloadManager.Query().setFilterById(*ids.toLongArray()))
+        }.getOrNull() ?: return emptyList()
+
+        cursor.use {
+            while (it.moveToNext()) {
+                val id = it.longValue(DownloadManager.COLUMN_ID)
+                seenIds += id
+                items += OfflineDownloadItem(
+                    id = id,
+                    title = it.stringValue(DownloadManager.COLUMN_TITLE).ifBlank { "StreamVault video" },
+                    sourceUri = it.stringValue(DownloadManager.COLUMN_URI),
+                    lookupUri = preferences.getString(sourceKey(id), null).orEmpty(),
+                    localUri = it.stringValue(DownloadManager.COLUMN_LOCAL_URI),
+                    status = it.intValue(DownloadManager.COLUMN_STATUS).toOfflineStatus(),
+                    reason = it.intValue(DownloadManager.COLUMN_REASON).takeIf { reason -> reason != 0 }?.toString(),
+                    bytesDownloaded = it.longValue(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR).coerceAtLeast(0L),
+                    totalBytes = it.longValue(DownloadManager.COLUMN_TOTAL_SIZE_BYTES).takeIf { size -> size > 0L }
+                )
+            }
+        }
+
+        val missingIds = ids - seenIds
+        if (missingIds.isNotEmpty()) {
+            val pausedItems = missingIds.mapNotNull(::pausedItem)
+            items += pausedItems
+            forgetDownloads(missingIds - pausedItems.map { it.id }.toSet())
+        }
+        return items.sortedWith(
+            compareBy<OfflineDownloadItem> { it.status.sortOrder }
+                .thenByDescending { it.id }
+        )
+    }
+
+    fun delete(downloadId: Long): Boolean {
+        val downloadManager = context.getSystemService(DownloadManager::class.java)
+        val removed = runCatching { downloadManager?.remove(downloadId) ?: 0 }.getOrDefault(0) > 0
+        forgetDownloads(setOf(downloadId))
+        return removed
+    }
+
+    fun pause(item: OfflineDownloadItem): Boolean {
+        if (item.status !in setOf(OfflineDownloadStatus.PENDING, OfflineDownloadStatus.RUNNING)) return false
+        rememberPausedItem(item)
+        val downloadManager = context.getSystemService(DownloadManager::class.java)
+        runCatching { downloadManager?.remove(item.id) }.getOrNull()
+        return true
+    }
+
+    fun restart(item: OfflineDownloadItem): OfflineDownloadResult {
+        if (item.sourceUri.isBlank()) {
+            return OfflineDownloadResult.Error("StreamVault cannot resume this download because the source URL is missing.")
+        }
+        delete(item.id)
+        val extension = Uri.parse(item.sourceUri).lastPathSegment
+            ?.substringAfterLast('.', missingDelimiterValue = "")
+            ?.takeIf { it.length in 2..5 }
+            ?: "mp4"
+        val fileName = "${safeFileName(item.title)}.$extension"
+        val request = DownloadManager.Request(Uri.parse(item.sourceUri))
+            .setTitle(item.title)
+            .setDescription("Saved by StreamVault for offline playback")
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setAllowedOverMetered(true)
+            .setAllowedOverRoaming(false)
+            .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_MOVIES, "StreamVault/$fileName")
+        val downloadManager = context.getSystemService(DownloadManager::class.java)
+            ?: return OfflineDownloadResult.Error("Android Download Manager is unavailable on this device.")
+        return try {
+            val id = downloadManager.enqueue(request)
+            rememberDownload(id, item.lookupUri.ifBlank { item.sourceUri })
+            OfflineDownloadResult.Queued(id, fileName)
+        } catch (error: Exception) {
+            OfflineDownloadResult.Error(error.message ?: "Android could not restart this download.")
+        }
+    }
+
+    fun findBySourceUrl(sourceUrl: String): OfflineDownloadItem? {
+        val normalizedSourceUrl = sourceUrl.trim()
+        if (normalizedSourceUrl.isBlank()) return null
+        return snapshot().firstOrNull { item ->
+            item.sourceUri.trim() == normalizedSourceUrl || item.lookupUri.trim() == normalizedSourceUrl
+        }
+    }
+
+    private fun safeFileName(title: String): String =
+        title.trim()
+            .ifBlank { "StreamVault video" }
+            .replace(Regex("[\\\\/:*?\"<>|\\p{Cntrl}]"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .take(120)
+
+    private fun rememberDownload(downloadId: Long, lookupUrl: String) {
+        val updated = storedDownloadIds() + downloadId
+        preferences.edit()
+            .putStringSet(KEY_DOWNLOAD_IDS, updated.map { it.toString() }.toSet())
+            .putString(sourceKey(downloadId), lookupUrl)
+            .apply()
+    }
+
+    private fun forgetDownloads(downloadIds: Set<Long>) {
+        if (downloadIds.isEmpty()) return
+        val updated = storedDownloadIds() - downloadIds
+        preferences.edit().apply {
+            putStringSet(KEY_DOWNLOAD_IDS, updated.map { it.toString() }.toSet())
+            downloadIds.forEach { remove(sourceKey(it)) }
+        }.apply()
+        downloadIds.forEach(::removePausedItem)
+    }
+
+    private fun rememberPausedItem(item: OfflineDownloadItem) {
+        preferences.edit()
+            .putStringSet(KEY_PAUSED_IDS, (storedPausedIds() + item.id).map { it.toString() }.toSet())
+            .putString(pausedKey(item.id, "title"), item.title)
+            .putString(pausedKey(item.id, "source"), item.sourceUri)
+            .putString(pausedKey(item.id, "lookup"), item.lookupUri)
+            .putLong(pausedKey(item.id, "bytes"), item.bytesDownloaded)
+            .putLong(pausedKey(item.id, "total"), item.totalBytes ?: -1L)
+            .apply()
+    }
+
+    private fun pausedItem(downloadId: Long): OfflineDownloadItem? {
+        if (downloadId !in storedPausedIds()) return null
+        val source = preferences.getString(pausedKey(downloadId, "source"), "").orEmpty()
+        if (source.isBlank()) return null
+        val total = preferences.getLong(pausedKey(downloadId, "total"), -1L).takeIf { it > 0L }
+        return OfflineDownloadItem(
+            id = downloadId,
+            title = preferences.getString(pausedKey(downloadId, "title"), null).orEmpty().ifBlank { "StreamVault video" },
+            sourceUri = source,
+            lookupUri = preferences.getString(pausedKey(downloadId, "lookup"), null).orEmpty(),
+            localUri = "",
+            status = OfflineDownloadStatus.PAUSED,
+            reason = null,
+            bytesDownloaded = preferences.getLong(pausedKey(downloadId, "bytes"), 0L).coerceAtLeast(0L),
+            totalBytes = total
+        )
+    }
+
+    private fun removePausedItem(downloadId: Long) {
+        val updatedPausedIds = storedPausedIds() - downloadId
+        preferences.edit()
+            .putStringSet(KEY_PAUSED_IDS, updatedPausedIds.map { it.toString() }.toSet())
+            .remove(pausedKey(downloadId, "title"))
+            .remove(pausedKey(downloadId, "source"))
+            .remove(pausedKey(downloadId, "lookup"))
+            .remove(pausedKey(downloadId, "bytes"))
+            .remove(pausedKey(downloadId, "total"))
+            .apply()
+    }
+
+    private fun storedDownloadIds(): Set<Long> =
+        preferences.getStringSet(KEY_DOWNLOAD_IDS, emptySet()).orEmpty()
+            .mapNotNull { it.toLongOrNull() }
+            .toSet()
+
+    private fun storedPausedIds(): Set<Long> =
+        preferences.getStringSet(KEY_PAUSED_IDS, emptySet()).orEmpty()
+            .mapNotNull { it.toLongOrNull() }
+            .toSet()
+
+    private fun android.database.Cursor.stringValue(columnName: String): String {
+        val index = getColumnIndex(columnName)
+        return if (index >= 0 && !isNull(index)) getString(index).orEmpty() else ""
+    }
+
+    private fun android.database.Cursor.longValue(columnName: String): Long {
+        val index = getColumnIndex(columnName)
+        return if (index >= 0 && !isNull(index)) getLong(index) else 0L
+    }
+
+    private fun android.database.Cursor.intValue(columnName: String): Int {
+        val index = getColumnIndex(columnName)
+        return if (index >= 0 && !isNull(index)) getInt(index) else 0
+    }
+
+    private fun Int.toOfflineStatus(): OfflineDownloadStatus = when (this) {
+        DownloadManager.STATUS_PENDING -> OfflineDownloadStatus.PENDING
+        DownloadManager.STATUS_RUNNING -> OfflineDownloadStatus.RUNNING
+        DownloadManager.STATUS_PAUSED -> OfflineDownloadStatus.PAUSED
+        DownloadManager.STATUS_SUCCESSFUL -> OfflineDownloadStatus.SUCCESSFUL
+        DownloadManager.STATUS_FAILED -> OfflineDownloadStatus.FAILED
+        else -> OfflineDownloadStatus.UNKNOWN
+    }
+
+    private companion object {
+        const val KEY_DOWNLOAD_IDS = "download_ids"
+        const val KEY_PAUSED_IDS = "paused_ids"
+        fun sourceKey(downloadId: Long): String = "source_url_$downloadId"
+        fun pausedKey(downloadId: Long, name: String): String = "paused_${downloadId}_$name"
+    }
+}
+
+sealed interface OfflineDownloadResult {
+    data class Queued(val downloadId: Long, val fileName: String) : OfflineDownloadResult
+    data class AlreadyExists(val item: OfflineDownloadItem) : OfflineDownloadResult
+    data class Unsupported(val message: String) : OfflineDownloadResult
+    data class Error(val message: String) : OfflineDownloadResult
+}
+
+data class OfflineDownloadItem(
+    val id: Long,
+    val title: String,
+    val sourceUri: String,
+    val lookupUri: String,
+    val localUri: String,
+    val status: OfflineDownloadStatus,
+    val reason: String?,
+    val bytesDownloaded: Long,
+    val totalBytes: Long?
+) {
+    val progress: Float?
+        get() = totalBytes?.takeIf { it > 0L }?.let { total -> bytesDownloaded.toFloat() / total.toFloat() }
+
+    val progressPercent: Int?
+        get() = progress?.let { (it * 100f).toInt().coerceIn(0, 100) }
+}
+
+enum class OfflineDownloadStatus(val sortOrder: Int) {
+    RUNNING(0),
+    PENDING(1),
+    PAUSED(2),
+    FAILED(3),
+    SUCCESSFUL(4),
+    UNKNOWN(5)
+}
+
+val OfflineDownloadStatus.isKeptDownload: Boolean
+    get() = this == OfflineDownloadStatus.PENDING ||
+        this == OfflineDownloadStatus.RUNNING ||
+        this == OfflineDownloadStatus.PAUSED ||
+        this == OfflineDownloadStatus.SUCCESSFUL

--- a/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
@@ -29,6 +29,7 @@ import com.streamvault.app.ui.screens.player.PlayerScreen
 import com.streamvault.app.ui.screens.plugins.PluginsScreen
 import com.streamvault.app.ui.screens.provider.ProviderSetupScreen
 import com.streamvault.app.ui.screens.series.SeriesScreen
+import com.streamvault.app.ui.screens.settings.SETTINGS_CATEGORY_DOWNLOADS
 import com.streamvault.app.ui.screens.settings.SettingsScreen
 import com.streamvault.app.ui.screens.welcome.WelcomeScreen
 import com.streamvault.app.MainActivity
@@ -73,6 +74,7 @@ object Routes {
     const val EPG_DESTINATION = "epg?categoryId={categoryId}&anchorTime={anchorTime}&favoritesOnly={favoritesOnly}"
     const val SETTINGS = "settings"
     const val SETTINGS_DESTINATION = "settings?backupUri={backupUri}"
+    const val SETTINGS_DOWNLOADS = "downloads_settings"
     const val PLUGINS = "plugins"
     const val PLAYER = "player"
     const val SEARCH = "search"
@@ -572,6 +574,23 @@ fun AppNavigation(mainActivity: MainActivity) {
                 },
                 currentRoute = Routes.SETTINGS,
                 initialBackupImportUri = backupUri
+            )
+        }
+
+        composable(Routes.SETTINGS_DOWNLOADS) {
+            SettingsScreen(
+                onNavigate = { route -> tabNavigate(route) },
+                onAddProvider = dropUnlessResumed {
+                    navController.navigate(Routes.providerSetup(null))
+                },
+                onEditProvider = { provider ->
+                    navController.navigateIfResumed(Routes.providerSetup(provider.id))
+                },
+                onNavigateToParentalControl = { providerId ->
+                    navController.navigateIfResumed(Routes.parentalControlGroups(providerId))
+                },
+                currentRoute = Routes.SETTINGS_DOWNLOADS,
+                initialSelectedCategory = SETTINGS_CATEGORY_DOWNLOADS
             )
         }
 

--- a/app/src/main/java/com/streamvault/app/ui/components/shell/AppShell.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/shell/AppShell.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
@@ -838,6 +839,7 @@ private fun buildDestinationItems(): List<DestinationItem> = listOf(
     DestinationItem(Routes.MOVIES, R.string.nav_movies, Icons.Default.Star),
     DestinationItem(Routes.SERIES, R.string.nav_series, Icons.Default.Menu),
     DestinationItem(Routes.EPG, R.string.nav_epg, Icons.Default.Info),
+    DestinationItem(Routes.SETTINGS_DOWNLOADS, R.string.nav_downloads, Icons.Default.KeyboardArrowDown),
     DestinationItem(Routes.SEARCH, R.string.search_title, Icons.Default.Search),
     DestinationItem(Routes.PLUGINS, R.string.nav_plugins, PluginBlocksIcon),
     DestinationItem(Routes.SETTINGS, R.string.nav_settings, Icons.Default.Settings)

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.runtime.Composable
@@ -63,6 +64,8 @@ import com.streamvault.domain.model.Movie
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.interaction.TvIconButton
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadStatus
 
 @Composable
 fun MovieDetailScreen(
@@ -107,7 +110,12 @@ fun MovieDetailScreen(
                 externalRatings = uiState.externalRatings,
                 isLoadingExternalRatings = uiState.isLoadingExternalRatings,
                 relatedContent = uiState.relatedContent,
+                isDownloadQueued = uiState.isDownloadQueued,
+                downloadItem = uiState.downloadItem,
+                downloadStatus = uiState.downloadStatus,
+                downloadMessage = uiState.downloadMessage,
                 onPlay = { onPlay(movie) },
+                onDownload = viewModel::downloadMovie,
                 onToggleFavorite = viewModel::toggleFavorite,
                 onRelatedClick = onPlay,
                 onBack = onBack
@@ -124,7 +132,12 @@ private fun MovieDetailContent(
     externalRatings: ExternalRatings,
     isLoadingExternalRatings: Boolean,
     relatedContent: List<Movie>,
+    isDownloadQueued: Boolean,
+    downloadItem: OfflineDownloadItem?,
+    downloadStatus: OfflineDownloadStatus?,
+    downloadMessage: String?,
     onPlay: () -> Unit,
+    onDownload: () -> Unit,
     onToggleFavorite: () -> Unit,
     onRelatedClick: (Movie) -> Unit,
     onBack: () -> Unit
@@ -210,8 +223,13 @@ private fun MovieDetailContent(
                             externalRatings = externalRatings,
                             isLoadingExternalRatings = isLoadingExternalRatings,
                             onPlay = onPlay,
+                            onDownload = onDownload,
                             onToggleFavorite = onToggleFavorite,
                             playButtonFocusRequester = playButtonFocusRequester,
+                            isDownloadQueued = isDownloadQueued,
+                            downloadItem = downloadItem,
+                            downloadStatus = downloadStatus,
+                            downloadMessage = downloadMessage,
                             onPlayTrailer = {
                                 resolveTrailerUrl(movie.youtubeTrailer)?.let { trailerUrl ->
                                     runCatching {
@@ -234,8 +252,13 @@ private fun MovieDetailContent(
                             externalRatings = externalRatings,
                             isLoadingExternalRatings = isLoadingExternalRatings,
                             onPlay = onPlay,
+                            onDownload = onDownload,
                             onToggleFavorite = onToggleFavorite,
                             playButtonFocusRequester = playButtonFocusRequester,
+                            isDownloadQueued = isDownloadQueued,
+                            downloadItem = downloadItem,
+                            downloadStatus = downloadStatus,
+                            downloadMessage = downloadMessage,
                             onPlayTrailer = {
                                 resolveTrailerUrl(movie.youtubeTrailer)?.let { trailerUrl ->
                                     runCatching {
@@ -327,8 +350,13 @@ private fun MovieDetailHeroText(
     externalRatings: ExternalRatings,
     isLoadingExternalRatings: Boolean,
     onPlay: () -> Unit,
+    onDownload: () -> Unit,
     onToggleFavorite: () -> Unit,
     playButtonFocusRequester: FocusRequester,
+    isDownloadQueued: Boolean,
+    downloadItem: OfflineDownloadItem?,
+    downloadStatus: OfflineDownloadStatus?,
+    downloadMessage: String?,
     onPlayTrailer: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -402,6 +430,31 @@ private fun MovieDetailHeroText(
                     Text(stringResource(R.string.movie_detail_trailer))
                 }
             }
+            TvButton(
+                onClick = onDownload,
+                enabled = !isDownloadQueued && (downloadStatus == null || downloadStatus == OfflineDownloadStatus.PAUSED),
+                colors = ButtonDefaults.colors(
+                    containerColor = AppColors.SurfaceEmphasis,
+                    contentColor = AppColors.TextPrimary,
+                    disabledContainerColor = AppColors.SurfaceElevated,
+                    disabledContentColor = AppColors.TextTertiary
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Download,
+                    contentDescription = null
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = if (isDownloadQueued) {
+                        stringResource(R.string.vod_download_preparing)
+                    } else if (downloadStatus != null) {
+                        downloadStatus.buttonLabel(downloadItem)
+                    } else {
+                        stringResource(R.string.vod_download)
+                    }
+                )
+            }
             TvIconButton(
                 onClick = onToggleFavorite,
                 colors = ButtonDefaults.colors(
@@ -418,6 +471,16 @@ private fun MovieDetailHeroText(
             }
         }
 
+        downloadMessage?.takeIf { it.isNotBlank() }?.let { message ->
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = AppColors.TextSecondary,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
         Text(
             text = movie.plot?.ifBlank { stringResource(R.string.movie_plot_fallback) }
                 ?: stringResource(R.string.movie_plot_fallback),
@@ -426,6 +489,23 @@ private fun MovieDetailHeroText(
             maxLines = 6,
             overflow = TextOverflow.Ellipsis
         )
+    }
+}
+
+@Composable
+private fun OfflineDownloadStatus.buttonLabel(item: OfflineDownloadItem?): String {
+    val percent = item?.progressPercent
+    return when (this) {
+        OfflineDownloadStatus.PENDING,
+        OfflineDownloadStatus.RUNNING -> percent?.let {
+            stringResource(R.string.vod_download_downloading_progress, it)
+        } ?: stringResource(R.string.vod_download_downloading)
+        OfflineDownloadStatus.PAUSED -> percent?.let {
+            stringResource(R.string.vod_download_resume_progress, it)
+        } ?: stringResource(R.string.vod_download_resume)
+        OfflineDownloadStatus.SUCCESSFUL -> stringResource(R.string.vod_download_downloaded)
+        OfflineDownloadStatus.FAILED,
+        OfflineDownloadStatus.UNKNOWN -> stringResource(R.string.vod_download)
     }
 }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
@@ -3,6 +3,11 @@ package com.streamvault.app.ui.screens.movies
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.streamvault.app.download.OfflineDownloadResult
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadStatus
+import com.streamvault.app.download.OfflineVodDownloadManager
+import com.streamvault.app.download.isKeptDownload
 import com.streamvault.app.util.isPlaybackComplete
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.ExternalRatings
@@ -16,6 +21,7 @@ import com.streamvault.domain.repository.PlaybackHistoryRepository
 import com.streamvault.domain.repository.ProviderRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,7 +36,8 @@ class MovieDetailViewModel @Inject constructor(
     private val providerRepository: ProviderRepository,
     private val playbackHistoryRepository: PlaybackHistoryRepository,
     private val externalRatingsRepository: ExternalRatingsRepository,
-    private val favoriteRepository: FavoriteRepository
+    private val favoriteRepository: FavoriteRepository,
+    private val offlineVodDownloadManager: OfflineVodDownloadManager
 ) : ViewModel() {
 
     private val movieId: Long = checkNotNull(
@@ -43,6 +50,23 @@ class MovieDetailViewModel @Inject constructor(
 
     init {
         loadMovieDetails()
+        observeDownloadStatus()
+    }
+
+    private fun observeDownloadStatus() {
+        viewModelScope.launch {
+            while (true) {
+                refreshDownloadStatus()
+                delay(2_000)
+            }
+        }
+    }
+
+    private fun refreshDownloadStatus() {
+        val movie = _uiState.value.movie ?: return
+        val item = offlineVodDownloadManager.findBySourceUrl(movie.streamUrl)
+            ?.takeIf { it.status.isKeptDownload }
+        _uiState.update { it.copy(downloadItem = item, downloadStatus = item?.status) }
     }
 
     private fun loadMovieDetails() {
@@ -85,6 +109,7 @@ class MovieDetailViewModel @Inject constructor(
                             resumePositionMs = if (hasResume) resumePositionMs else 0L
                         )
                     }.also {
+                        refreshDownloadStatus()
                         loadExternalRatings(result.data)
                         loadRelatedContent(effectiveProviderId)
                     }
@@ -113,6 +138,46 @@ class MovieDetailViewModel @Inject constructor(
                 favoriteRepository.removeFavorite(movie.providerId, movie.id, ContentType.MOVIE)
             }
             _uiState.update { it.copy(movie = movie.copy(isFavorite = newState)) }
+        }
+    }
+
+    fun downloadMovie() {
+        val movie = _uiState.value.movie ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isDownloadQueued = true, downloadMessage = "Preparing download...") }
+            when (val streamResult = movieRepository.getStreamInfo(movie)) {
+                is Result.Success -> {
+                    val restartPaused = _uiState.value.downloadItem?.status == OfflineDownloadStatus.PAUSED
+                    when (val downloadResult = offlineVodDownloadManager.enqueue(movie.name, streamResult.data, movie.streamUrl, restartPaused)) {
+                        is OfflineDownloadResult.Queued -> _uiState.update {
+                            it.copy(
+                                isDownloadQueued = false,
+                                downloadItem = null,
+                                downloadStatus = OfflineDownloadStatus.PENDING,
+                                downloadMessage = "Download queued: ${downloadResult.fileName}"
+                            )
+                        }
+                        is OfflineDownloadResult.AlreadyExists -> _uiState.update {
+                            it.copy(
+                                isDownloadQueued = false,
+                                downloadItem = downloadResult.item,
+                                downloadStatus = downloadResult.item.status,
+                                downloadMessage = downloadResult.item.status.toExistingDownloadMessage()
+                            )
+                        }
+                        is OfflineDownloadResult.Unsupported -> _uiState.update {
+                            it.copy(isDownloadQueued = false, downloadMessage = downloadResult.message)
+                        }
+                        is OfflineDownloadResult.Error -> _uiState.update {
+                            it.copy(isDownloadQueued = false, downloadMessage = downloadResult.message)
+                        }
+                    }
+                }
+                is Result.Error -> _uiState.update {
+                    it.copy(isDownloadQueued = false, downloadMessage = streamResult.message)
+                }
+                is Result.Loading -> Unit
+            }
         }
     }
 
@@ -149,6 +214,15 @@ class MovieDetailViewModel @Inject constructor(
             _uiState.update { it.copy(relatedContent = related) }
         }
     }
+
+    private fun OfflineDownloadStatus.toExistingDownloadMessage(): String = when (this) {
+        OfflineDownloadStatus.SUCCESSFUL -> "Already downloaded. Open Downloads from the top menu to manage it."
+        OfflineDownloadStatus.PAUSED -> "Already in Downloads, but paused. Open Downloads from the top menu to manage it."
+        OfflineDownloadStatus.PENDING,
+        OfflineDownloadStatus.RUNNING -> "Already downloading. Open Downloads from the top menu to check progress."
+        OfflineDownloadStatus.FAILED,
+        OfflineDownloadStatus.UNKNOWN -> "Already in Downloads. Open Downloads from the top menu to manage it."
+    }
 }
 
 data class MovieDetailUiState(
@@ -159,5 +233,9 @@ data class MovieDetailUiState(
     val resumePositionMs: Long = 0L,
     val isLoadingExternalRatings: Boolean = false,
     val externalRatings: ExternalRatings = ExternalRatings.unavailable(),
-    val relatedContent: List<Movie> = emptyList()
+    val relatedContent: List<Movie> = emptyList(),
+    val isDownloadQueued: Boolean = false,
+    val downloadItem: OfflineDownloadItem? = null,
+    val downloadStatus: OfflineDownloadStatus? = null,
+    val downloadMessage: String? = null
 )

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -66,6 +67,8 @@ import com.streamvault.domain.model.Series
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.interaction.TvIconButton
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadStatus
 
 private const val EPISODE_DETAIL_PAGE_SIZE = 100
 
@@ -113,7 +116,12 @@ fun SeriesDetailScreen(
         unwatchedEpisodeCount = uiState.unwatchedEpisodeCount,
         externalRatings = uiState.externalRatings,
         isLoadingExternalRatings = uiState.isLoadingExternalRatings,
+        downloadingEpisodeIds = uiState.downloadingEpisodeIds,
+        episodeDownloadStatuses = uiState.episodeDownloadStatuses,
+        episodeDownloadItems = uiState.episodeDownloadItems,
+        downloadMessage = uiState.downloadMessage,
         onToggleFavorite = viewModel::toggleFavorite,
+        onDownloadEpisode = viewModel::downloadEpisode,
         onSeasonSelected = viewModel::selectSeason,
         onEpisodeClick = onEpisodeClick,
         onResumeClick = onResumeClick ?: onEpisodeClick,
@@ -129,7 +137,12 @@ private fun SeriesDetailContent(
     unwatchedEpisodeCount: Int,
     externalRatings: ExternalRatings,
     isLoadingExternalRatings: Boolean,
+    downloadingEpisodeIds: Set<Long>,
+    episodeDownloadStatuses: Map<Long, OfflineDownloadStatus>,
+    episodeDownloadItems: Map<Long, OfflineDownloadItem>,
+    downloadMessage: String?,
     onToggleFavorite: () -> Unit,
+    onDownloadEpisode: (Episode) -> Unit,
     onSeasonSelected: (Season) -> Unit,
     onEpisodeClick: (Episode) -> Unit,
     onResumeClick: (Episode) -> Unit,
@@ -273,6 +286,10 @@ private fun SeriesDetailContent(
                                     resumeEpisode = ep,
                                     hasProgress = hasProgress,
                                     onResumeClick = onResumeClick,
+                                    onDownloadEpisode = onDownloadEpisode,
+                                    isDownloading = ep.id in downloadingEpisodeIds,
+                                    downloadStatus = episodeDownloadStatuses[ep.id],
+                                    downloadItem = episodeDownloadItems[ep.id],
                                     onToggleFavorite = onToggleFavorite
                                 )
                             }
@@ -353,6 +370,10 @@ private fun SeriesDetailContent(
                                     resumeEpisode = ep,
                                     hasProgress = hasProgress,
                                     onResumeClick = onResumeClick,
+                                    onDownloadEpisode = onDownloadEpisode,
+                                    isDownloading = ep.id in downloadingEpisodeIds,
+                                    downloadStatus = episodeDownloadStatuses[ep.id],
+                                    downloadItem = episodeDownloadItems[ep.id],
                                     onToggleFavorite = onToggleFavorite
                                 )
                             }
@@ -401,10 +422,27 @@ private fun SeriesDetailContent(
                             style = MaterialTheme.typography.bodyMedium,
                             color = AppColors.TextTertiary
                         )
+                        downloadMessage?.takeIf { it.isNotBlank() }?.let { message ->
+                            Text(
+                                text = message,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = AppColors.TextSecondary,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
                 items(visibleEpisodes, key = { it.id }) { episode ->
-                    EpisodeItem(episode = episode, onClick = { onEpisodeClick(episode) })
+                    EpisodeItem(
+                        episode = episode,
+                        onClick = { onEpisodeClick(episode) },
+                        onDownload = { onDownloadEpisode(episode) },
+                        onPlayDownload = { item -> onEpisodeClick(episode.copy(streamUrl = item.localUri)) },
+                        isDownloading = episode.id in downloadingEpisodeIds,
+                        downloadStatus = episodeDownloadStatuses[episode.id],
+                        downloadItem = episodeDownloadItems[episode.id]
+                    )
                 }
                 if (visibleEpisodes.size < season.episodes.size) {
                     item {
@@ -435,8 +473,14 @@ private fun SeriesDetailActions(
     resumeEpisode: Episode,
     hasProgress: Boolean,
     onResumeClick: (Episode) -> Unit,
+    onDownloadEpisode: (Episode) -> Unit,
+    isDownloading: Boolean,
+    downloadStatus: OfflineDownloadStatus?,
+    downloadItem: OfflineDownloadItem?,
     onToggleFavorite: () -> Unit
 ) {
+    val canPlayDownload = downloadItem?.isPlayable == true
+    val canResumeDownload = downloadStatus == OfflineDownloadStatus.PAUSED
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
         TvButton(
             onClick = { onResumeClick(resumeEpisode) },
@@ -459,6 +503,36 @@ private fun SeriesDetailActions(
                         resumeEpisode.seasonNumber,
                         resumeEpisode.episodeNumber
                     )
+                }
+            )
+        }
+        TvButton(
+            onClick = {
+                if (canPlayDownload) {
+                    onResumeClick(resumeEpisode.copy(streamUrl = checkNotNull(downloadItem).localUri))
+                } else {
+                    onDownloadEpisode(resumeEpisode)
+                }
+            },
+            enabled = canPlayDownload || canResumeDownload || (!isDownloading && downloadStatus == null),
+            colors = ButtonDefaults.colors(
+                containerColor = AppColors.SurfaceEmphasis,
+                contentColor = AppColors.TextPrimary,
+                disabledContainerColor = AppColors.SurfaceElevated,
+                disabledContentColor = AppColors.TextTertiary
+            )
+        ) {
+            Icon(imageVector = Icons.Filled.Download, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = if (isDownloading) {
+                    stringResource(R.string.vod_download_downloading)
+                } else if (canPlayDownload) {
+                    stringResource(R.string.settings_downloads_play)
+                } else if (downloadStatus != null) {
+                    downloadStatus.buttonLabel(downloadItem)
+                } else {
+                    stringResource(R.string.vod_download)
                 }
             )
         }
@@ -524,20 +598,83 @@ fun SeasonChip(
 @Composable
 fun EpisodeItem(
     episode: Episode,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onDownload: () -> Unit,
+    onPlayDownload: (OfflineDownloadItem) -> Unit,
+    isDownloading: Boolean,
+    downloadStatus: OfflineDownloadStatus?,
+    downloadItem: OfflineDownloadItem?
 ) {
-    TvClickableSurface(
-        onClick = onClick,
-        shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(18.dp)),
-        colors = ClickableSurfaceDefaults.colors(
-            containerColor = AppColors.SurfaceElevated,
-            focusedContainerColor = AppColors.SurfaceEmphasis
-        ),
-        modifier = Modifier.fillMaxWidth()
+    val canPlayDownload = downloadItem?.isPlayable == true
+    val canResumeDownload = downloadStatus == OfflineDownloadStatus.PAUSED
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        EpisodeRowCard(
-            episode = episode,
-            modifier = Modifier.fillMaxWidth()
-        )
+        TvClickableSurface(
+            onClick = onClick,
+            shape = ClickableSurfaceDefaults.shape(shape = RoundedCornerShape(18.dp)),
+            colors = ClickableSurfaceDefaults.colors(
+                containerColor = AppColors.SurfaceElevated,
+                focusedContainerColor = AppColors.SurfaceEmphasis
+            ),
+            modifier = Modifier.weight(1f)
+        ) {
+            EpisodeRowCard(
+                episode = episode,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        TvButton(
+            onClick = {
+                if (canPlayDownload) {
+                    onPlayDownload(checkNotNull(downloadItem))
+                } else {
+                    onDownload()
+                }
+            },
+            enabled = canPlayDownload || canResumeDownload || (!isDownloading && downloadStatus == null),
+            colors = ButtonDefaults.colors(
+                containerColor = AppColors.SurfaceEmphasis,
+                contentColor = AppColors.TextPrimary,
+                disabledContainerColor = AppColors.SurfaceElevated,
+                disabledContentColor = AppColors.TextTertiary
+            )
+        ) {
+            Icon(imageVector = Icons.Filled.Download, contentDescription = null)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = if (isDownloading) {
+                    stringResource(R.string.vod_download_downloading)
+                } else if (canPlayDownload) {
+                    stringResource(R.string.settings_downloads_play)
+                } else if (downloadStatus != null) {
+                    downloadStatus.buttonLabel(downloadItem)
+                } else {
+                    stringResource(R.string.vod_download)
+                }
+            )
+        }
+    }
+}
+
+private val OfflineDownloadItem.isPlayable: Boolean
+    get() = status == OfflineDownloadStatus.SUCCESSFUL && localUri.isNotBlank()
+
+@Composable
+private fun OfflineDownloadStatus.buttonLabel(item: OfflineDownloadItem?): String {
+    val percent = item?.progressPercent
+    return when (this) {
+        OfflineDownloadStatus.PENDING,
+        OfflineDownloadStatus.RUNNING -> percent?.let {
+            stringResource(R.string.vod_download_downloading_progress, it)
+        } ?: stringResource(R.string.vod_download_downloading)
+        OfflineDownloadStatus.PAUSED -> percent?.let {
+            stringResource(R.string.vod_download_resume_progress, it)
+        } ?: stringResource(R.string.vod_download_resume)
+        OfflineDownloadStatus.SUCCESSFUL -> stringResource(R.string.vod_download_downloaded)
+        OfflineDownloadStatus.FAILED,
+        OfflineDownloadStatus.UNKNOWN -> stringResource(R.string.vod_download)
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
@@ -3,6 +3,11 @@ package com.streamvault.app.ui.screens.series
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.streamvault.app.download.OfflineDownloadResult
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadStatus
+import com.streamvault.app.download.OfflineVodDownloadManager
+import com.streamvault.app.download.isKeptDownload
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.Episode
 import com.streamvault.domain.model.ExternalRatings
@@ -19,6 +24,7 @@ import com.streamvault.domain.util.isPlaybackComplete
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -34,7 +40,8 @@ class SeriesDetailViewModel @Inject constructor(
     private val providerRepository: ProviderRepository,
     private val playbackHistoryRepository: PlaybackHistoryRepository,
     private val externalRatingsRepository: ExternalRatingsRepository,
-    private val favoriteRepository: FavoriteRepository
+    private val favoriteRepository: FavoriteRepository,
+    private val offlineVodDownloadManager: OfflineVodDownloadManager
 ) : ViewModel() {
 
     private val seriesId: Long = checkNotNull(
@@ -48,6 +55,7 @@ class SeriesDetailViewModel @Inject constructor(
     private var providerDetailJob: Job? = null
 
     init {
+        observeDownloadStatuses()
         viewModelScope.launch {
             providerRepository.getActiveProvider().collect { provider ->
                 providerDetailJob?.cancel()
@@ -69,6 +77,31 @@ class SeriesDetailViewModel @Inject constructor(
                     loadSeriesDetailsForProvider(effectiveProviderId)
                 }
             }
+        }
+    }
+
+    private fun observeDownloadStatuses() {
+        viewModelScope.launch {
+            while (true) {
+                refreshDownloadStatuses()
+                delay(2_000)
+            }
+        }
+    }
+
+    private fun refreshDownloadStatuses() {
+        val episodes = _uiState.value.series?.seasons.orEmpty().flatMap { it.episodes }
+        if (episodes.isEmpty()) return
+        val items = episodes.mapNotNull { episode ->
+            offlineVodDownloadManager.findBySourceUrl(episode.streamUrl)
+                ?.takeIf { it.status.isKeptDownload }
+                ?.let { episode.id to it }
+        }.toMap()
+        _uiState.update {
+            it.copy(
+                episodeDownloadItems = items,
+                episodeDownloadStatuses = items.mapValues { entry -> entry.value.status }
+            )
         }
     }
 
@@ -96,6 +129,7 @@ class SeriesDetailViewModel @Inject constructor(
                             error = null
                         )
                     }
+                    refreshDownloadStatuses()
                 }
                 is Result.Error -> {
                     _uiState.update {
@@ -160,6 +194,70 @@ class SeriesDetailViewModel @Inject constructor(
         _uiState.update { it.copy(selectedSeason = season) }
     }
 
+    fun downloadEpisode(episode: Episode) {
+        val seriesTitle = _uiState.value.series?.name.orEmpty()
+        val title = buildString {
+            if (seriesTitle.isNotBlank()) {
+                append(seriesTitle)
+                append(" - ")
+            }
+            append("S")
+            append(episode.seasonNumber.toString().padStart(2, '0'))
+            append("E")
+            append(episode.episodeNumber.toString().padStart(2, '0'))
+            append(" - ")
+            append(episode.title)
+        }
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    downloadingEpisodeIds = it.downloadingEpisodeIds + episode.id,
+                    downloadMessage = "Preparing download..."
+                )
+            }
+            when (val streamResult = seriesRepository.getEpisodeStreamInfo(episode)) {
+                is Result.Success -> {
+                    val restartPaused = _uiState.value.episodeDownloadItems[episode.id]?.status == OfflineDownloadStatus.PAUSED
+                    val downloadResult = offlineVodDownloadManager.enqueue(
+                        title = title,
+                        streamInfo = streamResult.data,
+                        lookupUrl = episode.streamUrl,
+                        restartPaused = restartPaused
+                    )
+                    val message = when (downloadResult) {
+                        is OfflineDownloadResult.Queued -> "Download queued: ${downloadResult.fileName}"
+                        is OfflineDownloadResult.AlreadyExists -> downloadResult.item.status.toExistingDownloadMessage()
+                        is OfflineDownloadResult.Unsupported -> downloadResult.message
+                        is OfflineDownloadResult.Error -> downloadResult.message
+                    }
+                    _uiState.update {
+                        it.copy(
+                            downloadingEpisodeIds = it.downloadingEpisodeIds - episode.id,
+                            episodeDownloadStatuses = when (downloadResult) {
+                                is OfflineDownloadResult.Queued -> it.episodeDownloadStatuses + (episode.id to OfflineDownloadStatus.PENDING)
+                                is OfflineDownloadResult.AlreadyExists -> it.episodeDownloadStatuses + (episode.id to downloadResult.item.status)
+                                else -> it.episodeDownloadStatuses
+                            },
+                            episodeDownloadItems = when (downloadResult) {
+                                is OfflineDownloadResult.AlreadyExists -> it.episodeDownloadItems + (episode.id to downloadResult.item)
+                                else -> it.episodeDownloadItems
+                            },
+                            downloadMessage = message
+                        )
+                    }
+                }
+                is Result.Error -> _uiState.update {
+                    it.copy(
+                        downloadingEpisodeIds = it.downloadingEpisodeIds - episode.id,
+                        downloadMessage = streamResult.message
+                    )
+                }
+                is Result.Loading -> Unit
+            }
+        }
+    }
+
+
     private fun findResumeEpisode(series: Series): Episode? {
         val ordered = series.seasons
             .sortedBy { it.seasonNumber }
@@ -175,6 +273,15 @@ class SeriesDetailViewModel @Inject constructor(
         // Fall back to the first episode that has never been started
         return ordered.firstOrNull { ep -> ep.lastWatchedAt == 0L }
     }
+
+    private fun OfflineDownloadStatus.toExistingDownloadMessage(): String = when (this) {
+        OfflineDownloadStatus.SUCCESSFUL -> "Already downloaded. Open Downloads from the top menu to manage it."
+        OfflineDownloadStatus.PAUSED -> "Already in Downloads, but paused. Open Downloads from the top menu to manage it."
+        OfflineDownloadStatus.PENDING,
+        OfflineDownloadStatus.RUNNING -> "Already downloading. Open Downloads from the top menu to check progress."
+        OfflineDownloadStatus.FAILED,
+        OfflineDownloadStatus.UNKNOWN -> "Already in Downloads. Open Downloads from the top menu to manage it."
+    }
 }
 
 data class SeriesDetailUiState(
@@ -185,5 +292,9 @@ data class SeriesDetailUiState(
     val unwatchedEpisodeCount: Int = 0,
     val error: String? = null,
     val isLoadingExternalRatings: Boolean = false,
-    val externalRatings: ExternalRatings = ExternalRatings.unavailable()
+    val externalRatings: ExternalRatings = ExternalRatings.unavailable(),
+    val downloadingEpisodeIds: Set<Long> = emptySet(),
+    val episodeDownloadStatuses: Map<Long, OfflineDownloadStatus> = emptyMap(),
+    val episodeDownloadItems: Map<Long, OfflineDownloadItem> = emptyMap(),
+    val downloadMessage: String? = null
 )

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.streamvault.app.download.OfflineDownloadItem
 import com.streamvault.domain.model.Provider
 
 @Composable
@@ -33,6 +34,7 @@ internal fun SettingsContentPane(
     onDriveSignOut: () -> Unit,
     onDrivePush: () -> Unit,
     onDrivePull: () -> Unit,
+    onPlayDownload: (OfflineDownloadItem) -> Unit,
     onOpenUri: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -141,7 +143,13 @@ internal fun SettingsContentPane(
                 onShowRecordingPaddingDialogChange = { dialogState.showRecordingPaddingDialog = it },
                 onShowRecordingBrowserDialogChange = { dialogState.showRecordingBrowserDialog = it }
             )
-        } else if (dialogState.selectedCategory == 5) {
+        } else if (dialogState.selectedCategory == SETTINGS_CATEGORY_DOWNLOADS) {
+            settingsDownloadsSection(
+                uiState = uiState,
+                viewModel = viewModel,
+                onPlayDownload = onPlayDownload
+            )
+        } else if (dialogState.selectedCategory == SETTINGS_CATEGORY_BACKUP) {
             settingsBackupSection(
                 onCreateBackup = onCreateBackup,
                 onShareBackup = onShareBackup,
@@ -154,12 +162,12 @@ internal fun SettingsContentPane(
                 onPush = onDrivePush,
                 onPull = onDrivePull
             )
-        } else if (dialogState.selectedCategory == 6) {
+        } else if (dialogState.selectedCategory == 7) {
             epgSourcesSection(
                 uiState = uiState,
                 viewModel = viewModel
             )
-        } else if (dialogState.selectedCategory == 7) {
+        } else if (dialogState.selectedCategory == 8) {
             settingsAboutSection(
                 uiState = uiState,
                 context = context,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDownloadsSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsDownloadsSection.kt
@@ -1,0 +1,394 @@
+package com.streamvault.app.ui.screens.settings
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.tv.material3.Border
+import androidx.tv.material3.ClickableSurfaceDefaults
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Surface
+import androidx.tv.material3.SurfaceDefaults
+import androidx.tv.material3.Text
+import com.streamvault.app.R
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadStatus
+import com.streamvault.app.ui.interaction.TvButton
+import com.streamvault.app.ui.theme.ErrorColor
+import com.streamvault.app.ui.theme.FocusBorder
+import com.streamvault.app.ui.theme.OnBackground
+import com.streamvault.app.ui.theme.OnSurface
+import com.streamvault.app.ui.theme.OnSurfaceDim
+import com.streamvault.app.ui.theme.Primary
+import com.streamvault.app.ui.theme.SurfaceElevated
+
+internal fun LazyListScope.settingsDownloadsSection(
+    uiState: SettingsUiState,
+    viewModel: SettingsViewModel,
+    onPlayDownload: (OfflineDownloadItem) -> Unit
+) {
+    item {
+        DownloadsSummaryCard(
+            activeCount = uiState.offlineDownloads.count { it.status.isActive },
+            completedCount = uiState.offlineDownloads.count { it.status == OfflineDownloadStatus.SUCCESSFUL },
+            totalCount = uiState.offlineDownloads.size,
+            onRefresh = viewModel::refreshOfflineDownloads
+        )
+    }
+    if (uiState.offlineDownloads.isEmpty()) {
+        item {
+            EmptyDownloadsCard()
+        }
+    } else {
+        item {
+            DownloadSelectionCard(
+                selectedCount = uiState.selectedOfflineDownloadIds.size,
+                onDeleteSelected = viewModel::deleteSelectedOfflineDownloads,
+                onClearSelection = viewModel::clearOfflineDownloadSelection
+            )
+        }
+        groupedDownloadFolders(uiState.offlineDownloads).forEach { folder ->
+            item(key = "folder-${folder.name}") {
+                DownloadFolderHeader(
+                    folder = folder,
+                    selectedCount = folder.items.count { it.id in uiState.selectedOfflineDownloadIds },
+                    onSelectAll = { viewModel.selectOfflineDownloads(folder.items.map { it.id }.toSet()) }
+                )
+            }
+            items(folder.items, key = { it.id }) { download ->
+                DownloadItemCard(
+                    item = download,
+                    isSelected = download.id in uiState.selectedOfflineDownloadIds,
+                    onToggleSelected = { viewModel.toggleOfflineDownloadSelection(download.id) },
+                    onPlay = { onPlayDownload(download) },
+                    onPause = { viewModel.pauseOfflineDownload(download) },
+                    onResume = { viewModel.resumeOfflineDownload(download) },
+                    onDelete = { viewModel.deleteOfflineDownload(download.id) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadsSummaryCard(
+    activeCount: Int,
+    completedCount: Int,
+    totalCount: Int,
+    onRefresh: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        colors = SurfaceDefaults.colors(containerColor = SurfaceElevated),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                SettingsSectionHeader(
+                    title = stringResource(R.string.settings_downloads_title),
+                    subtitle = stringResource(R.string.settings_downloads_subtitle)
+                )
+                TvButton(onClick = onRefresh) {
+                    Text(stringResource(R.string.settings_downloads_refresh))
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                SettingsOverviewStat(
+                    label = stringResource(R.string.settings_downloads_active),
+                    value = activeCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+                SettingsOverviewStat(
+                    label = stringResource(R.string.settings_downloads_completed),
+                    value = completedCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+                SettingsOverviewStat(
+                    label = stringResource(R.string.settings_downloads_total),
+                    value = totalCount.toString(),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyDownloadsCard() {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        colors = SurfaceDefaults.colors(containerColor = SurfaceElevated),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.settings_downloads_empty),
+            style = MaterialTheme.typography.bodyMedium,
+            color = OnSurfaceDim,
+            modifier = Modifier.padding(20.dp)
+        )
+    }
+}
+
+@Composable
+private fun DownloadSelectionCard(
+    selectedCount: Int,
+    onDeleteSelected: () -> Unit,
+    onClearSelection: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        colors = SurfaceDefaults.colors(containerColor = SurfaceElevated),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.settings_downloads_selected_count, selectedCount),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (selectedCount > 0) OnBackground else OnSurfaceDim
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                TvButton(onClick = onClearSelection, enabled = selectedCount > 0) {
+                    Text(stringResource(R.string.settings_downloads_clear_selection))
+                }
+                TvButton(onClick = onDeleteSelected, enabled = selectedCount > 0) {
+                    Text(stringResource(R.string.settings_downloads_delete_selected))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadFolderHeader(
+    folder: DownloadFolder,
+    selectedCount: Int,
+    onSelectAll: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        colors = SurfaceDefaults.colors(containerColor = Color.White.copy(alpha = 0.06f)),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                Text(
+                    text = folder.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    color = OnBackground,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(
+                    text = stringResource(R.string.settings_downloads_folder_count, folder.items.size, selectedCount),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = OnSurfaceDim
+                )
+            }
+            TvButton(onClick = onSelectAll) {
+                Text(stringResource(R.string.settings_downloads_select_all))
+            }
+        }
+    }
+}
+
+@Composable
+private fun DownloadItemCard(
+    item: OfflineDownloadItem,
+    isSelected: Boolean,
+    onToggleSelected: () -> Unit,
+    onPlay: () -> Unit,
+    onPause: () -> Unit,
+    onResume: () -> Unit,
+    onDelete: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        colors = SurfaceDefaults.colors(containerColor = SurfaceElevated),
+        shape = RoundedCornerShape(16.dp),
+        border = Border(
+            border = BorderStroke(1.dp, Color.White.copy(alpha = 0.08f)),
+            shape = RoundedCornerShape(16.dp)
+        )
+    ) {
+        Column(
+            modifier = Modifier.padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.Top
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(5.dp)
+                ) {
+                    Text(
+                        text = item.title,
+                        style = MaterialTheme.typography.titleSmall,
+                        color = OnBackground,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    Text(
+                        text = item.localUri.ifBlank { item.sourceUri },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = OnSurfaceDim,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                StatusTonePill(
+                    label = stringResource(item.status.labelRes),
+                    accent = item.status.accentColor
+                )
+            }
+
+            item.progress?.let { progress ->
+                LinearProgressIndicator(
+                    progress = { progress.coerceIn(0f, 1f) },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = Primary,
+                    trackColor = Color.White.copy(alpha = 0.12f)
+                )
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = downloadSizeLabel(item),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = OnSurface
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    TvButton(onClick = onToggleSelected) {
+                        Text(
+                            stringResource(
+                                if (isSelected) {
+                                    R.string.settings_downloads_selected
+                                } else {
+                                    R.string.settings_downloads_select
+                                }
+                            )
+                        )
+                    }
+                    if (item.status == OfflineDownloadStatus.SUCCESSFUL && item.localUri.isNotBlank()) {
+                        TvButton(onClick = onPlay) {
+                            Text(stringResource(R.string.settings_downloads_play))
+                        }
+                    }
+                    if (item.status == OfflineDownloadStatus.RUNNING || item.status == OfflineDownloadStatus.PENDING) {
+                        TvButton(onClick = onPause) {
+                            Text(stringResource(R.string.vod_download_pause))
+                        }
+                    }
+                    if (item.status == OfflineDownloadStatus.PAUSED) {
+                        TvButton(onClick = onResume) {
+                            Text(stringResource(R.string.vod_download_resume))
+                        }
+                    }
+                    TvButton(onClick = onDelete) {
+                        Text(stringResource(R.string.settings_downloads_delete))
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun downloadSizeLabel(item: OfflineDownloadItem): String {
+    val downloaded = formatBytes(item.bytesDownloaded)
+    val total = item.totalBytes?.let(::formatBytes)
+    val sizeLabel = if (total == null) downloaded else "$downloaded / $total"
+    return item.progressPercent?.let { "$sizeLabel ($it%)" } ?: sizeLabel
+}
+
+private data class DownloadFolder(
+    val name: String,
+    val items: List<OfflineDownloadItem>
+)
+
+private fun groupedDownloadFolders(items: List<OfflineDownloadItem>): List<DownloadFolder> =
+    items.groupBy { it.folderName }
+        .toSortedMap(compareBy<String> { if (it == MOVIES_FOLDER) "zzzz-$it" else it.lowercase() })
+        .map { (name, downloads) ->
+            DownloadFolder(
+                name = name,
+                items = downloads.sortedWith(
+                    compareBy<OfflineDownloadItem> { it.status.sortOrder }
+                        .thenBy { it.title.lowercase() }
+                )
+            )
+        }
+
+private val OfflineDownloadItem.folderName: String
+    get() {
+        val match = SERIES_TITLE_PATTERN.find(title)
+        return match?.groupValues?.getOrNull(1)?.takeIf { it.isNotBlank() } ?: MOVIES_FOLDER
+    }
+
+private const val MOVIES_FOLDER = "Movies"
+private val SERIES_TITLE_PATTERN = Regex("^(.+?)\\s+-\\s+S\\d{1,2}E\\d{1,2}\\s+-\\s+.+$")
+
+private val OfflineDownloadStatus.isActive: Boolean
+    get() = this == OfflineDownloadStatus.RUNNING ||
+        this == OfflineDownloadStatus.PENDING ||
+        this == OfflineDownloadStatus.PAUSED
+
+private val OfflineDownloadStatus.labelRes: Int
+    get() = when (this) {
+        OfflineDownloadStatus.RUNNING -> R.string.settings_downloads_status_running
+        OfflineDownloadStatus.PENDING -> R.string.settings_downloads_status_pending
+        OfflineDownloadStatus.PAUSED -> R.string.settings_downloads_status_paused
+        OfflineDownloadStatus.SUCCESSFUL -> R.string.settings_downloads_status_complete
+        OfflineDownloadStatus.FAILED -> R.string.settings_downloads_status_failed
+        OfflineDownloadStatus.UNKNOWN -> R.string.settings_downloads_status_unknown
+    }
+
+private val OfflineDownloadStatus.accentColor: Color
+    get() = when (this) {
+        OfflineDownloadStatus.RUNNING,
+        OfflineDownloadStatus.PENDING -> Primary
+        OfflineDownloadStatus.PAUSED -> OnSurface
+        OfflineDownloadStatus.SUCCESSFUL -> Color(0xFF66BB6A)
+        OfflineDownloadStatus.FAILED -> ErrorColor
+        OfflineDownloadStatus.UNKNOWN -> OnSurfaceDim
+    }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsNavigationRail.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsNavigationRail.kt
@@ -23,6 +23,9 @@ private data class SettingsNavEntry(
     val accent: Color
 )
 
+internal const val SETTINGS_CATEGORY_BACKUP = 6
+internal const val SETTINGS_CATEGORY_DOWNLOADS = 5
+
 @Composable
 internal fun SettingsNavigationRail(
     selectedCategory: Int,
@@ -54,6 +57,11 @@ internal fun SettingsNavigationRail(
             label = stringResource(R.string.settings_recording_title),
             icon = "R",
             accent = Color(0xFFEF5350)
+        ),
+        SettingsNavEntry(
+            label = stringResource(R.string.settings_downloads_title),
+            icon = "v",
+            accent = Color(0xFF26C6DA)
         ),
         SettingsNavEntry(
             label = stringResource(R.string.settings_backup_restore),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreen.kt
@@ -29,6 +29,7 @@ import com.streamvault.app.ui.theme.*
 import com.streamvault.domain.model.Provider
 import androidx.compose.ui.res.stringResource
 import com.streamvault.app.R
+import com.streamvault.app.navigation.Routes
 import com.streamvault.app.ui.design.requestFocusSafely
 import kotlinx.coroutines.delay
 
@@ -41,6 +42,7 @@ fun SettingsScreen(
     onNavigateToParentalControl: (Long) -> Unit = {},
     currentRoute: String,
     initialBackupImportUri: String? = null,
+    initialSelectedCategory: Int? = null,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -128,6 +130,10 @@ fun SettingsScreen(
         }
     }
 
+    LaunchedEffect(initialSelectedCategory) {
+        initialSelectedCategory?.let { dialogState.selectedCategory = it }
+    }
+
     LaunchedEffect(uiState.recordingItems) {
         dialogState.selectedRecordingId = when {
             uiState.recordingItems.isEmpty() -> null
@@ -141,7 +147,7 @@ fun SettingsScreen(
         val uri = initialBackupImportUri?.takeIf { it.isNotBlank() } ?: return@LaunchedEffect
         if (handledInitialBackupImportUri == uri) return@LaunchedEffect
         handledInitialBackupImportUri = uri
-        dialogState.selectedCategory = 5
+        dialogState.selectedCategory = SETTINGS_CATEGORY_BACKUP
         viewModel.inspectBackup(uri)
     }
 
@@ -205,6 +211,17 @@ fun SettingsScreen(
                     onDriveSignOut = viewModel::signOutDrive,
                     onDrivePush = viewModel::pushToDrive,
                     onDrivePull = viewModel::pullFromDrive,
+                    onPlayDownload = { item ->
+                        mainActivity?.openPlayer(
+                            Routes.player(
+                                streamUrl = item.localUri,
+                                title = item.title,
+                                internalId = item.id,
+                                contentType = "MOVIE",
+                                returnRoute = currentRoute
+                            )
+                        )
+                    },
                     onOpenUri = uriHandler::openUri,
                     modifier = Modifier.weight(1f)
                 )

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -3,6 +3,7 @@ package com.streamvault.app.ui.screens.settings
 import com.streamvault.app.ui.model.LiveTvChannelMode
 import com.streamvault.app.ui.model.LiveTvQuickFilterVisibilityMode
 import com.streamvault.app.ui.model.VodViewMode
+import com.streamvault.app.download.OfflineDownloadItem
 import com.streamvault.domain.manager.BackupImportPlan
 import com.streamvault.domain.manager.BackupPreview
 import com.streamvault.domain.manager.DriveAuthState
@@ -104,6 +105,8 @@ data class SettingsUiState(
     val wifiOnlyRecording: Boolean = false,
     val recordingPaddingBeforeMinutes: Int = 0,
     val recordingPaddingAfterMinutes: Int = 0,
+    val offlineDownloads: List<OfflineDownloadItem> = emptyList(),
+    val selectedOfflineDownloadIds: Set<Long> = emptySet(),
     val isIncognitoMode: Boolean = false,
     val useXtreamTextClassification: Boolean = true,
     val xtreamBase64TextCompatibility: Boolean = false,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -8,6 +8,9 @@ import androidx.lifecycle.viewModelScope
 import com.streamvault.app.R
 import com.streamvault.app.BuildConfig
 import com.streamvault.app.diagnostics.CrashReportStore
+import com.streamvault.app.download.OfflineDownloadItem
+import com.streamvault.app.download.OfflineDownloadResult
+import com.streamvault.app.download.OfflineVodDownloadManager
 import com.streamvault.app.tv.LauncherRecommendationsManager
 import com.streamvault.app.tv.WatchNextManager
 import com.streamvault.app.tvinput.TvInputChannelSyncManager
@@ -75,6 +78,7 @@ import com.streamvault.domain.usecase.SyncProviderResult
 import com.streamvault.player.AudioCompatibilityMemoryStore
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlin.math.max
@@ -112,7 +116,8 @@ class SettingsViewModel @Inject constructor(
     private val gitHubReleaseChecker: GitHubReleaseChecker,
     private val appUpdateInstaller: AppUpdateInstaller,
     private val getCustomCategories: GetCustomCategories,
-    private val audioCompatibilityMemoryStore: AudioCompatibilityMemoryStore
+    private val audioCompatibilityMemoryStore: AudioCompatibilityMemoryStore,
+    private val offlineVodDownloadManager: OfflineVodDownloadManager
 ) : ViewModel() {
     private val appContext = application
     private val exportBackup = ExportBackup(backupManager)
@@ -212,7 +217,106 @@ class SettingsViewModel @Inject constructor(
             epgSourceRepository = epgSourceRepository,
             uiState = _uiState
         )
+        observeOfflineDownloads()
         driveBackupActions.observeAuthState(viewModelScope)
+    }
+
+    private fun observeOfflineDownloads() {
+        viewModelScope.launch {
+            while (true) {
+                refreshOfflineDownloads()
+                delay(2_000)
+            }
+        }
+    }
+
+    fun refreshOfflineDownloads() {
+        val downloads = offlineVodDownloadManager.snapshot()
+        val liveIds = downloads.map { it.id }.toSet()
+        _uiState.update {
+            it.copy(
+                offlineDownloads = downloads,
+                selectedOfflineDownloadIds = it.selectedOfflineDownloadIds intersect liveIds
+            )
+        }
+    }
+
+    fun deleteOfflineDownload(downloadId: Long) {
+        val deleted = offlineVodDownloadManager.delete(downloadId)
+        _uiState.update {
+            it.copy(
+                offlineDownloads = offlineVodDownloadManager.snapshot(),
+                selectedOfflineDownloadIds = it.selectedOfflineDownloadIds - downloadId,
+                userMessage = appContext.getString(
+                    if (deleted) R.string.settings_downloads_deleted else R.string.settings_downloads_removed
+                )
+            )
+        }
+    }
+
+    fun toggleOfflineDownloadSelection(downloadId: Long) {
+        _uiState.update {
+            val selected = it.selectedOfflineDownloadIds
+            it.copy(
+                selectedOfflineDownloadIds = if (downloadId in selected) {
+                    selected - downloadId
+                } else {
+                    selected + downloadId
+                }
+            )
+        }
+    }
+
+    fun selectOfflineDownloads(downloadIds: Set<Long>) {
+        _uiState.update { it.copy(selectedOfflineDownloadIds = it.selectedOfflineDownloadIds + downloadIds) }
+    }
+
+    fun clearOfflineDownloadSelection() {
+        _uiState.update { it.copy(selectedOfflineDownloadIds = emptySet()) }
+    }
+
+    fun deleteSelectedOfflineDownloads() {
+        val selectedIds = _uiState.value.selectedOfflineDownloadIds
+        if (selectedIds.isEmpty()) return
+        selectedIds.forEach { offlineVodDownloadManager.delete(it) }
+        _uiState.update {
+            it.copy(
+                offlineDownloads = offlineVodDownloadManager.snapshot(),
+                selectedOfflineDownloadIds = emptySet(),
+                userMessage = appContext.resources.getQuantityString(
+                    R.plurals.settings_downloads_deleted_count,
+                    selectedIds.size,
+                    selectedIds.size
+                )
+            )
+        }
+    }
+
+    fun resumeOfflineDownload(item: OfflineDownloadItem) {
+        val result = offlineVodDownloadManager.restart(item)
+        _uiState.update {
+            it.copy(
+                offlineDownloads = offlineVodDownloadManager.snapshot(),
+                userMessage = when (result) {
+                    is OfflineDownloadResult.Queued -> appContext.getString(R.string.settings_downloads_resumed)
+                    is OfflineDownloadResult.Error -> result.message
+                    is OfflineDownloadResult.Unsupported -> result.message
+                    is OfflineDownloadResult.AlreadyExists -> appContext.getString(R.string.settings_downloads_already_active)
+                }
+            )
+        }
+    }
+
+    fun pauseOfflineDownload(item: OfflineDownloadItem) {
+        val paused = offlineVodDownloadManager.pause(item)
+        _uiState.update {
+            it.copy(
+                offlineDownloads = offlineVodDownloadManager.snapshot(),
+                userMessage = appContext.getString(
+                    if (paused) R.string.settings_downloads_paused else R.string.settings_downloads_pause_failed
+                )
+            )
+        }
     }
 
     fun refreshCrashReport() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="nav_movies">Movies</string>
     <string name="nav_series">Series</string>
     <string name="nav_epg">Guide</string>
+    <string name="nav_downloads">Downloads</string>
     <string name="nav_settings">Settings</string>
     <string name="nav_plugins">Plugins</string>
 
@@ -1340,6 +1341,15 @@
     <string name="movie_detail_play">Play</string>
     <string name="movie_detail_resume_from">Resume from %1$s</string>
     <string name="movie_detail_trailer">Trailer</string>
+    <string name="vod_download">Download</string>
+    <string name="vod_download_preparing">Preparing...</string>
+    <string name="vod_download_downloading">Downloading</string>
+    <string name="vod_download_downloading_progress">Downloading %1$d%%</string>
+    <string name="vod_download_paused">Paused</string>
+    <string name="vod_download_pause">Pause</string>
+    <string name="vod_download_resume">Resume</string>
+    <string name="vod_download_resume_progress">Resume %1$d%%</string>
+    <string name="vod_download_downloaded">Downloaded</string>
     <string name="movie_detail_related">More Like This</string>
     <string name="favorites_add">Add to favourites</string>
     <string name="favorites_remove">Remove from favourites</string>
@@ -1399,6 +1409,38 @@
 
     
     <string name="settings_privacy">Privacy</string>
+    <string name="settings_downloads_title">Downloads</string>
+    <string name="settings_downloads_subtitle">Manage offline movies and episodes saved by StreamVault.</string>
+    <string name="settings_downloads_active">Active</string>
+    <string name="settings_downloads_completed">Completed</string>
+    <string name="settings_downloads_total">Total</string>
+    <string name="settings_downloads_refresh">Refresh</string>
+    <string name="settings_downloads_empty">No offline downloads yet. Use Download on a movie or episode to save it for travel.</string>
+    <string name="settings_downloads_play">Play</string>
+    <string name="settings_downloads_delete">Delete</string>
+    <string name="settings_downloads_select">Select</string>
+    <string name="settings_downloads_selected">Selected</string>
+    <string name="settings_downloads_select_all">Select all</string>
+    <string name="settings_downloads_clear_selection">Clear selection</string>
+    <string name="settings_downloads_delete_selected">Delete selected</string>
+    <string name="settings_downloads_selected_count">%1$d selected</string>
+    <string name="settings_downloads_folder_count">%1$d items - %2$d selected</string>
+    <string name="settings_downloads_deleted">Download deleted</string>
+    <string name="settings_downloads_removed">Download removed from StreamVault</string>
+    <string name="settings_downloads_resumed">Download resumed</string>
+    <string name="settings_downloads_paused">Download paused</string>
+    <string name="settings_downloads_pause_failed">Could not pause download</string>
+    <string name="settings_downloads_already_active">Download is already active</string>
+    <plurals name="settings_downloads_deleted_count">
+        <item quantity="one">%1$d download deleted</item>
+        <item quantity="other">%1$d downloads deleted</item>
+    </plurals>
+    <string name="settings_downloads_status_running">Downloading</string>
+    <string name="settings_downloads_status_pending">Queued</string>
+    <string name="settings_downloads_status_paused">Paused</string>
+    <string name="settings_downloads_status_complete">Ready</string>
+    <string name="settings_downloads_status_failed">Failed</string>
+    <string name="settings_downloads_status_unknown">Unknown</string>
     <string name="settings_privacy_subtitle">Manage watch history and incognito mode.</string>
     <string name="settings_incognito_mode">Incognito Mode</string>
     <string name="settings_incognito_mode_subtitle">Don\'t save watch history or recently visited categories while active.</string>


### PR DESCRIPTION
## Summary
- Adds offline VOD downloads for movies and series episodes.
- Adds an app-managed Downloads section in Settings with active, paused, completed, and failed downloads.
- Adds grouped download folders for series, multi-select deletion, pause/resume/restart controls, and local playback for completed files.
- Adds a Downloads shortcut in the top navigation before Search.
- Stores downloads in app-owned external storage so uninstalling the app removes new downloaded files.

## Testing
- Built debug APK successfully with `./gradlew.bat assembleDebug --no-daemon -Pkotlin.incremental=false` before this PR refresh.
- Did not rebuild after restoring LeakCanary, per request.