### PR TITLE
Fix Fire TV HEVC fullscreen handoff

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
@@ -6,4 +6,7 @@ import com.streamvault.player.PlayerStats
 internal fun shouldRenewAdoptedPreviewOnFullscreen(
     playbackState: PlaybackState,
     playerStats: PlayerStats
-): Boolean = playbackState != PlaybackState.READY || playerStats.ttffMs <= 0L
+): Boolean {
+    if (playerStats.ttffMs <= 0L) return true
+    return playbackState != PlaybackState.READY && playbackState != PlaybackState.BUFFERING
+}

--- a/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
@@ -31,7 +31,6 @@ class PlayerPreviewHandoffSupportTest {
     fun `non ready preview renews fullscreen stream`() {
         val states = listOf(
             PlaybackState.IDLE,
-            PlaybackState.BUFFERING,
             PlaybackState.ENDED,
             PlaybackState.ERROR
         )
@@ -44,5 +43,15 @@ class PlayerPreviewHandoffSupportTest {
                 )
             ).isTrue()
         }
+    }
+
+    @Test
+    fun `buffering preview with rendered frame skips fullscreen renewal`() {
+        val shouldRenew = shouldRenewAdoptedPreviewOnFullscreen(
+            playbackState = PlaybackState.BUFFERING,
+            playerStats = PlayerStats(ttffMs = 250L)
+        )
+
+        assertThat(shouldRenew).isFalse()
     }
 }

--- a/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
@@ -106,6 +106,8 @@ class Media3PlayerEngine @Inject constructor(
     companion object {
         private const val TAG = "Media3PlayerEngine"
         private const val AUDIO_RENDERER_RECOVERY_COOLDOWN_MS = 15_000L
+        private const val LEGACY_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.N_MR1
+        private const val FIRE_TV_MEDIATEK_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.P
         private const val TEXTURE_VIEW_STARTUP_TIMEOUT_MS = 9_000L
         private const val TEXTURE_VIEW_BUFFERED_STARTUP_THRESHOLD_MS = 4_000L
         private const val KNOWN_BAD_FAILURE_THRESHOLD = 3
@@ -1430,8 +1432,23 @@ class Media3PlayerEngine @Inject constructor(
         _renderSurfaceType.value = when (surfaceMode) {
             PlayerSurfaceMode.SURFACE_VIEW -> PlayerRenderSurfaceType.SURFACE_VIEW
             PlayerSurfaceMode.TEXTURE_VIEW -> PlayerRenderSurfaceType.TEXTURE_VIEW
-            PlayerSurfaceMode.AUTO -> PlayerRenderSurfaceType.SURFACE_VIEW
+            PlayerSurfaceMode.AUTO -> {
+                if (shouldPreferTextureViewForAutoSurface()) {
+                    PlayerRenderSurfaceType.TEXTURE_VIEW
+                } else {
+                    PlayerRenderSurfaceType.SURFACE_VIEW
+                }
+            }
         }
+    }
+
+    private fun shouldPreferTextureViewForAutoSurface(): Boolean {
+        if (Build.VERSION.SDK_INT <= LEGACY_TEXTURE_VIEW_MAX_SDK) return true
+        val isAmazonFireTv = Build.MANUFACTURER.equals("Amazon", ignoreCase = true)
+        val isMediaTek = Build.HARDWARE.orEmpty().startsWith("mt", ignoreCase = true)
+        return isAmazonFireTv &&
+            isMediaTek &&
+            Build.VERSION.SDK_INT <= FIRE_TV_MEDIATEK_TEXTURE_VIEW_MAX_SDK
     }
 
     private fun refreshKnownBadCompatibilityRecords() {


### PR DESCRIPTION
## Summary

Fixes a Fire TV fullscreen playback regression where HEVC live channels can play in preview but show a black screen / buffering during fullscreen handoff before eventually recovering.

Changes:
- Prefer `TextureView` automatically on Amazon Fire TV MediaTek devices running Android/Fire OS builds up to API 28.
- Avoid renewing an adopted live preview when it has already rendered video and is only temporarily `BUFFERING` during fullscreen surface handoff.
- Add unit coverage for the buffering-but-rendered preview handoff case.

## Why this is needed

On affected Amazon Fire TV hardware, especially MediaTek-based Fire OS devices, preview playback can be healthy but fullscreen handoff changes the render target and briefly reports buffering. The old logic treated that transient buffering state as unhealthy and renewed/reprepared the stream, which caused a visible sequence of preview -> black screen -> buffering -> playback.

The logs from the device showed the stream eventually reached a healthy media session state, but only after the unnecessary fullscreen renewal. Separately, MediaTek decoder/surface logs showed the hardware path is sensitive during HEVC rendering, so AUTO surface selection should use `TextureView` on this device family instead of the default `SurfaceView` path.

This keeps an already-rendered preview alive through fullscreen transition and uses the safer render surface on affected Fire TV hardware.

## Validation

- `./gradlew.bat :app:testDebugUnitTest --tests "com.streamvault.app.ui.screens.player.PlayerPreviewHandoffSupportTest" --no-daemon -Pkotlin.incremental=false`
- `./gradlew.bat assembleRelease --no-daemon -Pkotlin.incremental=false`
- Manual Fire TV validation on Amazon Fire TV MediaTek device (`AFTKA`, API 28): BBC HEVC live channel reached `PlaybackState` playing with `error=null` after the TextureView/preview handoff fixes.
