### PR TITLE
Support playback on API 25 Fire TV devices

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 
     defaultConfig {
         applicationId = "com.streamvault.app"
-        minSdk = 27
+        minSdk = 25
         targetSdk = 36
         versionCode = 13
         versionName = "1.0.12"
@@ -128,6 +128,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -157,10 +158,11 @@ kover {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
     implementation(project(":data"))
     implementation(project(":player"))
-    implementation(files("../player/libs/media3-decoder-ffmpeg-1.9.2.aar"))
 
     // Compose BOM
     val composeBom = platform(libs.compose.bom)
@@ -185,6 +187,7 @@ dependencies {
     implementation(libs.media3.exoplayer.rtsp)
     implementation(libs.media3.datasource.okhttp)
     implementation(libs.media3.ui)
+    implementation(files("../player/libs/media3-decoder-ffmpeg-1.9.2.aar"))
 
     // Room
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/streamvault/app/MainActivity.kt
+++ b/app/src/main/java/com/streamvault/app/MainActivity.kt
@@ -114,9 +114,9 @@ class MainActivity : ComponentActivity() {
         handleExternalIntent(intent)
         if (isTelevisionDevice()) {
             lifecycleScope.launch {
-                watchNextManager.refreshWatchNext()
-                launcherRecommendationsManager.refreshRecommendations()
-                tvInputChannelSyncManager.refreshTvInputCatalog()
+                runCatching { watchNextManager.refreshWatchNext() }
+                runCatching { launcherRecommendationsManager.refreshRecommendations() }
+                runCatching { tvInputChannelSyncManager.refreshTvInputCatalog() }
             }
         }
         setContent {

--- a/app/src/main/java/com/streamvault/app/StreamVaultApp.kt
+++ b/app/src/main/java/com/streamvault/app/StreamVaultApp.kt
@@ -48,14 +48,31 @@ class StreamVaultApp : Application(), SingletonImageLoader.Factory {
         CrashReportStore.install(this)
         runtimeDiagnosticsManager.start()
         applicationScope.launch {
-            // Clean up any timeshift temp directories left behind by crashes, OOM kills, or
-            // force-stops from the previous run. activeSessionDir = null means wipe everything.
-            TimeshiftDiskManager(applicationContext).cleanupStaleDirectories(activeSessionDir = null)
+            runCatching {
+                // Clean up any timeshift temp directories left behind by crashes, OOM kills, or
+                // force-stops from the previous run. activeSessionDir = null means wipe everything.
+                TimeshiftDiskManager(applicationContext).cleanupStaleDirectories(activeSessionDir = null)
+            }
         }
         applicationScope.launch {
-            refreshCachedAppUpdateIfNeeded()
+            runCatching { refreshCachedAppUpdateIfNeeded() }
         }
-        
+
+        scheduleStartupMaintenance()
+    }
+
+    override fun onTerminate() {
+        runtimeDiagnosticsManager.stop()
+        super.onTerminate()
+    }
+
+    private fun scheduleStartupMaintenance() {
+        runCatching {
+            enqueueStartupMaintenance()
+        }
+    }
+
+    private fun enqueueStartupMaintenance() {
         // Schedule daily data maintenance: EPG pruning, stale-favorite cleanup, and DB compaction checks.
         // BLD-H02: Require network + device idle so the worker doesn't drain battery.
         val gcConstraints = Constraints.Builder()
@@ -80,11 +97,6 @@ class StreamVaultApp : Application(), SingletonImageLoader.Factory {
         XtreamIndexWorker.enqueueLaunchStaleCheck(this)
         RecordingReconcileWorker.enqueuePeriodic(this)
         RecordingReconcileWorker.enqueueOneShot(this)
-    }
-
-    override fun onTerminate() {
-        runtimeDiagnosticsManager.stop()
-        super.onTerminate()
     }
 
     private suspend fun refreshCachedAppUpdateIfNeeded() {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -13,10 +13,11 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 25
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -45,6 +46,8 @@ kover {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
 
     // Room

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ retrofit = "2.12.0"
 okhttp = "4.12.0"
 coil = "3.4.0"
 coroutines = "1.10.2"
+desugar-jdk-libs = "2.1.5"
 lifecycle = "2.10.0"
 navigation-compose = "2.9.7"
 datastore = "1.2.1"
@@ -98,6 +99,7 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }

--- a/player/build.gradle.kts
+++ b/player/build.gradle.kts
@@ -13,10 +13,11 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 25
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -113,6 +114,8 @@ tasks.named("preBuild").configure {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
 
     // Media3

--- a/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
@@ -106,6 +106,7 @@ class Media3PlayerEngine @Inject constructor(
     companion object {
         private const val TAG = "Media3PlayerEngine"
         private const val AUDIO_RENDERER_RECOVERY_COOLDOWN_MS = 15_000L
+        private const val LEGACY_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.N_MR1
         private const val TEXTURE_VIEW_STARTUP_TIMEOUT_MS = 9_000L
         private const val TEXTURE_VIEW_BUFFERED_STARTUP_THRESHOLD_MS = 4_000L
         private const val KNOWN_BAD_FAILURE_THRESHOLD = 3
@@ -1430,7 +1431,13 @@ class Media3PlayerEngine @Inject constructor(
         _renderSurfaceType.value = when (surfaceMode) {
             PlayerSurfaceMode.SURFACE_VIEW -> PlayerRenderSurfaceType.SURFACE_VIEW
             PlayerSurfaceMode.TEXTURE_VIEW -> PlayerRenderSurfaceType.TEXTURE_VIEW
-            PlayerSurfaceMode.AUTO -> PlayerRenderSurfaceType.SURFACE_VIEW
+            PlayerSurfaceMode.AUTO -> {
+                if (Build.VERSION.SDK_INT <= LEGACY_TEXTURE_VIEW_MAX_SDK) {
+                    PlayerRenderSurfaceType.TEXTURE_VIEW
+                } else {
+                    PlayerRenderSurfaceType.SURFACE_VIEW
+                }
+            }
         }
     }
 

--- a/player/src/main/java/com/streamvault/player/audio/PlayerAudioFocusController.kt
+++ b/player/src/main/java/com/streamvault/player/audio/PlayerAudioFocusController.kt
@@ -3,6 +3,7 @@ package com.streamvault.player.audio
 import android.content.Context
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +16,7 @@ class PlayerAudioFocusController(
     private val onAudioFocusDenied: (() -> Unit)? = null
 ) {
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    private var audioFocusRequest: AudioFocusRequest? = null
+    private var audioFocusRequest: Any? = null
     private var hasAudioFocus = false
     private var shouldResumeOnAudioFocusGain = false
     private var isDucked = false
@@ -77,12 +78,22 @@ class PlayerAudioFocusController(
         }
         if (osContentType != currentOsContentType) {
             currentOsContentType = osContentType
-            audioFocusRequest?.let(audioManager::abandonAudioFocusRequest)
+            abandonAudioFocusRequestObject()
             audioFocusRequest = null
             hasAudioFocus = false
         }
-        val request = audioFocusRequest ?: buildAudioFocusRequest().also { audioFocusRequest = it }
-        val granted = audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = (audioFocusRequest as? AudioFocusRequest)
+                ?: buildAudioFocusRequest().also { audioFocusRequest = it }
+            audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
         hasAudioFocus = granted
         if (!granted) {
             Log.w(TAG, "audio-focus denied")
@@ -163,9 +174,18 @@ class PlayerAudioFocusController(
 
     private fun abandonAudioFocusIfHeld() {
         if (!hasAudioFocus) return
-        audioFocusRequest?.let(audioManager::abandonAudioFocusRequest)
+        abandonAudioFocusRequestObject()
         hasAudioFocus = false
         isDucked = false
+    }
+
+    private fun abandonAudioFocusRequestObject() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            (audioFocusRequest as? AudioFocusRequest)?.let(audioManager::abandonAudioFocusRequest)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
+        }
     }
 
     private fun buildAudioFocusRequest(): AudioFocusRequest {

--- a/player/src/main/java/com/streamvault/player/ui/PlayerViewBinder.kt
+++ b/player/src/main/java/com/streamvault/player/ui/PlayerViewBinder.kt
@@ -36,7 +36,12 @@ class PlayerViewBinder(
         val playerView = renderView as? PlayerView ?: return
         boundResizeMode = resizeMode
         if (boundPlayerView !== playerView) {
-            PlayerView.switchTargetView(player, boundPlayerView, playerView)
+            runCatching {
+                PlayerView.switchTargetView(player, boundPlayerView, playerView)
+            }.getOrElse {
+                boundPlayerView?.player = null
+                playerView.player = player
+            }
             boundPlayerView = playerView
         } else if (playerView.player !== player) {
             playerView.player = player


### PR DESCRIPTION
﻿## Summary
- lower Android module minSdk to 25 and enable core library desugaring for Java APIs used below API 26
- keep bundled Media3 FFmpeg decoder while preserving Fire TV ABIs
- use legacy audio focus APIs below Android O and prefer TextureView for AUTO rendering on API 25-era devices
- guard startup maintenance/TV refresh work so vendor-specific startup failures do not crash launch

## Testing
- `./gradlew.bat assembleRelease --no-daemon "-Pkotlin.incremental=false"`
- verified release APK metadata: package `com.streamvault.app`, minSdk `25`, targetSdk `36`, ABIs `arm64-v8a`/`armeabi-v7a`
- installed signed local release APK on Amazon Fire TV Stick 4K 1st gen / Fire OS 6.7.1.1 (Android API 25) and confirmed movie playback no longer crashes
