### PR TITLE
Live preview pane for Guide + EPG quality-of-life improvementsFeature/live preview enhancements

### DIFF
--- a/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
@@ -669,16 +669,18 @@ fun AppNavigation(mainActivity: MainActivity) {
                     onBack = {
                         val route = safePlayerRequest.returnRoute
                         if (!route.isNullOrBlank() && navController.popBackStack(route, false)) {
+                            // Popped back to the exact route already in the backstack (same VM, handoff works)
                             Unit
-                        } else if (!route.isNullOrBlank()) {
-                            navController.navigate(route) {
+                        } else if (!navController.popBackStack()) {
+                            // Nothing left to pop — navigate to the return route or home as a last resort
+                            val fallback = route?.takeIf { it.isNotBlank() } ?: Routes.HOME
+                            navController.navigate(fallback) {
                                 popUpTo(Routes.PLAYER) { inclusive = true }
                                 launchSingleTop = true
                                 restoreState = true
                             }
-                        } else {
-                            navController.popBackStack()
                         }
+                        // else: plain popBackStack() succeeded — returns to existing Guide entry, preserving EpgViewModel
                     },
                     onNavigate = { route ->
                         navController.navigateIfResumed(route) {

--- a/app/src/main/java/com/streamvault/app/player/LivePreviewHandoffManager.kt
+++ b/app/src/main/java/com/streamvault/app/player/LivePreviewHandoffManager.kt
@@ -10,27 +10,49 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+enum class PreviewHandoffSource { HOME, GUIDE }
 
 @Singleton
 class LivePreviewHandoffManager @Inject constructor() {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var pendingReleaseJob: Job? = null
     private var session: LivePreviewHandoffSession? = null
+    private var pendingReverseReleaseJob: Job? = null
+    private val _reverseSessionFlow = MutableStateFlow<LivePreviewHandoffSession?>(null)
+    val reverseSessionFlow: StateFlow<LivePreviewHandoffSession?> = _reverseSessionFlow.asStateFlow()
+    private val reverseSession: LivePreviewHandoffSession?
+        get() = _reverseSessionFlow.value
 
     fun registerPreviewSession(
         channel: Channel,
         streamInfo: StreamInfo,
-        engine: PlayerEngine
+        engine: PlayerEngine,
+        source: PreviewHandoffSource = PreviewHandoffSource.HOME
+    ) {
+        registerPreviewSession(channel.id, channel.providerId, streamInfo, engine, source)
+    }
+
+    fun registerPreviewSession(
+        channelId: Long,
+        providerId: Long,
+        streamInfo: StreamInfo,
+        engine: PlayerEngine,
+        source: PreviewHandoffSource = PreviewHandoffSource.HOME
     ) {
         val previous = session
         pendingReleaseJob?.cancel()
         session = LivePreviewHandoffSession(
             engine = engine,
-            channelId = channel.id,
-            providerId = channel.providerId,
+            channelId = channelId,
+            providerId = providerId,
             streamInfo = streamInfo,
-            pendingFullscreen = false
+            pendingFullscreen = false,
+            source = source
         )
         if (previous != null && previous.engine !== engine) {
             previous.engine.release()
@@ -73,12 +95,46 @@ class LivePreviewHandoffManager @Inject constructor() {
         session = null
     }
 
+    fun beginReverseHandoff(
+        channel: Channel,
+        streamInfo: StreamInfo,
+        engine: PlayerEngine,
+        source: PreviewHandoffSource = PreviewHandoffSource.HOME
+    ) {
+        pendingReverseReleaseJob?.cancel()
+        _reverseSessionFlow.value = LivePreviewHandoffSession(
+            engine = engine,
+            channelId = channel.id,
+            providerId = channel.providerId,
+            streamInfo = streamInfo,
+            pendingFullscreen = false,
+            source = source
+        )
+        pendingReverseReleaseJob = scope.launch {
+            delay(PENDING_FULLSCREEN_TIMEOUT_MS)
+            val stale = _reverseSessionFlow.value
+            if (stale != null) {
+                _reverseSessionFlow.value = null
+                stale.engine.release()
+            }
+        }
+    }
+
+    fun consumeReverseHandoff(forSource: PreviewHandoffSource? = null): LivePreviewHandoffSession? {
+        val s = _reverseSessionFlow.value ?: return null
+        if (forSource != null && s.source != forSource) return null
+        pendingReverseReleaseJob?.cancel()
+        _reverseSessionFlow.value = null
+        return s
+    }
+
     data class LivePreviewHandoffSession(
         val engine: PlayerEngine,
         val channelId: Long,
         val providerId: Long,
         val streamInfo: StreamInfo,
         val pendingFullscreen: Boolean,
+        val source: PreviewHandoffSource = PreviewHandoffSource.HOME,
         val updatedAtMs: Long = System.currentTimeMillis()
     )
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
@@ -118,6 +118,7 @@ internal fun EpgGrid(
     guideWindowEnd: Long,
     density: GuideDensity,
     onChannelClick: (Channel) -> Unit,
+    onChannelLongClick: ((Channel, Program?) -> Unit)? = null,
     onProgramClick: (Channel, Program) -> Unit,
     onChannelFocused: (Channel, Program?, Boolean) -> Unit,
     onProgramFocused: (Channel, Program, Boolean) -> Unit,
@@ -190,6 +191,7 @@ internal fun EpgGrid(
                         markerStepMs = markerStepMs,
                         scrollState = horizontalScrollState,
                         onChannelClick = { onChannelClick(channel) },
+                        onChannelLongClick = onChannelLongClick?.let { cb -> { prog -> cb(channel, prog) } },
                         onChannelFocused = { onChannelFocused(channel, it, isFirstRow) },
                         onProgramClick = { program -> onProgramClick(channel, program) },
                         onProgramFocused = { program -> onProgramFocused(channel, program, isFirstRow) }
@@ -336,6 +338,7 @@ fun EpgRow(
     markerStepMs: Long,
     scrollState: androidx.compose.foundation.ScrollState,
     onChannelClick: () -> Unit,
+    onChannelLongClick: ((Program?) -> Unit)? = null,
     onChannelFocused: (Program?) -> Unit,
     onProgramClick: (Program) -> Unit,
     onProgramFocused: (Program) -> Unit
@@ -365,6 +368,13 @@ fun EpgRow(
     ) {
         TvClickableSurface(
             onClick = onChannelClick,
+            onLongClick = onChannelLongClick?.let { cb ->
+                {
+                    val prog = currentProgram
+                        ?: programs.minByOrNull { kotlin.math.abs(it.startTime - now) }
+                    cb(prog)
+                }
+            },
             modifier = Modifier
                 .width(channelRailWidth)
                 .fillMaxHeight()

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
@@ -247,25 +247,6 @@ private fun GuideTimelineHeader(
             modifier = Modifier.width(timelineViewportWidth),
             verticalArrangement = Arrangement.spacedBy(2.dp)
         ) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = stringResource(R.string.epg_timeline_label),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = OnSurfaceDim
-                )
-                Text(
-                    text = stringResource(
-                        R.string.epg_timeline_range_label,
-                        formatWindowDuration(totalDuration)
-                    ),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = OnSurfaceDim
-                )
-            }
             Box(
                 modifier = Modifier
                     .width(timelineViewportWidth)
@@ -313,11 +294,6 @@ private fun GuideTimelineHeader(
                     }
                 }
             }
-            Text(
-                text = markerLabel,
-                style = MaterialTheme.typography.labelSmall,
-                color = if (now in windowStart..windowEnd) Primary else OnSurfaceDim
-            )
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
@@ -226,7 +226,8 @@ private fun GuideTimelineHeader(
         stringResource(R.string.epg_outside_window)
     }
     val hourMarkers = buildList {
-        var marker = windowStart
+        val firstMarker = windowStart - (windowStart % markerStepMs)
+        var marker = firstMarker
         while (marker <= windowEnd) {
             add(marker)
             marker += markerStepMs
@@ -458,7 +459,8 @@ fun EpgRow(
                 ) {
                 val markers = remember(windowStart, windowEnd, markerStepMs) {
                     buildList {
-                        var marker = windowStart
+                        val firstMarker = windowStart - (windowStart % markerStepMs)
+                        var marker = firstMarker
                         while (marker <= windowEnd) {
                             add(marker)
                             marker += markerStepMs

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgHeroComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgHeroComponents.kt
@@ -1,16 +1,22 @@
 package com.streamvault.app.ui.screens.epg
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -20,12 +26,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.Border
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.MaterialTheme
@@ -34,6 +43,7 @@ import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import com.streamvault.app.R
 import com.streamvault.app.ui.components.ChannelLogoBadge
+import com.streamvault.app.ui.components.PlayerRenderView
 import com.streamvault.app.ui.model.isArchivePlayable
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.model.guideLookupKey
@@ -47,6 +57,9 @@ import com.streamvault.app.ui.theme.SurfaceElevated
 import com.streamvault.app.ui.theme.SurfaceHighlight
 import com.streamvault.domain.model.Channel
 import com.streamvault.domain.model.Program
+import com.streamvault.player.PlayerEngine
+import com.streamvault.player.PlayerRenderSurfaceType
+import com.streamvault.player.PlayerSurfaceResizeMode
 import java.util.Date
 
 internal data class GuideHeroSelection(
@@ -292,6 +305,150 @@ internal fun GuideHeroBadge(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
+    }
+}
+
+@Composable
+internal fun GuidePreviewPane(
+    previewPlayerEngine: PlayerEngine?,
+    isPreviewLoading: Boolean,
+    focusedChannel: Channel?,
+    focusedProgram: Program?,
+    modifier: Modifier = Modifier
+) {
+    val renderSurfaceType by (previewPlayerEngine?.renderSurfaceType)?.collectAsStateWithLifecycle(
+        initialValue = PlayerRenderSurfaceType.SURFACE_VIEW
+    ) ?: remember { mutableStateOf(PlayerRenderSurfaceType.SURFACE_VIEW) }
+    val now = currentGuideNow()
+    val appTimeFormat = LocalAppTimeFormat.current
+    val timeFormat = remember(appTimeFormat) { appTimeFormat.createTimeFormat() }
+
+    Surface(
+        modifier = modifier.height(150.dp),
+        colors = SurfaceDefaults.colors(containerColor = SurfaceElevated),
+        shape = RoundedCornerShape(20.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // Video preview area (16:9 at 90dp height = 160dp wide)
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .aspectRatio(16f / 9f)
+                    .background(Color.Black, RoundedCornerShape(12.dp))
+                    .clip(RoundedCornerShape(12.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                if (previewPlayerEngine != null) {
+                    PlayerRenderView(
+                        playerEngine = previewPlayerEngine,
+                        resizeMode = PlayerSurfaceResizeMode.FIT,
+                        surfaceType = renderSurfaceType,
+                        modifier = Modifier.fillMaxSize()
+                    )
+                    if (isPreviewLoading) {
+                        CircularProgressIndicator(
+                            color = Primary,
+                            strokeWidth = 2.dp,
+                            modifier = Modifier.size(22.dp)
+                        )
+                    }
+                } else {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                        modifier = Modifier.padding(horizontal = 12.dp)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.live_preview_placeholder_title),
+                            style = MaterialTheme.typography.labelMedium,
+                            color = OnSurfaceDim,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+
+            // Program info
+            val channel = focusedChannel
+            val program = focusedProgram
+            if (channel != null) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        ChannelLogoBadge(
+                            channelName = channel.name,
+                            logoUrl = channel.logoUrl,
+                            modifier = Modifier.size(32.dp),
+                            shape = RoundedCornerShape(8.dp)
+                        )
+                        Text(
+                            text = if (channel.number > 0) "${channel.number}. ${channel.name}" else channel.name,
+                            style = MaterialTheme.typography.titleSmall,
+                            color = OnSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                    if (program != null) {
+                        Text(
+                            text = program.title,
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = OnSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Text(
+                            text = "${timeFormat.format(Date(program.startTime))} – ${timeFormat.format(Date(program.endTime))}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = OnSurfaceDim
+                        )
+                        if (now in program.startTime until program.endTime) {
+                            LinearProgressIndicator(
+                                progress = { ((now - program.startTime).toFloat() / (program.endTime - program.startTime).toFloat()).coerceIn(0f, 1f) },
+                                modifier = Modifier
+                                    .fillMaxWidth(0.6f)
+                                    .height(3.dp),
+                                color = Primary,
+                                trackColor = SurfaceHighlight
+                            )
+                        }
+                        if (program.description.isNotBlank()) {
+                            Text(
+                                text = program.description,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = OnSurfaceDim,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+                    } else {
+                        Text(
+                            text = stringResource(R.string.epg_no_schedule),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = OnSurfaceDim
+                        )
+                    }
+                }
+            } else {
+                Text(
+                    text = stringResource(R.string.epg_title),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = OnSurfaceDim,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -189,7 +190,8 @@ fun FullEpgScreen(
         when (action) {
             is LockedGuideAction.SelectCategory -> viewModel.selectCategory(action.category.id)
             is LockedGuideAction.OpenProgram -> selectedProgram = action.channel to action.program
-            is LockedGuideAction.PlayChannel ->
+            is LockedGuideAction.PlayChannel -> {
+                viewModel.handoffOrClearForFullscreen(action.channel)
                 onPlayChannel(
                     action.channel,
                     playerCategoryId,
@@ -197,7 +199,9 @@ fun FullEpgScreen(
                     uiState.combinedProfileId,
                     action.returnRoute
                 )
-            is LockedGuideAction.PlayArchive ->
+            }
+            is LockedGuideAction.PlayArchive -> {
+                viewModel.clearPreview()
                 onPlayArchive(
                     action.channel,
                     action.program,
@@ -206,6 +210,7 @@ fun FullEpgScreen(
                     uiState.combinedProfileId,
                     action.returnRoute
                 )
+            }
         }
     }
 
@@ -213,6 +218,10 @@ fun FullEpgScreen(
         pendingLockedAction = action
         pinError = null
         showPinDialog = true
+    }
+
+    DisposableEffect(viewModel) {
+        onDispose { viewModel.clearPreview() }
     }
 
     LaunchedEffect(initialCategoryId, initialAnchorTime, initialFavoritesOnly) {
@@ -383,8 +392,9 @@ fun FullEpgScreen(
 
                 else -> {
                     GuideNowProvider {
-                        GuideHeroSection(
-                            uiState = uiState,
+                        GuidePreviewPane(
+                            previewPlayerEngine = uiState.previewPlayerEngine,
+                            isPreviewLoading = uiState.isPreviewLoading,
                             focusedChannel = focusedChannel,
                             focusedProgram = focusedProgram,
                             modifier = Modifier
@@ -438,7 +448,8 @@ fun FullEpgScreen(
                             onChannelClick = { channel ->
                                 if (isGuideChannelLocked(channel, categoriesById, uiState.parentalControlLevel)) {
                                     requestLockedGuideAction(LockedGuideAction.PlayChannel(channel, returnRoute))
-                                } else {
+                                } else if (uiState.previewChannelId == channel.id) {
+                                    viewModel.handoffOrClearForFullscreen(channel)
                                     onPlayChannel(
                                         channel,
                                         playerCategoryId,
@@ -446,6 +457,33 @@ fun FullEpgScreen(
                                         uiState.combinedProfileId,
                                         returnRoute
                                     )
+                                } else {
+                                    viewModel.previewChannel(channel)
+                                }
+                            },
+                            onChannelLongClick = { channel, currentProgram ->
+                                topNavVisible = false
+                                if (isGuideChannelLocked(channel, categoriesById, uiState.parentalControlLevel)) {
+                                    requestLockedGuideAction(LockedGuideAction.PlayChannel(channel, returnRoute))
+                                } else {
+                                    val program = currentProgram ?: run {
+                                        // No EPG match — synthesize a 1-hour "now" program so
+                                        // the dialog still shows Record / Record Daily / Weekly.
+                                        val now = System.currentTimeMillis()
+                                        Program(
+                                            channelId = channel.id.toString(),
+                                            title = channel.name,
+                                            startTime = now,
+                                            endTime = now + 60L * 60L * 1000L
+                                        )
+                                    }
+                                    // Delay so the long-press key-release lands on the
+                                    // channel cell, not on an auto-focused button inside
+                                    // the dialog (which would auto-fire "Watch Live").
+                                    scope.launch {
+                                        kotlinx.coroutines.delay(350)
+                                        selectedProgram = channel to program
+                                    }
                                 }
                             },
                             onProgramClick = { channel, program ->
@@ -609,6 +647,7 @@ fun FullEpgScreen(
                     if (isGuideChannelLocked(channel, categoriesById, uiState.parentalControlLevel)) {
                         requestLockedGuideAction(LockedGuideAction.PlayChannel(channel, returnRoute))
                     } else {
+                        viewModel.handoffOrClearForFullscreen(channel)
                         onPlayChannel(
                             channel,
                             playerCategoryId,
@@ -624,6 +663,7 @@ fun FullEpgScreen(
                         if (isGuideChannelLocked(channel, categoriesById, uiState.parentalControlLevel)) {
                             requestLockedGuideAction(LockedGuideAction.PlayArchive(channel, program, returnRoute))
                         } else {
+                            viewModel.clearPreview()
                             onPlayArchive(
                                 channel,
                                 program,

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgScreen.kt
@@ -224,6 +224,19 @@ fun FullEpgScreen(
         onDispose { viewModel.clearPreview() }
     }
 
+    val hasActivePreview = uiState.previewPlayerEngine != null
+    DisposableEffect(hasActivePreview) {
+        val window = (context as? android.app.Activity)?.window
+        if (hasActivePreview) {
+            window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            if (hasActivePreview) {
+                window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+    }
+
     LaunchedEffect(initialCategoryId, initialAnchorTime, initialFavoritesOnly) {
         viewModel.applyNavigationContext(
             categoryId = initialCategoryId,

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
@@ -61,6 +61,15 @@ import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.ZoneId
 import javax.inject.Inject
+import android.app.Application
+import com.streamvault.app.R
+import com.streamvault.app.di.AuxiliaryPlayerEngine
+import com.streamvault.app.player.LivePreviewHandoffManager
+import com.streamvault.app.player.PreviewHandoffSource
+import com.streamvault.app.plugins.StreamVaultPluginManager
+import com.streamvault.player.PlaybackState
+import com.streamvault.player.PlayerEngine
+import javax.inject.Provider as InjectProvider
 
 data class RecordingConflictInfo(
     val conflictingItems: List<RecordingItem>,
@@ -97,7 +106,11 @@ data class EpgUiState(
     val guideWindowEnd: Long = DEFAULT_NOW + EpgViewModel.LOOKAHEAD_MS,
     val recordingMessage: String? = null,
     val pendingRecordingConflict: RecordingConflictInfo? = null,
-    val hasMoreChannels: Boolean = false
+    val hasMoreChannels: Boolean = false,
+    val previewPlayerEngine: PlayerEngine? = null,
+    val isPreviewLoading: Boolean = false,
+    val previewErrorMessage: String? = null,
+    val previewChannelId: Long? = null,
 ) {
     companion object {
         private val DEFAULT_NOW = System.currentTimeMillis()
@@ -252,8 +265,14 @@ class EpgViewModel @Inject constructor(
     private val programReminderManager: ProgramReminderManager,
     private val getCustomCategories: GetCustomCategories,
     private val scheduleRecording: ScheduleRecording,
-    private val recordingManager: RecordingManager
+    private val recordingManager: RecordingManager,
+    @param:AuxiliaryPlayerEngine private val playerEngineProvider: InjectProvider<PlayerEngine>,
+    private val pluginManager: StreamVaultPluginManager,
+    private val livePreviewHandoffManager: LivePreviewHandoffManager,
+    application: Application,
 ) : ViewModel() {
+
+    private val appContext = application
 
     companion object {
         const val MAX_CHANNELS = 60
@@ -291,11 +310,22 @@ class EpgViewModel @Inject constructor(
     private var prefetchJob: Deferred<GuidePrefetchedPage?>? = null
     private var loadMoreJob: Job? = null
     private var combinedCategoriesById: Map<Long, CombinedCategory> = emptyMap()
+    private var previewPlayerEngine: PlayerEngine? = null
+    private var previewSessionVersion: Long = 0L
+    private var previewPlaybackJob: Job? = null
+    private var previewErrorJob: Job? = null
 
     init {
         restoreGuidePreferences()
         observeGuideBase()
         observeGuidePresentation()
+        viewModelScope.launch {
+            livePreviewHandoffManager.reverseSessionFlow.collect { session ->
+                if (session != null && session.source == PreviewHandoffSource.GUIDE) {
+                    resumePreviewFromHandoff()
+                }
+            }
+        }
     }
 
     fun selectCategory(categoryId: Long) {
@@ -321,6 +351,192 @@ class EpgViewModel @Inject constructor(
 
     suspend fun verifyPin(pin: String): Boolean =
         preferencesRepository.verifyParentalPin(pin)
+
+    fun previewChannel(channel: Channel) {
+        if (_uiState.value.previewChannelId == channel.id && _uiState.value.previewPlayerEngine != null) return
+        val version = ++previewSessionVersion
+        val engine = previewPlayerEngine ?: playerEngineProvider.get().also { previewPlayerEngine = it }
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        _uiState.update {
+            it.copy(
+                previewChannelId = channel.id,
+                previewPlayerEngine = engine,
+                isPreviewLoading = true,
+                previewErrorMessage = null
+            )
+        }
+        previewPlaybackJob = viewModelScope.launch {
+            engine.playbackState.collectLatest { state ->
+                if (!isActivePreviewSession(version, channel.id)) return@collectLatest
+                _uiState.update { s ->
+                    s.copy(
+                        isPreviewLoading = state == PlaybackState.IDLE || state == PlaybackState.BUFFERING,
+                        previewErrorMessage = when {
+                            state == PlaybackState.ERROR && s.previewErrorMessage.isNullOrBlank() ->
+                                appContext.getString(R.string.live_preview_failed)
+                            state != PlaybackState.ERROR -> null
+                            else -> s.previewErrorMessage
+                        }
+                    )
+                }
+            }
+        }
+        previewErrorJob = viewModelScope.launch {
+            engine.error.collectLatest { error ->
+                if (!isActivePreviewSession(version, channel.id)) return@collectLatest
+                if (error != null) {
+                    _uiState.update {
+                        it.copy(
+                            isPreviewLoading = false,
+                            previewErrorMessage = error.message.ifBlank { appContext.getString(R.string.live_preview_failed) }
+                        )
+                    }
+                }
+            }
+        }
+        viewModelScope.launch {
+            when (val result = channelRepository.getStreamInfo(channel)) {
+                is Result.Success -> {
+                    if (!isActivePreviewSession(version, channel.id)) return@launch
+                    val preparedStreamInfo = when (val r = pluginManager.preparePlaybackStreamInfo(result.data)) {
+                        is Result.Success -> r.data
+                        is Result.Error -> {
+                            if (!isActivePreviewSession(version, channel.id)) return@launch
+                            _uiState.update {
+                                it.copy(isPreviewLoading = false, previewErrorMessage = r.message.ifBlank { appContext.getString(R.string.live_preview_failed) })
+                            }
+                            return@launch
+                        }
+                        Result.Loading -> result.data
+                    }
+                    if (!isActivePreviewSession(version, channel.id)) return@launch
+                    engine.stop()
+                    engine.setDecoderMode(preferencesRepository.playerDecoderMode.first())
+                    engine.setSurfaceMode(preferencesRepository.playerSurfaceMode.first())
+                    engine.prepare(preparedStreamInfo)
+                    engine.setVolume(1f)
+                    engine.play()
+                    livePreviewHandoffManager.registerPreviewSession(
+                        channel = channel,
+                        streamInfo = preparedStreamInfo,
+                        engine = engine,
+                        source = PreviewHandoffSource.GUIDE
+                    )
+                }
+                is Result.Error -> {
+                    if (!isActivePreviewSession(version, channel.id)) return@launch
+                    _uiState.update { it.copy(isPreviewLoading = false, previewErrorMessage = result.message) }
+                }
+                Result.Loading -> Unit
+            }
+        }
+    }
+
+    fun beginPreviewHandoff(channel: Channel): Boolean {
+        val engine = previewPlayerEngine ?: return false
+        if (_uiState.value.previewChannelId != channel.id) return false
+        if (!livePreviewHandoffManager.beginFullscreenHandoff(channel.id, engine)) return false
+
+        previewSessionVersion++
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        previewPlaybackJob = null
+        previewErrorJob = null
+        previewPlayerEngine = null
+        _uiState.update {
+            it.copy(
+                previewChannelId = null,
+                previewPlayerEngine = null,
+                isPreviewLoading = false,
+                previewErrorMessage = null
+            )
+        }
+        return true
+    }
+
+    fun resumePreviewFromHandoff() {
+        val session = livePreviewHandoffManager.consumeReverseHandoff(PreviewHandoffSource.GUIDE) ?: return
+        val engine = session.engine
+        previewSessionVersion++
+        val version = previewSessionVersion
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        previewPlaybackJob = null
+        previewErrorJob = null
+        previewPlayerEngine?.stop()
+        previewPlayerEngine?.release()
+        previewPlayerEngine = engine
+        (engine as? com.streamvault.player.Media3PlayerEngine)?.let {
+            it.enableMediaSession = false
+            it.bypassAudioFocus = true
+        }
+        engine.play()
+        livePreviewHandoffManager.registerPreviewSession(
+            channelId = session.channelId,
+            providerId = session.providerId,
+            streamInfo = session.streamInfo,
+            engine = engine,
+            source = PreviewHandoffSource.GUIDE
+        )
+        _uiState.update {
+            it.copy(
+                previewChannelId = session.channelId,
+                previewPlayerEngine = engine,
+                isPreviewLoading = false,
+                previewErrorMessage = null
+            )
+        }
+        previewPlaybackJob = viewModelScope.launch {
+            engine.playbackState.collectLatest { state ->
+                if (!isActivePreviewSession(version, session.channelId)) return@collectLatest
+                if (state == PlaybackState.ERROR && _uiState.value.previewErrorMessage == null) {
+                    _uiState.update { it.copy(previewErrorMessage = appContext.getString(R.string.live_preview_failed)) }
+                }
+            }
+        }
+    }
+
+    fun clearPreview() {
+        val engine = previewPlayerEngine ?: return
+        previewSessionVersion++
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        previewPlaybackJob = null
+        previewErrorJob = null
+        livePreviewHandoffManager.clear(engine)
+        engine.stop()
+        engine.release()
+        previewPlayerEngine = null
+        _uiState.update {
+            it.copy(
+                previewChannelId = null,
+                previewPlayerEngine = null,
+                isPreviewLoading = false,
+                previewErrorMessage = null
+            )
+        }
+    }
+
+    /**
+     * Call before navigating to the fullscreen player. If `channel` matches the current preview,
+     * hands the engine off; otherwise releases the preview so two streams can't run in parallel.
+     */
+    fun handoffOrClearForFullscreen(channel: Channel) {
+        if (!beginPreviewHandoff(channel)) clearPreview()
+    }
+
+    private fun isActivePreviewSession(version: Long, channelId: Long): Boolean =
+        version == previewSessionVersion && _uiState.value.previewChannelId == channelId
+
+    override fun onCleared() {
+        super.onCleared()
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        previewPlayerEngine?.stop()
+        previewPlayerEngine?.release()
+        previewPlayerEngine = null
+    }
 
     fun unlockCategory(categoryId: Long) {
         val providerId = baseGuideSnapshot.value?.providerId?.takeIf { it > 0L } ?: return

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeScreen.kt
@@ -224,6 +224,19 @@ fun HomeScreen(
         }
     }
 
+    val hasActivePreview = uiState.previewPlayerEngine != null
+    DisposableEffect(hasActivePreview) {
+        val window = (context as? android.app.Activity)?.window
+        if (hasActivePreview) {
+            window?.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        onDispose {
+            if (hasActivePreview) {
+                window?.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+    }
+
         val hasOverlay = showPinDialog || showSplitManagerDialog || pendingSplitPlannerChannel != null ||
         showAddQuickFilterDialog || showHiddenCategoriesDialog || showHiddenChannelsDialog ||
         uiState.showDialog || uiState.showDeleteGroupDialog ||

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeSidebarComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeSidebarComponents.kt
@@ -155,7 +155,7 @@ internal fun LivePreviewPane(
                     .background(Color.Black, RoundedCornerShape(16.dp)),
                 contentAlignment = Alignment.Center
             ) {
-                if (channel != null && playerEngine != null && errorMessage == null) {
+                if (playerEngine != null && errorMessage == null) {
                     PlayerRenderView(
                         playerEngine = playerEngine,
                         resizeMode = PlayerSurfaceResizeMode.FIT,

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.streamvault.app.di.AuxiliaryPlayerEngine
 import com.streamvault.app.player.LivePreviewHandoffManager
+import com.streamvault.app.player.PreviewHandoffSource
 import com.streamvault.app.plugins.StreamVaultPluginManager
 import com.streamvault.app.tvinput.TvInputChannelSyncManager
 import com.streamvault.app.ui.screens.multiview.MultiViewManager
@@ -118,6 +119,13 @@ class HomeViewModel @Inject constructor(
 
     init {
         loadAllProviders()
+        viewModelScope.launch {
+            livePreviewHandoffManager.reverseSessionFlow.collect { session ->
+                if (session != null && session.source == PreviewHandoffSource.HOME) {
+                    resumePreviewFromHandoff()
+                }
+            }
+        }
         viewModelScope.launch {
             combine(
                 multiViewManager.slots,
@@ -1057,7 +1065,8 @@ class HomeViewModel @Inject constructor(
                     livePreviewHandoffManager.registerPreviewSession(
                         channel = channel,
                         streamInfo = preparedStreamInfo,
-                        engine = engine
+                        engine = engine,
+                        source = PreviewHandoffSource.HOME
                     )
                     scheduleAdaptivePreviewReprime(
                         previewVersion = previewVersion,
@@ -1126,6 +1135,50 @@ class HomeViewModel @Inject constructor(
             )
         }
         return true
+    }
+
+    fun resumePreviewFromHandoff() {
+        val session = livePreviewHandoffManager.consumeReverseHandoff(PreviewHandoffSource.HOME) ?: return
+        val engine = session.engine
+        previewSessionVersion++
+        val version = previewSessionVersion
+        previewPlaybackJob?.cancel()
+        previewErrorJob?.cancel()
+        previewPlaybackJob = null
+        previewErrorJob = null
+        previewPlayerEngine?.stop()
+        previewPlayerEngine?.release()
+        previewPlayerEngine = engine
+        // Restore auxiliary-engine defaults that the fullscreen handoff flipped.
+        (engine as? com.streamvault.player.Media3PlayerEngine)?.let {
+            it.enableMediaSession = false
+            it.bypassAudioFocus = true
+        }
+        engine.play()
+        // Re-register the forward-handoff slot so a subsequent click can open fullscreen again.
+        livePreviewHandoffManager.registerPreviewSession(
+            channelId = session.channelId,
+            providerId = session.providerId,
+            streamInfo = session.streamInfo,
+            engine = engine,
+            source = PreviewHandoffSource.HOME
+        )
+        _uiState.update {
+            it.copy(
+                previewChannelId = session.channelId,
+                previewPlayerEngine = engine,
+                isPreviewLoading = false,
+                previewErrorMessage = null
+            )
+        }
+        previewPlaybackJob = viewModelScope.launch {
+            engine.playbackState.collectLatest { state ->
+                if (!isActivePreviewSession(version, session.channelId)) return@collectLatest
+                if (state == PlaybackState.ERROR && _uiState.value.previewErrorMessage == null) {
+                    _uiState.update { it.copy(previewErrorMessage = appContext.getString(R.string.live_preview_failed)) }
+                }
+            }
+        }
     }
 
     fun clearPreview() {

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerLifecycleActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerLifecycleActions.kt
@@ -3,6 +3,7 @@ package com.streamvault.app.ui.screens.player
 import androidx.lifecycle.viewModelScope
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.ProviderType
+import com.streamvault.player.PlaybackState
 import com.streamvault.player.PlayerEngine
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -175,11 +176,32 @@ internal fun PlayerViewModel.cleanupAfterCleared(mainPlayerEngine: PlayerEngine)
     inFlightThumbnailPreloadKey = null
     lastCompletedThumbnailPreloadKey = null
     seekThumbnailProvider.clearCache()
-    livePreviewHandoffManager.clear(playerEngine)
-    if (playerEngine === mainPlayerEngine) {
+
+    val activeEngine = playerEngine
+    val channel = currentChannel.value
+    val streamInfo = currentResolvedStreamInfo
+    val canReverseHandoff = currentContentType == ContentType.LIVE
+        && !isCatchUpPlayback.value
+        && activeEngine !== mainPlayerEngine
+        && channel != null
+        && streamInfo != null
+        && activeEngine.playbackState.value != PlaybackState.ERROR
+
+    if (canReverseHandoff) {
+        livePreviewHandoffManager.beginReverseHandoff(
+            channel = channel!!,
+            streamInfo = streamInfo!!,
+            engine = activeEngine,
+            source = adoptedHandoffSource ?: com.streamvault.app.player.PreviewHandoffSource.HOME
+        )
         mainPlayerEngine.resetForReuse()
     } else {
-        playerEngine.release()
-        mainPlayerEngine.resetForReuse()
+        livePreviewHandoffManager.clear(activeEngine)
+        if (activeEngine === mainPlayerEngine) {
+            mainPlayerEngine.resetForReuse()
+        } else {
+            activeEngine.release()
+            mainPlayerEngine.resetForReuse()
+        }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
@@ -250,6 +250,7 @@ class PlayerViewModel @Inject constructor(
     internal var currentArtworkUrl: String? = null
     internal var currentResolvedPlaybackUrl: String = ""
     internal var currentResolvedStreamInfo: StreamInfo? = null
+    internal var adoptedHandoffSource: com.streamvault.app.player.PreviewHandoffSource? = null
     internal var pendingCatchUpUrls: List<String> = emptyList()
     internal var channelNumberingMode: ChannelNumberingMode = ChannelNumberingMode.GROUP
         set(value) {
@@ -1075,6 +1076,7 @@ class PlayerViewModel @Inject constructor(
             providerId = providerId.takeIf { it > 0L }
         ) ?: return false
 
+        adoptedHandoffSource = session.source
         val adoptedEngine = session.engine
         return runCatching {
             val shouldRenewAdoptedPreview = shouldRenewAdoptedPreviewOnFullscreen(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSection.kt
@@ -126,5 +126,126 @@ internal fun LazyListScope.epgSourcesSection(
             )
         }
     }
+
+    if (providers.isNotEmpty()) {
+        item {
+            Text(
+                text = "EPG Time Shift",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color(0xFF66BB6A),
+                modifier = Modifier.padding(top = 24.dp, bottom = 8.dp)
+            )
+            Text(
+                text = "Adjust EPG times if they're consistently off from broadcast time (e.g., wrong timezone in the provider's data). Negative values shift programs earlier; positive shift them later.",
+                style = MaterialTheme.typography.bodySmall,
+                color = OnSurfaceDim,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+        items(providers, key = { provider -> "epg-shift-${provider.id}" }) { provider ->
+            val shiftMinutes = uiState.epgTimeShiftMinutesByProvider[provider.id] ?: 0
+            EpgTimeShiftCard(
+                providerName = provider.name,
+                shiftMinutes = shiftMinutes,
+                onAdjust = { delta -> viewModel.adjustEpgTimeShift(provider.id, delta) },
+                onReset = { viewModel.resetEpgTimeShift(provider.id) }
+            )
+        }
+    }
+}
+
+@Composable
+private fun EpgTimeShiftCard(
+    providerName: String,
+    shiftMinutes: Int,
+    onAdjust: (Int) -> Unit,
+    onReset: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Color(0xFF1A1A1A))
+            .padding(16.dp)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = providerName,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Text(
+                    text = formatShiftLabel(shiftMinutes),
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (shiftMinutes == 0) OnSurfaceDim else Primary,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp)
+            ) {
+                ShiftAdjustButton("−1h", onClick = { onAdjust(-60) })
+                ShiftAdjustButton("−30m", onClick = { onAdjust(-30) })
+                ShiftAdjustButton("−15m", onClick = { onAdjust(-15) })
+                ShiftAdjustButton("−5m", onClick = { onAdjust(-5) })
+                ShiftAdjustButton("Reset", onClick = onReset, enabled = shiftMinutes != 0)
+                ShiftAdjustButton("+5m", onClick = { onAdjust(5) })
+                ShiftAdjustButton("+15m", onClick = { onAdjust(15) })
+                ShiftAdjustButton("+30m", onClick = { onAdjust(30) })
+                ShiftAdjustButton("+1h", onClick = { onAdjust(60) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun ShiftAdjustButton(
+    label: String,
+    onClick: () -> Unit,
+    enabled: Boolean = true
+) {
+    TvClickableSurface(
+        onClick = onClick,
+        enabled = enabled,
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = Color(0xFF262626),
+            focusedContainerColor = Primary,
+            disabledContainerColor = Color(0xFF1A1A1A)
+        ),
+        border = ClickableSurfaceDefaults.border(
+            focusedBorder = Border(
+                border = androidx.compose.foundation.BorderStroke(2.dp, Primary)
+            )
+        )
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.labelMedium,
+            color = if (enabled) Color.White else OnSurfaceDim
+        )
+    }
+}
+
+private fun formatShiftLabel(minutes: Int): String {
+    if (minutes == 0) return "No shift"
+    val sign = if (minutes < 0) "−" else "+"
+    val abs = kotlin.math.abs(minutes)
+    val hours = abs / 60
+    val mins = abs % 60
+    return when {
+        hours > 0 && mins > 0 -> "$sign${hours}h ${mins}m"
+        hours > 0 -> "$sign${hours}h"
+        else -> "$sign${mins}m"
+    }
 }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsObserverRegistrations.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsObserverRegistrations.kt
@@ -126,11 +126,17 @@ internal fun registerRecordingObservers(
 internal fun registerEpgObservers(
     scope: CoroutineScope,
     epgSourceRepository: EpgSourceRepository,
+    preferencesRepository: PreferencesRepository,
     uiState: MutableStateFlow<SettingsUiState>
 ) {
     scope.launch {
         epgSourceRepository.getAllSources().collect { sources ->
             uiState.update { it.copy(epgSources = sources) }
+        }
+    }
+    scope.launch {
+        preferencesRepository.epgTimeShiftsByProvider.collect { map ->
+            uiState.update { it.copy(epgTimeShiftMinutesByProvider = map) }
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -131,6 +131,7 @@ data class SettingsUiState(
     val epgResolutionSummaries: Map<Long, EpgResolutionSummary> = emptyMap(),
     val refreshingEpgSourceIds: Set<Long> = emptySet(),
     val epgPendingDeleteSourceId: Long? = null,
+    val epgTimeShiftMinutesByProvider: Map<Long, Int> = emptyMap(),
     val autoCheckAppUpdates: Boolean = true,
     val autoDownloadAppUpdates: Boolean = false,
     val isCheckingForUpdates: Boolean = false,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -210,6 +210,7 @@ class SettingsViewModel @Inject constructor(
         registerEpgObservers(
             scope = viewModelScope,
             epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository,
             uiState = _uiState
         )
         driveBackupActions.observeAuthState(viewModelScope)
@@ -1047,6 +1048,20 @@ class SettingsViewModel @Inject constructor(
 
     fun refreshEpgSource(sourceId: Long) {
         epgActions.refreshEpgSource(viewModelScope, sourceId)
+    }
+
+    fun adjustEpgTimeShift(providerId: Long, deltaMinutes: Int) {
+        viewModelScope.launch {
+            val current = _uiState.value.epgTimeShiftMinutesByProvider[providerId] ?: 0
+            val next = (current + deltaMinutes).coerceIn(-720, 720)
+            preferencesRepository.setEpgTimeShiftMinutes(providerId, next)
+        }
+    }
+
+    fun resetEpgTimeShift(providerId: Long) {
+        viewModelScope.launch {
+            preferencesRepository.setEpgTimeShiftMinutes(providerId, 0)
+        }
     }
 
     fun assignEpgSourceToProvider(providerId: Long, epgSourceId: Long) {

--- a/app/src/test/java/com/streamvault/app/player/LivePreviewHandoffManagerTest.kt
+++ b/app/src/test/java/com/streamvault/app/player/LivePreviewHandoffManagerTest.kt
@@ -68,6 +68,109 @@ class LivePreviewHandoffManagerTest {
         verify(engine).release()
     }
 
+    @Test
+    fun `reverse handoff session is visible on flow after beginReverseHandoff`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.GUIDE)
+
+        assertThat(manager.reverseSessionFlow.value).isNotNull()
+        assertThat(manager.reverseSessionFlow.value?.engine).isSameInstanceAs(engine)
+        assertThat(manager.reverseSessionFlow.value?.source).isEqualTo(PreviewHandoffSource.GUIDE)
+    }
+
+    @Test
+    fun `consumeReverseHandoff without filter returns any session`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.HOME)
+
+        val session = manager.consumeReverseHandoff()
+        assertThat(session).isNotNull()
+        assertThat(session?.engine).isSameInstanceAs(engine)
+        assertThat(manager.reverseSessionFlow.value).isNull()
+    }
+
+    @Test
+    fun `consumeReverseHandoff for HOME ignores GUIDE session`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.GUIDE)
+
+        assertThat(manager.consumeReverseHandoff(PreviewHandoffSource.HOME)).isNull()
+        assertThat(manager.reverseSessionFlow.value).isNotNull()
+    }
+
+    @Test
+    fun `consumeReverseHandoff for GUIDE ignores HOME session`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.HOME)
+
+        assertThat(manager.consumeReverseHandoff(PreviewHandoffSource.GUIDE)).isNull()
+        assertThat(manager.reverseSessionFlow.value).isNotNull()
+    }
+
+    @Test
+    fun `consumeReverseHandoff for GUIDE returns GUIDE session`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.GUIDE)
+
+        val session = manager.consumeReverseHandoff(PreviewHandoffSource.GUIDE)
+        assertThat(session).isNotNull()
+        assertThat(session?.engine).isSameInstanceAs(engine)
+        assertThat(manager.reverseSessionFlow.value).isNull()
+        verifyNoInteractions(engine)
+    }
+
+    @Test
+    fun `reverse handoff engine is released when never consumed`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.HOME)
+
+        advanceTimeBy(15_001L)
+        testDispatcher.scheduler.runCurrent()
+
+        assertThat(manager.reverseSessionFlow.value).isNull()
+        verify(engine).release()
+    }
+
+    @Test
+    fun `consuming reverse handoff prevents engine release`() = runTest(testDispatcher) {
+        val manager = LivePreviewHandoffManager()
+        val engine = mock<PlayerEngine>()
+        val channel = channel(id = 1L, providerId = 2L)
+        val streamInfo = StreamInfo(url = "https://example.com/live.m3u8", title = channel.name)
+
+        manager.beginReverseHandoff(channel, streamInfo, engine, PreviewHandoffSource.GUIDE)
+        manager.consumeReverseHandoff(PreviewHandoffSource.GUIDE)
+
+        advanceTimeBy(15_001L)
+        testDispatcher.scheduler.runCurrent()
+
+        verifyNoInteractions(engine)
+    }
+
     private fun channel(id: Long, providerId: Long): Channel = Channel(
         id = id,
         name = "Preview $id",

--- a/app/src/test/java/com/streamvault/app/ui/screens/epg/EpgViewModelTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/epg/EpgViewModelTest.kt
@@ -2,11 +2,15 @@ package com.streamvault.app.ui.screens.epg
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import android.app.Application
 import androidx.lifecycle.ViewModel
+import com.streamvault.app.player.LivePreviewHandoffManager
+import com.streamvault.app.plugins.StreamVaultPluginManager
 import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.domain.manager.ParentalControlManager
 import com.streamvault.domain.manager.ProgramReminderManager
 import com.streamvault.domain.manager.RecordingManager
+import com.streamvault.player.PlayerEngine
 import com.streamvault.domain.model.Category
 import com.streamvault.domain.model.CategorySortMode
 import com.streamvault.domain.model.Channel
@@ -30,6 +34,7 @@ import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.usecase.GetCustomCategories
 import com.streamvault.domain.usecase.ScheduleRecording
 import kotlinx.coroutines.Dispatchers
+import javax.inject.Provider as InjectProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
@@ -66,6 +71,11 @@ class EpgViewModelTest {
     private val programReminderManager: ProgramReminderManager = mock()
     private val scheduleRecording: ScheduleRecording = mock()
     private val recordingManager: RecordingManager = mock()
+    private val livePreviewHandoffManager: LivePreviewHandoffManager = mock()
+    private val pluginManager: StreamVaultPluginManager = mock()
+    private val playerEngine: PlayerEngine = mock()
+    private val playerEngineProvider: InjectProvider<PlayerEngine> = mock()
+    private val application: Application = mock()
     private val getCustomCategories by lazy { GetCustomCategories(favoriteRepository) }
     private val createdViewModels = mutableListOf<EpgViewModel>()
 
@@ -74,6 +84,7 @@ class EpgViewModelTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        whenever(playerEngineProvider.get()).thenReturn(playerEngine)
         whenever(providerRepository.getActiveProvider()).thenReturn(flowOf(null))
         whenever(preferencesRepository.parentalControlLevel).thenReturn(flowOf(0))
         whenever(preferencesRepository.showAllChannelsCategory).thenReturn(flowOf(true))
@@ -126,7 +137,11 @@ class EpgViewModelTest {
             programReminderManager = programReminderManager,
             getCustomCategories = getCustomCategories,
             scheduleRecording = scheduleRecording,
-            recordingManager = recordingManager
+            recordingManager = recordingManager,
+            playerEngineProvider = playerEngineProvider,
+            pluginManager = pluginManager,
+            livePreviewHandoffManager = livePreviewHandoffManager,
+            application = application
         ).also(createdViewModels::add)
 
     private fun clearViewModel(viewModel: EpgViewModel) {

--- a/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
+++ b/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
@@ -109,6 +109,7 @@ class PreferencesRepository @Inject constructor(
         val GUIDE_DEFAULT_CATEGORY_ID = longPreferencesKey("guide_default_category_id")
         val GUIDE_FAVORITES_ONLY = intPreferencesKey("guide_favorites_only")
         val GUIDE_ANCHOR_TIME = longPreferencesKey("guide_anchor_time")
+        val EPG_TIME_SHIFT_BY_PROVIDER = stringPreferencesKey("epg_time_shift_by_provider")
         val PROMOTED_LIVE_GROUP_IDS = stringPreferencesKey("promoted_live_group_ids")
         val MULTIVIEW_PRESET_1 = stringPreferencesKey("multiview_preset_1")
         val MULTIVIEW_PRESET_2 = stringPreferencesKey("multiview_preset_2")
@@ -1399,6 +1400,45 @@ class PreferencesRepository @Inject constructor(
     suspend fun setGuideAnchorTime(anchorTimeMs: Long) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.GUIDE_ANCHOR_TIME] = anchorTimeMs
+        }
+    }
+
+    private fun decodeEpgTimeShifts(raw: String?): Map<Long, Int> {
+        if (raw.isNullOrBlank()) return emptyMap()
+        return raw.split(",").mapNotNull { token ->
+            val parts = token.split(":")
+            if (parts.size != 2) return@mapNotNull null
+            val id = parts[0].toLongOrNull() ?: return@mapNotNull null
+            val minutes = parts[1].toIntOrNull() ?: return@mapNotNull null
+            id to minutes
+        }.toMap()
+    }
+
+    private fun encodeEpgTimeShifts(map: Map<Long, Int>): String =
+        map.entries
+            .filter { it.value != 0 }
+            .joinToString(",") { "${it.key}:${it.value}" }
+
+    val epgTimeShiftsByProvider: Flow<Map<Long, Int>> = context.dataStore.data.map { prefs ->
+        decodeEpgTimeShifts(prefs[PreferencesKeys.EPG_TIME_SHIFT_BY_PROVIDER])
+    }
+
+    fun epgTimeShiftMinutes(providerId: Long): Flow<Int> =
+        epgTimeShiftsByProvider.map { it[providerId] ?: 0 }
+
+    suspend fun getEpgTimeShiftMinutes(providerId: Long): Int =
+        epgTimeShiftsByProvider.first()[providerId] ?: 0
+
+    suspend fun setEpgTimeShiftMinutes(providerId: Long, minutes: Int) {
+        context.dataStore.edit { prefs ->
+            val current = decodeEpgTimeShifts(prefs[PreferencesKeys.EPG_TIME_SHIFT_BY_PROVIDER]).toMutableMap()
+            if (minutes == 0) current.remove(providerId) else current[providerId] = minutes
+            val encoded = encodeEpgTimeShifts(current)
+            if (encoded.isEmpty()) {
+                prefs.remove(PreferencesKeys.EPG_TIME_SHIFT_BY_PROVIDER)
+            } else {
+                prefs[PreferencesKeys.EPG_TIME_SHIFT_BY_PROVIDER] = encoded
+            }
         }
     }
 

--- a/data/src/main/java/com/streamvault/data/repository/EpgRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/EpgRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.streamvault.data.local.DatabaseTransactionRunner
 import com.streamvault.data.local.dao.ProgramDao
 import com.streamvault.data.local.dao.ProviderDao
+import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.data.local.entity.ProgramBrowseEntity
 import com.streamvault.data.local.entity.ProgramEntity
 import com.streamvault.data.mapper.toDomain
@@ -56,8 +57,19 @@ class EpgRepositoryImpl @Inject constructor(
     private val okHttpClient: OkHttpClient,
     private val transactionRunner: DatabaseTransactionRunner,
     private val epgSourceRepository: EpgSourceRepository,
+    private val preferencesRepository: PreferencesRepository,
     private val externalScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) : EpgRepository {
+
+    private suspend fun shiftMsFor(providerId: Long): Long =
+        preferencesRepository.getEpgTimeShiftMinutes(providerId) * 60_000L
+
+    private fun Program.shifted(offsetMs: Long): Program =
+        if (offsetMs == 0L) this
+        else copy(startTime = startTime + offsetMs, endTime = endTime + offsetMs)
+
+    private fun List<Program>.shiftAll(offsetMs: Long): List<Program> =
+        if (offsetMs == 0L) this else map { it.shifted(offsetMs) }
 
     private val providerRefreshMutexes = ConcurrentHashMap<Long, Mutex>()
 
@@ -86,8 +98,11 @@ class EpgRepositoryImpl @Inject constructor(
         startTime: Long,
         endTime: Long
     ): Flow<List<Program>> =
-        programDao.getForChannel(providerId, channelId, startTime, endTime)
-            .map { entities -> entities.map { it.toDomain() } }
+        preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            programDao.getForChannel(providerId, channelId, startTime - offsetMs, endTime - offsetMs)
+                .map { entities -> entities.map { it.toDomain().shifted(offsetMs) } }
+        }
 
     override fun getProgramsForChannels(
         providerId: Long,
@@ -98,8 +113,11 @@ class EpgRepositoryImpl @Inject constructor(
         if (channelIds.isEmpty()) return flowOf(emptyMap())
         val chunks = channelIds.chunked(500)
         if (chunks.size == 1) {
-            return programDao.getForChannels(providerId, channelIds, startTime, endTime)
-                .map { entities -> entities.map { it.toDomain() }.groupBy { it.channelId } }
+            return preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+                val offsetMs = minutes * 60_000L
+                programDao.getForChannels(providerId, channelIds, startTime - offsetMs, endTime - offsetMs)
+                    .map { entities -> entities.map { it.toDomain().shifted(offsetMs) }.groupBy { it.channelId } }
+            }
         }
         return flow {
             emit(getProgramsForChannelsSnapshot(providerId, channelIds, startTime, endTime))
@@ -114,16 +132,20 @@ class EpgRepositoryImpl @Inject constructor(
     ): Map<String, List<Program>> {
         if (channelIds.isEmpty()) return emptyMap()
 
+        val offsetMs = shiftMsFor(providerId)
+        val adjustedStart = startTime - offsetMs
+        val adjustedEnd = endTime - offsetMs
+
         val entities = if (channelIds.size <= 500) {
-            programDao.getForChannelsSync(providerId, channelIds, startTime, endTime)
+            programDao.getForChannelsSync(providerId, channelIds, adjustedStart, adjustedEnd)
         } else {
             channelIds.chunked(500).flatMap { chunk ->
-                programDao.getForChannelsSync(providerId, chunk, startTime, endTime)
+                programDao.getForChannelsSync(providerId, chunk, adjustedStart, adjustedEnd)
             }
         }
 
         return entities
-            .map { it.toDomain() }
+            .map { it.toDomain().shifted(offsetMs) }
             .groupBy { it.channelId }
     }
 
@@ -133,8 +155,11 @@ class EpgRepositoryImpl @Inject constructor(
         startTime: Long,
         endTime: Long
     ): Flow<List<Program>> =
-        programDao.getForCategory(providerId, categoryId, startTime, endTime)
-            .map { entities -> entities.map { it.toDomain() } }
+        preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            programDao.getForCategory(providerId, categoryId, startTime - offsetMs, endTime - offsetMs)
+                .map { entities -> entities.map { it.toDomain().shifted(offsetMs) } }
+        }
 
     override fun searchPrograms(
         providerId: Long,
@@ -147,38 +172,48 @@ class EpgRepositoryImpl @Inject constructor(
         val normalizedQuery = query.trim()
         if (normalizedQuery.length < 2) return flowOf(emptyList())
         val escaped = normalizedQuery.escapeSqlLike()
-        return programDao.searchPrograms(
-            providerId = providerId,
-            queryPattern = "%$escaped%",
-            startTime = startTime,
-            endTime = endTime,
-            categoryId = categoryId,
-            limit = limit
-        ).map { entities ->
-            entities.map { it.toDomain() }
-                .rankSearchResults(normalizedQuery) { it.title }
+        return preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            programDao.searchPrograms(
+                providerId = providerId,
+                queryPattern = "%$escaped%",
+                startTime = startTime - offsetMs,
+                endTime = endTime - offsetMs,
+                categoryId = categoryId,
+                limit = limit
+            ).map { entities ->
+                entities.map { it.toDomain().shifted(offsetMs) }
+                    .rankSearchResults(normalizedQuery) { it.title }
+            }
         }
     }
 
     override fun getNowPlaying(providerId: Long, channelId: String): Flow<Program?> =
-        nowTicker.flatMapLatest { now ->
-            programDao.getNowPlaying(providerId, channelId, now)
-                .map { it?.toDomain() }
+        preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            nowTicker.flatMapLatest { realNow ->
+                programDao.getNowPlaying(providerId, channelId, realNow - offsetMs)
+                    .map { it?.toDomain()?.shifted(offsetMs) }
+            }
         }
 
     override fun getNowPlayingForChannels(providerId: Long, channelIds: List<String>): Flow<Map<String, Program?>> {
         if (channelIds.isEmpty()) return flowOf(emptyMap())
 
         val chunks = channelIds.chunked(500)
-        return nowTicker.flatMapLatest { now ->
-            if (chunks.size == 1) {
-                programDao.getNowPlayingForChannels(providerId, channelIds, now)
-                    .map { entities -> mapNowPlayingByChannel(channelIds, entities) }
-            } else {
-                combine(chunks.map { chunk ->
-                    programDao.getNowPlayingForChannels(providerId, chunk, now)
-                }) { arrays ->
-                    mapNowPlayingByChannel(channelIds, arrays.flatMap { it.toList() })
+        return preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            nowTicker.flatMapLatest { realNow ->
+                val now = realNow - offsetMs
+                if (chunks.size == 1) {
+                    programDao.getNowPlayingForChannels(providerId, channelIds, now)
+                        .map { entities -> mapNowPlayingByChannel(channelIds, entities, offsetMs) }
+                } else {
+                    combine(chunks.map { chunk ->
+                        programDao.getNowPlayingForChannels(providerId, chunk, now)
+                    }) { arrays ->
+                        mapNowPlayingByChannel(channelIds, arrays.flatMap { it.toList() }, offsetMs)
+                    }
                 }
             }
         }
@@ -190,7 +225,8 @@ class EpgRepositoryImpl @Inject constructor(
     ): Map<String, Program?> {
         if (channelIds.isEmpty()) return emptyMap()
 
-        val now = System.currentTimeMillis()
+        val offsetMs = shiftMsFor(providerId)
+        val now = System.currentTimeMillis() - offsetMs
         val entities = if (channelIds.size <= 500) {
             programDao.getNowPlayingForChannelsSync(providerId, channelIds, now)
         } else {
@@ -199,23 +235,27 @@ class EpgRepositoryImpl @Inject constructor(
             }
         }
 
-        val grouped = entities.map { it.toDomain() }.groupBy { it.channelId }
+        val grouped = entities.map { it.toDomain().shifted(offsetMs) }.groupBy { it.channelId }
         return channelIds.associateWith { id -> grouped[id]?.firstOrNull() }
     }
 
     override fun getNowAndNext(providerId: Long, channelId: String): Flow<Pair<Program?, Program?>> =
-        nowTicker.flatMapLatest { now ->
-            programDao.getForChannel(
-                providerId = providerId,
-                channelId = channelId,
-                startTime = now - NOW_AND_NEXT_LOOKBACK_MS,
-                endTime = now + NOW_AND_NEXT_LOOKAHEAD_MS
-            ).map { entities ->
-                val programs = entities.map { it.toDomain() }
-                val current = programs.find { it.startTime <= now && it.endTime > now }
-                val nextStart = current?.endTime ?: now
-                val next = programs.firstOrNull { it.startTime >= nextStart && it != current }
-                current to next
+        preferencesRepository.epgTimeShiftMinutes(providerId).flatMapLatest { minutes ->
+            val offsetMs = minutes * 60_000L
+            nowTicker.flatMapLatest { realNow ->
+                val now = realNow - offsetMs
+                programDao.getForChannel(
+                    providerId = providerId,
+                    channelId = channelId,
+                    startTime = now - NOW_AND_NEXT_LOOKBACK_MS,
+                    endTime = now + NOW_AND_NEXT_LOOKAHEAD_MS
+                ).map { entities ->
+                    val programs = entities.map { it.toDomain() }
+                    val current = programs.find { it.startTime <= now && it.endTime > now }
+                    val nextStart = current?.endTime ?: now
+                    val next = programs.firstOrNull { it.startTime >= nextStart && it != current }
+                    current?.shifted(offsetMs) to next?.shifted(offsetMs)
+                }
             }
         }
 
@@ -323,8 +363,12 @@ class EpgRepositoryImpl @Inject constructor(
         channelIds: List<Long>,
         startTime: Long,
         endTime: Long
-    ): Map<String, List<Program>> =
-        epgSourceRepository.getResolvedProgramsForChannels(providerId, channelIds, startTime, endTime)
+    ): Map<String, List<Program>> {
+        val offsetMs = shiftMsFor(providerId)
+        return epgSourceRepository.getResolvedProgramsForChannels(
+            providerId, channelIds, startTime - offsetMs, endTime - offsetMs
+        ).mapValues { (_, programs) -> programs.shiftAll(offsetMs) }
+    }
 
     override suspend fun getResolvedProgramsForPlaybackChannel(
         providerId: Long,
@@ -336,20 +380,22 @@ class EpgRepositoryImpl @Inject constructor(
     ): List<Program> {
         val normalizedChannelId = epgChannelId?.trim()?.takeIf { it.isNotEmpty() }
         val lookupKey = normalizedChannelId ?: streamId.takeIf { it > 0L }?.toString()
+        val offsetMs = shiftMsFor(providerId)
 
         if (internalChannelId > 0L && lookupKey != null) {
             val resolvedPrograms = epgSourceRepository.getResolvedProgramsForChannels(
                 providerId = providerId,
                 channelIds = listOf(internalChannelId),
-                startTime = startTime,
-                endTime = endTime
+                startTime = startTime - offsetMs,
+                endTime = endTime - offsetMs
             )[lookupKey].orEmpty()
             if (resolvedPrograms.isNotEmpty()) {
-                return resolvedPrograms.sortedBy { it.startTime }
+                return resolvedPrograms.shiftAll(offsetMs).sortedBy { it.startTime }
             }
         }
 
         if (normalizedChannelId != null) {
+            // getProgramsForChannel already applies the offset internally.
             return getProgramsForChannel(providerId, normalizedChannelId, startTime, endTime)
                 .first()
                 .sortedBy { it.startTime }
@@ -367,9 +413,10 @@ class EpgRepositoryImpl @Inject constructor(
 
     private fun mapNowPlayingByChannel(
         channelIds: List<String>,
-        entities: List<ProgramBrowseEntity>
+        entities: List<ProgramBrowseEntity>,
+        offsetMs: Long = 0L
     ): Map<String, Program?> {
-        val grouped = entities.map { it.toDomain() }.groupBy { it.channelId }
+        val grouped = entities.map { it.toDomain().shifted(offsetMs) }.groupBy { it.channelId }
         return channelIds.associateWith { id -> grouped[id]?.firstOrNull() }
     }
 

--- a/data/src/test/java/com/streamvault/data/repository/EpgRepositoryImplTest.kt
+++ b/data/src/test/java/com/streamvault/data/repository/EpgRepositoryImplTest.kt
@@ -38,6 +38,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
+import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.domain.repository.EpgSourceRepository
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -53,6 +54,7 @@ class EpgRepositoryImplTest {
     private val providerDao: ProviderDao = mock()
     private val xmltvParser: XmltvParser = mock()
     private val epgSourceRepository: EpgSourceRepository = mock()
+    private val preferencesRepository: PreferencesRepository = mock()
     private val transactionRunner = object : DatabaseTransactionRunner {
         override suspend fun <T> inTransaction(block: suspend () -> T): T = block()
     }
@@ -64,6 +66,7 @@ class EpgRepositoryImplTest {
         }
         runBlocking {
             whenever(providerDao.getById(any())).thenReturn(null)
+            whenever(preferencesRepository.getEpgTimeShiftMinutes(any())).thenReturn(0)
         }
     }
 
@@ -98,7 +101,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.searchPrograms(7L, "sports", 0L, 100L).first()
@@ -133,7 +137,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.getResolvedProgramsForPlaybackChannel(
@@ -179,7 +184,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.getResolvedProgramsForPlaybackChannel(
@@ -241,7 +247,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val firstRefresh = async { repository.refreshEpg(7L, "https://example.com/epg.xml") }
@@ -283,7 +290,8 @@ class EpgRepositoryImplTest {
                 contentType = "application/gzip"
             ),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml.gz")
@@ -314,7 +322,8 @@ class EpgRepositoryImplTest {
                 headers = mapOf("Content-Encoding" to "gzip")
             ),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml.gz")
@@ -337,7 +346,8 @@ class EpgRepositoryImplTest {
                 onRequest = { requestRef.set(it) }
             ),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml")
@@ -378,6 +388,7 @@ class EpgRepositoryImplTest {
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
             epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository,
             externalScope = backgroundScope
         )
 
@@ -447,6 +458,7 @@ class EpgRepositoryImplTest {
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
             epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository,
             externalScope = backgroundScope
         )
 
@@ -498,7 +510,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.getProgramsForChannelsSnapshot(
@@ -534,7 +547,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml")
@@ -590,7 +604,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = trackingTransactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml")
@@ -637,7 +652,8 @@ class EpgRepositoryImplTest {
             xmltvParser = xmltvParser,
             okHttpClient = okHttpClientReturningXml(),
             transactionRunner = transactionRunner,
-            epgSourceRepository = epgSourceRepository
+            epgSourceRepository = epgSourceRepository,
+            preferencesRepository = preferencesRepository
         )
 
         val result = repository.refreshEpg(7L, "https://example.com/epg.xml")


### PR DESCRIPTION
What's in this PR

  Live preview in the Guide

  The Guide now has a live video preview pane at the top (replacing the old static channel-info
  block). Single-clicking a channel starts streaming it in the preview; clicking the same
  channel a second time goes fullscreen. Long-pressing a channel opens the options menu (Watch
  Live, Watch Archive, Record, etc.).

  Preview stays alive when returning from fullscreen

  Fixed a bug where backing out of fullscreen from the Guide would leave the preview showing a
  black placeholder ("select a channel to preview") while audio continued playing in the
  background. The stream now correctly resumes in the preview pane.

  Screensaver suppression during preview

  Fire TV no longer dims or screensavers while a live preview is active — both in the Home
  sidebar and the Guide preview pane.

  Guide timeline alignment

  Fixed the timeline markers in the Guide grid. Previously they would land on arbitrary times
  like 7:48, 8:18, 8:48 depending on when the Guide was opened. They now always align to clean
  :00 / :30 boundaries.

  Guide timeline cleanup

  Removed the redundant "Timeline / 7h window" header row and "Now HH:MM" label from the Guide
  for a cleaner look.

  EPG time shift (Settings)

  Added a per-provider EPG time shift control under Settings → EPG Sources. If a provider's EPG
  data is consistently offset (e.g. wrong timezone), you can now correct it with quick-tap
  buttons (±5m, ±15m, ±30m, ±1h) up to ±12 hours. The shift is applied transparently — guide
  times show correctly without touching the raw data.

  ---
  Test plan

  - Open Guide, click a channel — preview starts in the pane
  - Click the same channel again — goes fullscreen
  - Back out of fullscreen — preview resumes in the Guide pane (no black placeholder, no ghost
  audio)
  - Long-press a channel in the Guide — options menu appears without auto-firing "Watch Live"
  - Leave the Guide open with a preview running for several minutes — screen stays on
  - Open Guide and check timeline markers — should read :00 and :30 boundaries
  - Settings → EPG Sources → adjust time shift for a provider — EPG times shift accordingly