### PR TITLE
Firetv compat lowmem

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
 
     defaultConfig {
         applicationId = "com.streamvault.app"
-        minSdk = 27
+        minSdk = 25
         targetSdk = 36
         versionCode = 13
         versionName = "1.0.12"
@@ -128,6 +128,7 @@ android {
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -157,10 +158,11 @@ kover {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
     implementation(project(":data"))
     implementation(project(":player"))
-    implementation(files("../player/libs/media3-decoder-ffmpeg-1.9.2.aar"))
 
     // Compose BOM
     val composeBom = platform(libs.compose.bom)
@@ -185,6 +187,7 @@ dependencies {
     implementation(libs.media3.exoplayer.rtsp)
     implementation(libs.media3.datasource.okhttp)
     implementation(libs.media3.ui)
+    implementation(files("../player/libs/media3-decoder-ffmpeg-1.9.2.aar"))
 
     // Room
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/streamvault/app/MainActivity.kt
+++ b/app/src/main/java/com/streamvault/app/MainActivity.kt
@@ -114,9 +114,9 @@ class MainActivity : ComponentActivity() {
         handleExternalIntent(intent)
         if (isTelevisionDevice()) {
             lifecycleScope.launch {
-                watchNextManager.refreshWatchNext()
-                launcherRecommendationsManager.refreshRecommendations()
-                tvInputChannelSyncManager.refreshTvInputCatalog()
+                runCatching { watchNextManager.refreshWatchNext() }
+                runCatching { launcherRecommendationsManager.refreshRecommendations() }
+                runCatching { tvInputChannelSyncManager.refreshTvInputCatalog() }
             }
         }
         setContent {

--- a/app/src/main/java/com/streamvault/app/StreamVaultApp.kt
+++ b/app/src/main/java/com/streamvault/app/StreamVaultApp.kt
@@ -48,14 +48,31 @@ class StreamVaultApp : Application(), SingletonImageLoader.Factory {
         CrashReportStore.install(this)
         runtimeDiagnosticsManager.start()
         applicationScope.launch {
-            // Clean up any timeshift temp directories left behind by crashes, OOM kills, or
-            // force-stops from the previous run. activeSessionDir = null means wipe everything.
-            TimeshiftDiskManager(applicationContext).cleanupStaleDirectories(activeSessionDir = null)
+            runCatching {
+                // Clean up any timeshift temp directories left behind by crashes, OOM kills, or
+                // force-stops from the previous run. activeSessionDir = null means wipe everything.
+                TimeshiftDiskManager(applicationContext).cleanupStaleDirectories(activeSessionDir = null)
+            }
         }
         applicationScope.launch {
-            refreshCachedAppUpdateIfNeeded()
+            runCatching { refreshCachedAppUpdateIfNeeded() }
         }
-        
+
+        scheduleStartupMaintenance()
+    }
+
+    override fun onTerminate() {
+        runtimeDiagnosticsManager.stop()
+        super.onTerminate()
+    }
+
+    private fun scheduleStartupMaintenance() {
+        runCatching {
+            enqueueStartupMaintenance()
+        }
+    }
+
+    private fun enqueueStartupMaintenance() {
         // Schedule daily data maintenance: EPG pruning, stale-favorite cleanup, and DB compaction checks.
         // BLD-H02: Require network + device idle so the worker doesn't drain battery.
         val gcConstraints = Constraints.Builder()
@@ -80,11 +97,6 @@ class StreamVaultApp : Application(), SingletonImageLoader.Factory {
         XtreamIndexWorker.enqueueLaunchStaleCheck(this)
         RecordingReconcileWorker.enqueuePeriodic(this)
         RecordingReconcileWorker.enqueueOneShot(this)
-    }
-
-    override fun onTerminate() {
-        runtimeDiagnosticsManager.stop()
-        super.onTerminate()
     }
 
     private suspend fun refreshCachedAppUpdateIfNeeded() {

--- a/app/src/main/java/com/streamvault/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/streamvault/app/di/DatabaseModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
-import com.streamvault.app.BuildConfig
 import com.streamvault.data.local.StreamVaultDatabase
 import com.streamvault.data.local.dao.*
 import com.streamvault.data.local.dao.ChannelPreferenceDao
@@ -18,8 +17,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
-    private const val DEBUG_SLOW_QUERY_THRESHOLD_MS = 100L
-
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): StreamVaultDatabase =
@@ -29,16 +26,7 @@ object DatabaseModule {
             "streamvault.db"
         )
             .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
-            .openHelperFactory(
-                if (BuildConfig.DEBUG) {
-                    SlowQueryLoggingOpenHelperFactory(
-                        delegate = FrameworkSQLiteOpenHelperFactory(),
-                        slowQueryThresholdMs = DEBUG_SLOW_QUERY_THRESHOLD_MS
-                    )
-                } else {
-                    FrameworkSQLiteOpenHelperFactory()
-                }
-            )
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
             .addMigrations(
                 StreamVaultDatabase.MIGRATION_1_2,
                 StreamVaultDatabase.MIGRATION_2_3,

--- a/app/src/main/java/com/streamvault/app/diagnostics/CrashReportStore.kt
+++ b/app/src/main/java/com/streamvault/app/diagnostics/CrashReportStore.kt
@@ -40,7 +40,7 @@ object CrashReportStore {
         if (!installed.compareAndSet(false, true)) return
         val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            if (writingCrash.compareAndSet(false, true)) {
+            if (!throwable.isOutOfMemoryError() && writingCrash.compareAndSet(false, true)) {
                 runCatching {
                     latestReportFile(application).writeText(
                         buildReport(application, thread, throwable),
@@ -168,4 +168,13 @@ object CrashReportStore {
             .firstOrNull { it.startsWith("$field: ") }
             ?.substringAfter(": ")
             ?.takeIf { it.isNotBlank() }
+
+    private fun Throwable.isOutOfMemoryError(): Boolean {
+        var current: Throwable? = this
+        while (current != null) {
+            if (current is OutOfMemoryError) return true
+            current = current.cause
+        }
+        return false
+    }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupport.kt
@@ -6,4 +6,7 @@ import com.streamvault.player.PlayerStats
 internal fun shouldRenewAdoptedPreviewOnFullscreen(
     playbackState: PlaybackState,
     playerStats: PlayerStats
-): Boolean = playbackState != PlaybackState.READY || playerStats.ttffMs <= 0L
+): Boolean {
+    if (playerStats.ttffMs <= 0L) return true
+    return playbackState != PlaybackState.READY && playbackState != PlaybackState.BUFFERING
+}

--- a/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
+++ b/app/src/test/java/com/streamvault/app/ui/screens/player/PlayerPreviewHandoffSupportTest.kt
@@ -31,7 +31,6 @@ class PlayerPreviewHandoffSupportTest {
     fun `non ready preview renews fullscreen stream`() {
         val states = listOf(
             PlaybackState.IDLE,
-            PlaybackState.BUFFERING,
             PlaybackState.ENDED,
             PlaybackState.ERROR
         )
@@ -44,5 +43,15 @@ class PlayerPreviewHandoffSupportTest {
                 )
             ).isTrue()
         }
+    }
+
+    @Test
+    fun `buffering preview with rendered frame skips fullscreen renewal`() {
+        val shouldRenew = shouldRenewAdoptedPreviewOnFullscreen(
+            playbackState = PlaybackState.BUFFERING,
+            playerStats = PlayerStats(ttffMs = 250L)
+        )
+
+        assertThat(shouldRenew).isFalse()
     }
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -13,10 +13,11 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 25
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -45,6 +46,8 @@ kover {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
 
     // Room

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ retrofit = "2.12.0"
 okhttp = "4.12.0"
 coil = "3.4.0"
 coroutines = "1.10.2"
+desugar-jdk-libs = "2.1.5"
 lifecycle = "2.10.0"
 navigation-compose = "2.9.7"
 datastore = "1.2.1"
@@ -98,6 +99,7 @@ navigation-compose = { group = "androidx.navigation", name = "navigation-compose
 # Coroutines
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+desugar-jdk-libs = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk-libs" }
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }

--- a/player/build.gradle.kts
+++ b/player/build.gradle.kts
@@ -13,10 +13,11 @@ android {
     compileSdk = 36
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 25
     }
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -113,6 +114,8 @@ tasks.named("preBuild").configure {
 }
 
 dependencies {
+    coreLibraryDesugaring(libs.desugar.jdk.libs)
+
     implementation(project(":domain"))
 
     // Media3

--- a/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
@@ -106,6 +106,7 @@ class Media3PlayerEngine @Inject constructor(
     companion object {
         private const val TAG = "Media3PlayerEngine"
         private const val AUDIO_RENDERER_RECOVERY_COOLDOWN_MS = 15_000L
+        private const val LEGACY_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.N_MR1
         private const val TEXTURE_VIEW_STARTUP_TIMEOUT_MS = 9_000L
         private const val TEXTURE_VIEW_BUFFERED_STARTUP_THRESHOLD_MS = 4_000L
         private const val KNOWN_BAD_FAILURE_THRESHOLD = 3
@@ -1430,7 +1431,13 @@ class Media3PlayerEngine @Inject constructor(
         _renderSurfaceType.value = when (surfaceMode) {
             PlayerSurfaceMode.SURFACE_VIEW -> PlayerRenderSurfaceType.SURFACE_VIEW
             PlayerSurfaceMode.TEXTURE_VIEW -> PlayerRenderSurfaceType.TEXTURE_VIEW
-            PlayerSurfaceMode.AUTO -> PlayerRenderSurfaceType.SURFACE_VIEW
+            PlayerSurfaceMode.AUTO -> {
+                if (Build.VERSION.SDK_INT <= LEGACY_TEXTURE_VIEW_MAX_SDK) {
+                    PlayerRenderSurfaceType.TEXTURE_VIEW
+                } else {
+                    PlayerRenderSurfaceType.SURFACE_VIEW
+                }
+            }
         }
     }
 

--- a/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
@@ -1,5 +1,6 @@
 package com.streamvault.player
 
+import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import android.os.Handler
@@ -107,6 +108,7 @@ class Media3PlayerEngine @Inject constructor(
         private const val TAG = "Media3PlayerEngine"
         private const val AUDIO_RENDERER_RECOVERY_COOLDOWN_MS = 15_000L
         private const val LEGACY_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.N_MR1
+        private const val FIRE_TV_MEDIATEK_TEXTURE_VIEW_MAX_SDK = Build.VERSION_CODES.P
         private const val TEXTURE_VIEW_STARTUP_TIMEOUT_MS = 9_000L
         private const val TEXTURE_VIEW_BUFFERED_STARTUP_THRESHOLD_MS = 4_000L
         private const val KNOWN_BAD_FAILURE_THRESHOLD = 3
@@ -191,6 +193,12 @@ class Media3PlayerEngine @Inject constructor(
     private var currentBufferIsLive: Boolean? = null
     private var audioCodecUnsupportedReported = false
     private var lastSupportErrorMessage: String? = null
+    private val isLowMemoryPlaybackDevice: Boolean = run {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+        val memoryClassMb = activityManager?.memoryClass ?: 256
+        val lowRam = activityManager?.isLowRamDevice ?: false
+        lowRam || memoryClassMb <= 256
+    }
 
     private val _playbackState = MutableStateFlow(PlaybackState.IDLE)
     override val playbackState: StateFlow<PlaybackState> = _playbackState.asStateFlow()
@@ -318,7 +326,9 @@ class Media3PlayerEngine @Inject constructor(
                     audioVideoSyncEnabled = _audioVideoSyncEnabled.value,
                     audioVideoSyncSinkActive = audioVideoSyncSinkActive
                 )
-                playbackSupportSnapshotStore.write(buildPlaybackSupportSnapshot())
+                if (shouldRefreshPlaybackSupportSnapshot()) {
+                    playbackSupportSnapshotStore.write(buildPlaybackSupportSnapshot())
+                }
                 if (shouldFallbackTextureViewBeforeFirstFrame(stats)) {
                     fallbackTextureViewSurface("NO_FIRST_FRAME")
                     continue
@@ -980,7 +990,8 @@ class Media3PlayerEngine @Inject constructor(
         val renderersFactory = buildRenderersFactory()
         val bufferPolicy = PlaybackBufferPolicies.forPlayback(
             isLive = currentBufferIsLive == true,
-            compatibilityMode = activeDecoderPolicy == ActiveDecoderPolicy.COMPATIBILITY
+            compatibilityMode = activeDecoderPolicy == ActiveDecoderPolicy.COMPATIBILITY,
+            lowMemoryDevice = isLowMemoryPlaybackDevice
         )
         val loadControl = DefaultLoadControl.Builder()
             .setBufferDurationsMs(
@@ -989,7 +1000,7 @@ class Media3PlayerEngine @Inject constructor(
                 bufferPolicy.playbackBufferMs,
                 bufferPolicy.rebufferMs
             )
-            .setPrioritizeTimeOverSizeThresholds(true)
+            .setPrioritizeTimeOverSizeThresholds(!isLowMemoryPlaybackDevice)
             .build()
         val livePlaybackSpeedControl = DefaultLivePlaybackSpeedControl.Builder()
             .setFallbackMinPlaybackSpeed(1.0f)
@@ -1431,14 +1442,19 @@ class Media3PlayerEngine @Inject constructor(
         _renderSurfaceType.value = when (surfaceMode) {
             PlayerSurfaceMode.SURFACE_VIEW -> PlayerRenderSurfaceType.SURFACE_VIEW
             PlayerSurfaceMode.TEXTURE_VIEW -> PlayerRenderSurfaceType.TEXTURE_VIEW
-            PlayerSurfaceMode.AUTO -> {
-                if (Build.VERSION.SDK_INT <= LEGACY_TEXTURE_VIEW_MAX_SDK) {
-                    PlayerRenderSurfaceType.TEXTURE_VIEW
-                } else {
-                    PlayerRenderSurfaceType.SURFACE_VIEW
-                }
+            PlayerSurfaceMode.AUTO -> if (shouldPreferTextureViewForAutoSurface()) {
+                PlayerRenderSurfaceType.TEXTURE_VIEW
+            } else {
+                PlayerRenderSurfaceType.SURFACE_VIEW
             }
         }
+    }
+
+    private fun shouldPreferTextureViewForAutoSurface(): Boolean {
+        if (Build.VERSION.SDK_INT <= LEGACY_TEXTURE_VIEW_MAX_SDK) return true
+        return Build.MANUFACTURER.equals("Amazon", ignoreCase = true) &&
+            Build.HARDWARE.orEmpty().startsWith("mt", ignoreCase = true) &&
+            Build.VERSION.SDK_INT <= FIRE_TV_MEDIATEK_TEXTURE_VIEW_MAX_SDK
     }
 
     private fun refreshKnownBadCompatibilityRecords() {
@@ -1814,6 +1830,11 @@ class Media3PlayerEngine @Inject constructor(
         appendLine("streamType=$currentResolvedStreamType")
         appendLine("target=${PlaybackLogSanitizer.sanitizeUrl(lastStreamInfo?.url)}")
         appendLine("lastError=${PlaybackLogSanitizer.sanitizeMessage(lastSupportErrorMessage)}")
+    }
+
+    private fun shouldRefreshPlaybackSupportSnapshot(): Boolean {
+        if (!isLowMemoryPlaybackDevice) return true
+        return _playbackState.value != PlaybackState.BUFFERING || _playerStats.value.ttffMs > 0L
     }
 
     private fun resolveStartupAudioOutputPath(): String = when {

--- a/player/src/main/java/com/streamvault/player/audio/PlayerAudioFocusController.kt
+++ b/player/src/main/java/com/streamvault/player/audio/PlayerAudioFocusController.kt
@@ -3,6 +3,7 @@ package com.streamvault.player.audio
 import android.content.Context
 import android.media.AudioFocusRequest
 import android.media.AudioManager
+import android.os.Build
 import android.util.Log
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +16,7 @@ class PlayerAudioFocusController(
     private val onAudioFocusDenied: (() -> Unit)? = null
 ) {
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-    private var audioFocusRequest: AudioFocusRequest? = null
+    private var audioFocusRequest: Any? = null
     private var hasAudioFocus = false
     private var shouldResumeOnAudioFocusGain = false
     private var isDucked = false
@@ -77,12 +78,22 @@ class PlayerAudioFocusController(
         }
         if (osContentType != currentOsContentType) {
             currentOsContentType = osContentType
-            audioFocusRequest?.let(audioManager::abandonAudioFocusRequest)
+            abandonAudioFocusRequestObject()
             audioFocusRequest = null
             hasAudioFocus = false
         }
-        val request = audioFocusRequest ?: buildAudioFocusRequest().also { audioFocusRequest = it }
-        val granted = audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        val granted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val request = (audioFocusRequest as? AudioFocusRequest)
+                ?: buildAudioFocusRequest().also { audioFocusRequest = it }
+            audioManager.requestAudioFocus(request) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.requestAudioFocus(
+                audioFocusChangeListener,
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
         hasAudioFocus = granted
         if (!granted) {
             Log.w(TAG, "audio-focus denied")
@@ -163,9 +174,18 @@ class PlayerAudioFocusController(
 
     private fun abandonAudioFocusIfHeld() {
         if (!hasAudioFocus) return
-        audioFocusRequest?.let(audioManager::abandonAudioFocusRequest)
+        abandonAudioFocusRequestObject()
         hasAudioFocus = false
         isDucked = false
+    }
+
+    private fun abandonAudioFocusRequestObject() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            (audioFocusRequest as? AudioFocusRequest)?.let(audioManager::abandonAudioFocusRequest)
+        } else {
+            @Suppress("DEPRECATION")
+            audioManager.abandonAudioFocus(audioFocusChangeListener)
+        }
     }
 
     private fun buildAudioFocusRequest(): AudioFocusRequest {

--- a/player/src/main/java/com/streamvault/player/playback/PlaybackBufferPolicies.kt
+++ b/player/src/main/java/com/streamvault/player/playback/PlaybackBufferPolicies.kt
@@ -9,6 +9,14 @@ internal data class PlaybackBufferPolicy(
 )
 
 internal object PlaybackBufferPolicies {
+    private const val LOW_MEMORY_LIVE_MIN_BUFFER_MS = 4_000
+    private const val LOW_MEMORY_LIVE_MAX_BUFFER_MS = 12_000
+    private const val LOW_MEMORY_COMPAT_LIVE_MIN_BUFFER_MS = 6_000
+    private const val LOW_MEMORY_COMPAT_LIVE_MAX_BUFFER_MS = 15_000
+    private const val LOW_MEMORY_VOD_MIN_BUFFER_MS = 15_000
+    private const val LOW_MEMORY_VOD_MAX_BUFFER_MS = 45_000
+    private const val LOW_MEMORY_PLAYBACK_BUFFER_MS = 1_000
+    private const val LOW_MEMORY_REBUFFER_MS = 3_000
     private const val LIVE_MIN_BUFFER_MS = 8_000
     private const val LIVE_MAX_BUFFER_MS = 30_000
     private const val COMPAT_LIVE_MIN_BUFFER_MS = 15_000
@@ -20,7 +28,13 @@ internal object PlaybackBufferPolicies {
     private const val VOD_PLAYBACK_BUFFER_MS = 8_000
     private const val VOD_REBUFFER_MS = 18_000
 
-    fun forPlayback(isLive: Boolean, compatibilityMode: Boolean): PlaybackBufferPolicy = when {
+    fun forPlayback(isLive: Boolean, compatibilityMode: Boolean, lowMemoryDevice: Boolean): PlaybackBufferPolicy = when {
+        lowMemoryDevice && compatibilityMode && isLive ->
+            PlaybackBufferPolicy("lowmem-compat-live", LOW_MEMORY_COMPAT_LIVE_MIN_BUFFER_MS, LOW_MEMORY_COMPAT_LIVE_MAX_BUFFER_MS, LOW_MEMORY_PLAYBACK_BUFFER_MS, LOW_MEMORY_REBUFFER_MS)
+        lowMemoryDevice && isLive ->
+            PlaybackBufferPolicy("lowmem-live", LOW_MEMORY_LIVE_MIN_BUFFER_MS, LOW_MEMORY_LIVE_MAX_BUFFER_MS, LOW_MEMORY_PLAYBACK_BUFFER_MS, LOW_MEMORY_REBUFFER_MS)
+        lowMemoryDevice ->
+            PlaybackBufferPolicy("lowmem-vod", LOW_MEMORY_VOD_MIN_BUFFER_MS, LOW_MEMORY_VOD_MAX_BUFFER_MS, LOW_MEMORY_PLAYBACK_BUFFER_MS, LOW_MEMORY_REBUFFER_MS)
         compatibilityMode && isLive ->
             PlaybackBufferPolicy("compat-live", COMPAT_LIVE_MIN_BUFFER_MS, COMPAT_LIVE_MAX_BUFFER_MS, PLAYBACK_BUFFER_MS, REBUFFER_MS)
         isLive ->

--- a/player/src/main/java/com/streamvault/player/ui/PlayerViewBinder.kt
+++ b/player/src/main/java/com/streamvault/player/ui/PlayerViewBinder.kt
@@ -36,7 +36,12 @@ class PlayerViewBinder(
         val playerView = renderView as? PlayerView ?: return
         boundResizeMode = resizeMode
         if (boundPlayerView !== playerView) {
-            PlayerView.switchTargetView(player, boundPlayerView, playerView)
+            runCatching {
+                PlayerView.switchTargetView(player, boundPlayerView, playerView)
+            }.getOrElse {
+                boundPlayerView?.player = null
+                playerView.player = player
+            }
             boundPlayerView = playerView
         } else if (playerView.player !== player) {
             playerView.player = player


### PR DESCRIPTION
## Summary
This combines the Android Fire TV / Firestick changes into one PR and restores LeakCanary in the debug build.

## Changes from previous PRs
- Prefer `TextureView` on Amazon MediaTek Fire TV devices through API 28 while preserving explicit surface overrides.
- Prevent fullscreen handoff from renewing when the preview is buffering but already has a rendered frame.
- Add and update coverage for the preview handoff buffering behavior.
- Use smaller ExoPlayer buffer policies on low-memory devices to reduce playback pressure.
- Avoid extra playback-support snapshot churn on low-memory devices.
- Remove debug slow-query logging overhead during playback.
- Skip crash-report persistence for `OutOfMemoryError` so the uncaught-exception path stays lightweight.
- Lower `minSdk` to 25 across the app, data, and player modules and enable core library desugaring.
- Move FFmpeg wiring into the app module where it belongs.
- Harden TV startup by wrapping non-critical refresh and maintenance work in `runCatching`.
- Make player view switching and audio-focus handling safer on older Fire TV paths.

## This PR
- Restore LeakCanary in the debug build so debug diagnostics remain available.

## Validation
- Local code was prepared and pushed to the fork branch used for this PR.
- Per request, no APK rebuild was performed for this update.