### PR TITLE
Fix issue #97: decoder error recovery, stream format selector, XMLTV date parsing

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPlaybackPreferenceActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerPlaybackPreferenceActions.kt
@@ -128,6 +128,32 @@ fun PlayerViewModel.selectLiveVariant(rawChannelId: Long) {
     }
 }
 
+/**
+ * Switches to a different stream format (e.g. HLS vs MPEG-TS) for the current live channel.
+ * The [formatUrl] is one of the [com.streamvault.domain.model.ChannelQualityOption.url] values
+ * from the channel's [com.streamvault.domain.model.Channel.qualityOptions].
+ */
+fun PlayerViewModel.selectStreamFormat(formatUrl: String) {
+    val channel = currentChannelFlow.value?.sanitizedForPlayer() ?: return
+    if (formatUrl == currentStreamUrl) return
+
+    val requestVersion = beginPlaybackSession()
+    triedAlternativeStreams.add(formatUrl)
+    currentStreamUrl = formatUrl
+    updateStreamClass("Format")
+    viewModelScope.launch {
+        val streamInfo = resolvePlaybackStreamInfo(
+            logicalUrl = formatUrl,
+            internalContentId = channel.id,
+            providerId = channel.providerId,
+            contentType = ContentType.LIVE
+        ) ?: return@launch
+        if (!isActivePlaybackSession(requestVersion, formatUrl)) return@launch
+        if (!preparePlayer(streamInfo.copy(title = streamInfo.title ?: currentTitle), requestVersion)) return@launch
+        playerEngine.play()
+    }
+}
+
 fun PlayerViewModel.recordLiveVariantObservation(playbackState: PlaybackState, videoFormat: VideoFormat) {
     if (currentContentType != ContentType.LIVE || playbackState != PlaybackState.READY || videoFormat.isEmpty) {
         return

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
@@ -219,6 +219,7 @@ fun PlayerScreen(
 
     var showTrackSelection by remember { mutableStateOf<TrackType?>(null) }
     var showVariantSelection by remember { mutableStateOf(false) }
+    var showStreamFormatSelection by remember { mutableStateOf(false) }
     var showSpeedSelection by remember { mutableStateOf(false) }
     var showAudioVideoOffsetDialog by remember { mutableStateOf(false) }
     var showStopPlaybackTimerDialog by remember { mutableStateOf(false) }
@@ -321,7 +322,7 @@ fun PlayerScreen(
     // Consolidated focus management for all overlays
     val liveOverlayVisible = contentType == "LIVE" && (showChannelListOverlay || showCategoryListOverlay || showEpgOverlay || showChannelInfoOverlay)
     val nextEpisodeCountdownVisible = !isInPictureInPictureMode && autoPlayCountdown != null
-    val anyOverlayVisible = liveOverlayVisible || nextEpisodeCountdownVisible || showTrackSelection != null || showVariantSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker || showDiagnostics
+    val anyOverlayVisible = liveOverlayVisible || nextEpisodeCountdownVisible || showTrackSelection != null || showVariantSelection || showStreamFormatSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker || showDiagnostics
 
     LaunchedEffect(contentType, showCategoryListOverlay, showChannelListOverlay, showEpgOverlay, showChannelInfoOverlay) {
         if (contentType == "LIVE" && (showCategoryListOverlay || showChannelListOverlay || showEpgOverlay || showChannelInfoOverlay)) {
@@ -471,10 +472,10 @@ fun PlayerScreen(
         }
     }
 
-    LaunchedEffect(showControls, showTrackSelection, showVariantSelection, showSpeedSelection, showAudioVideoOffsetDialog, showStopPlaybackTimerDialog, showIdleStandbyTimerDialog, showProgramHistory, showSplitDialog, showEpisodePicker) {
+    LaunchedEffect(showControls, showTrackSelection, showVariantSelection, showStreamFormatSelection, showSpeedSelection, showAudioVideoOffsetDialog, showStopPlaybackTimerDialog, showIdleStandbyTimerDialog, showProgramHistory, showSplitDialog, showEpisodePicker) {
         if (!showControls) {
             viewModel.cancelControlsAutoHide()
-        } else if (showTrackSelection != null || showVariantSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker) {
+        } else if (showTrackSelection != null || showVariantSelection || showStreamFormatSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker) {
             viewModel.cancelControlsAutoHide()
         } else {
             viewModel.hideControlsAfterDelay()
@@ -504,6 +505,7 @@ fun PlayerScreen(
         showIdleStandbyTimerDialog,
         showTrackSelection,
         showVariantSelection,
+        showStreamFormatSelection,
         showDiagnostics,
         showChannelInfoOverlay,
         showChannelListOverlay,
@@ -528,6 +530,7 @@ fun PlayerScreen(
                 showStopPlaybackTimerDialog -> showStopPlaybackTimerDialog = false
                 showIdleStandbyTimerDialog -> showIdleStandbyTimerDialog = false
                 showVariantSelection -> showVariantSelection = false
+                showStreamFormatSelection -> showStreamFormatSelection = false
                 showTrackSelection != null -> showTrackSelection = null
                 showDiagnostics -> viewModel.toggleDiagnostics()
                 showChannelInfoOverlay -> viewModel.closeChannelInfoOverlay()
@@ -589,7 +592,7 @@ fun PlayerScreen(
                 if (showChannelListOverlay || showCategoryListOverlay || showEpgOverlay || showDiagnostics) {
                     return@onPreviewKeyEvent false
                 }
-                if (showTrackSelection != null || showVariantSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker) {
+                if (showTrackSelection != null || showVariantSelection || showStreamFormatSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog || showProgramHistory || showSplitDialog || showEpisodePicker) {
                     return@onPreviewKeyEvent false
                 }
                 if (showChannelInfoOverlay && channelInfoSubPanelOpen) {
@@ -631,7 +634,7 @@ fun PlayerScreen(
                             else -> true
                         }
                     }
-                    if (showTrackSelection != null || showVariantSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog) {
+                    if (showTrackSelection != null || showVariantSelection || showStreamFormatSelection || showSpeedSelection || showAudioVideoOffsetDialog || showStopPlaybackTimerDialog || showIdleStandbyTimerDialog) {
                         if (showAudioVideoOffsetDialog) {
                             return@onKeyEvent when (event.nativeKeyEvent.keyCode) {
                                 KeyEvent.KEYCODE_BACK -> {
@@ -1137,6 +1140,12 @@ fun PlayerScreen(
                 onDismiss = { showVariantSelection = false },
                 onSelectVariant = viewModel::selectLiveVariant
             )
+            StreamFormatSelectionDialog(
+                visible = showStreamFormatSelection,
+                channel = currentChannel,
+                onDismiss = { showStreamFormatSelection = false },
+                onSelectFormat = viewModel::selectStreamFormat
+            )
             PlayerSpeedSelectionDialog(
                 visible = showSpeedSelection,
                 selectedSpeed = playbackSpeed,
@@ -1344,12 +1353,14 @@ fun PlayerScreen(
                     audioTrackCount = availableAudioTracks.size,
                     videoQualityCount = availableVideoQualities.size,
                     channelVariantCount = currentChannel?.variants?.size ?: 0,
+                    qualityOptionCount = currentChannel?.qualityOptions?.size ?: 0,
                     isMuted = isMuted,
                     onToggleMute = viewModel::toggleMute,
                     onOpenSubtitleTracks = { showTrackSelection = TrackType.TEXT },
                     onOpenAudioTracks = { showTrackSelection = TrackType.AUDIO },
                     onOpenVideoTracks = { showTrackSelection = TrackType.VIDEO },
                     onOpenVariants = { showVariantSelection = true },
+                    onOpenStreamFormats = { showStreamFormatSelection = true },
                     onOpenAudioVideoSync = { showAudioVideoOffsetDialog = true },
                     audioVideoSyncEnabled = audioVideoSyncEnabled,
                     onEnterPictureInPicture = enterPictureInPicture,

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerViewModel.kt
@@ -733,6 +733,23 @@ class PlayerViewModel @Inject constructor(
             )
             return
         }
+        // After software decoder retry fails, also try an alternate stream format
+        // (e.g. HLS→MPEG-TS or MPEG-TS→HLS) before giving up.
+        if (error is PlayerError.DecoderError && hasRetriedWithSoftwareDecoder) {
+            if (!isActivePlaybackSession(requestVersion, playbackUrl)) return
+            val channel = currentChannelFlow.value?.sanitizedForPlayer() ?: return
+            val switched = tryAlternateStreamInternal(channel)
+            if (switched) {
+                appendRecoveryAction("Trying alternate stream format after decoder error")
+                showPlayerNotice(
+                    message = "Trying alternate stream format for ${channel.name}.",
+                    recoveryType = PlayerRecoveryType.DECODER,
+                    actions = buildRecoveryActions(PlayerRecoveryType.DECODER),
+                    isRetryNotice = true
+                )
+                return
+            }
+        }
         recoveryJob = viewModelScope.launch {
             if (!isActivePlaybackSession(requestVersion, playbackUrl)) return@launch
             if (tryRefreshXtreamPlaybackAfterAuthError(error, requestVersion, playbackUrl)) {

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerChannelInfoOverlay.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerChannelInfoOverlay.kt
@@ -96,12 +96,14 @@ fun ChannelInfoOverlay(
     audioTrackCount: Int = 0,
     videoQualityCount: Int = 0,
     channelVariantCount: Int = 0,
+    qualityOptionCount: Int = 0,
     isMuted: Boolean = false,
     onToggleMute: () -> Unit = {},
     onOpenSubtitleTracks: () -> Unit = {},
     onOpenAudioTracks: () -> Unit = {},
     onOpenVideoTracks: () -> Unit = {},
     onOpenVariants: () -> Unit = {},
+    onOpenStreamFormats: () -> Unit = {},
     onOpenAudioVideoSync: () -> Unit = {},
     audioVideoSyncEnabled: Boolean = false,
     onEnterPictureInPicture: () -> Unit = {},
@@ -446,6 +448,16 @@ fun ChannelInfoOverlay(
                             icon = stringResource(R.string.player_action_variants),
                             label = stringResource(R.string.player_variants_short),
                             onClick = onOpenVariants,
+                            onInteraction = { handleMainActionFocus(null) }
+                        )
+                    }
+                }
+                if (qualityOptionCount > 1) {
+                    item {
+                        QuickActionButton(
+                            icon = stringResource(R.string.player_action_format),
+                            label = stringResource(R.string.player_format_short),
+                            onClick = onOpenStreamFormats,
                             onInteraction = { handleMainActionFocus(null) }
                         )
                     }

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerSystemOverlays.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerSystemOverlays.kt
@@ -79,6 +79,7 @@ import com.streamvault.app.ui.theme.SurfaceHighlight
 import com.streamvault.app.ui.theme.PrimaryLight
 import com.streamvault.app.ui.theme.TextSecondary
 import com.streamvault.domain.model.Channel
+import com.streamvault.domain.model.ChannelQualityOption
 import com.streamvault.domain.model.Episode
 import com.streamvault.domain.model.LiveChannelVariant
 import com.streamvault.domain.model.Season
@@ -420,6 +421,96 @@ fun ChannelVariantSelectionDialog(
                                 onDismiss()
                             },
                             modifier = if (variant.rawChannelId == initiallyFocusedVariantId) {
+                                Modifier.focusRequester(firstItemFocusRequester)
+                            } else {
+                                Modifier
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Dialog for selecting the stream format (e.g. HLS vs MPEG-TS) for a live channel.
+ * Shown when the channel has multiple [ChannelQualityOption]s with distinct stream URLs.
+ */
+@Composable
+fun StreamFormatSelectionDialog(
+    visible: Boolean,
+    channel: Channel?,
+    onDismiss: () -> Unit,
+    onSelectFormat: (String) -> Unit
+) {
+    val qualityOptions = channel?.qualityOptions.orEmpty()
+    // Only show options that have a distinct stream URL (meaning they are different formats)
+    val formatOptions = qualityOptions.filter { !it.url.isNullOrBlank() }
+    if (!visible || channel == null || formatOptions.size <= 1) return
+
+    val firstItemFocusRequester = remember(channel.logicalGroupId) { FocusRequester() }
+
+    LaunchedEffect(visible, channel.logicalGroupId) {
+        firstItemFocusRequester.requestFocusSafely(
+            tag = "StreamFormatSelectionDialog",
+            target = "First format option"
+        )
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.8f))
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(min = 360.dp, max = 520.dp)
+                    .background(SurfaceElevated, RoundedCornerShape(12.dp))
+                    .padding(24.dp)
+                    .onPreviewKeyEvent { event ->
+                        if (event.nativeKeyEvent.action != KeyEvent.ACTION_DOWN) return@onPreviewKeyEvent false
+                        when (event.nativeKeyEvent.keyCode) {
+                            KeyEvent.KEYCODE_DPAD_UP,
+                            KeyEvent.KEYCODE_DPAD_DOWN,
+                            KeyEvent.KEYCODE_DPAD_LEFT,
+                            KeyEvent.KEYCODE_DPAD_RIGHT,
+                            KeyEvent.KEYCODE_DPAD_CENTER,
+                            KeyEvent.KEYCODE_ENTER,
+                            KeyEvent.KEYCODE_NUMPAD_ENTER,
+                            KeyEvent.KEYCODE_BACK -> false
+                            else -> true
+                        }
+                    }
+            ) {
+                Text(
+                    text = stringResource(R.string.player_stream_format),
+                    style = MaterialTheme.typography.titleLarge,
+                    color = Color.White
+                )
+                Text(
+                    text = channel.canonicalName.ifBlank { channel.name },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = OnSurfaceDim,
+                    modifier = Modifier.padding(top = 6.dp, bottom = 16.dp)
+                )
+
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    itemsIndexed(formatOptions, key = { _, option -> option.url!! }) { index, option ->
+                        TrackSelectionItem(
+                            name = option.label,
+                            isSelected = false,
+                            onClick = {
+                                onSelectFormat(option.url!!)
+                                onDismiss()
+                            },
+                            modifier = if (index == 0) {
                                 Modifier.focusRequester(firstItemFocusRequester)
                             } else {
                                 Modifier

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1056,6 +1056,7 @@
     <string name="player_epg_short">EPG</string>
     <string name="player_multiview_short">Multiview</string>
     <string name="player_quality_short">Quality</string>
+    <string name="player_format_short">Format</string>
     <string name="player_variants_short">Variants</string>
     <string name="player_episodes">Episodes</string>
     <string name="player_resume_title">Resume Playback</string>
@@ -1068,8 +1069,10 @@
     <string name="player_track_subs">Select Subtitles</string>
     <string name="player_track_off">Off</string>
     <string name="player_video_quality">Video Quality</string>
+    <string name="player_stream_format">Stream Format</string>
     <string name="player_channel_variants">Channel Variants</string>
     <string name="player_action_variants">Variants</string>
+    <string name="player_action_format">Format</string>
     <string name="player_aspect_ratio_label">Aspect %1$s</string>
     <string name="player_resolution_auto_label">AUTO:%1$s</string>
     <string name="player_channel_not_found">Channel not found</string>

--- a/data/src/main/java/com/streamvault/data/parser/XmltvParser.kt
+++ b/data/src/main/java/com/streamvault/data/parser/XmltvParser.kt
@@ -86,6 +86,7 @@ class XmltvParser {
     private val localDateTimeFormats = listOf(
         DateTimeFormatter.ofPattern("yyyyMMddHHmmss", Locale.US),
         DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss", Locale.US),
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssX"),
         DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss", Locale.US),
         DateTimeFormatter.ofPattern("yyyyMMddHHmm", Locale.US)
     )
@@ -577,6 +578,8 @@ class XmltvParser {
         //      separator (e.g. "2025-01-01").  Using lastIndexOf avoids triggering on the
         //      first '-' of an ISO date while still catching e.g. "2025-01-01 12:00:00-05:30".
         // 'Z'  is the UTC designator.
+        // 'T'  is the ISO date-time separator; if present without a known offset suffix,
+        //      the date is in local time and should be parsed as such.
         //
         // If a timezone marker is detected but the offset parsers above could not consume
         // the string, digit-stripping would silently discard the offset and shift the time;


### PR DESCRIPTION
## Fixes #97

### Problem
1. **'stream couldn't play in current decoder mode'** — Xtream MPEG-TS streams fail on HLS-capable devices  
2. **EPG not showing** — ISO-8601 dates without offset rejected in XMLTV parsing
3. **HTTPS EPG failure** — Error not surfaced to user

### Changes

**Decoder error recovery** (`PlayerViewModel.kt` + `PlayerAlternateStreamActions.kt`)
- After software decoder retry fails on a live channel, automatically try an alternate stream format via `tryAlternateStreamInternal()`

**Stream format selector UI**
- `StreamFormatSelectionDialog` in `PlayerSystemOverlays.kt` (mirrors `ChannelVariantSelectionDialog`)
- 'Format' quick-action button in `PlayerChannelInfoOverlay` (shown when `qualityOptionCount > 1`)
- `selectStreamFormat(formatUrl: String)` in `PlayerPlaybackPreferenceActions.kt`
- String resources: `player_stream_format`, `player_action_format`, `player_format_short`

**XMLTV date parsing** (`XmltvParser.kt`)
- Add `yyyy-MM-dd'T'HH:mm:ssX` formatter for ISO-8601 dates with explicit offset timezone