### PR TITLE
Fix issue #79: propagate error when channel has no stream URL

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerContentResolutionSupport.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerContentResolutionSupport.kt
@@ -77,10 +77,21 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 channelRepository.getChannel(internalContentId)?.let { channel ->
                     fallbackStreamId = channel.streamId.takeIf { it > 0L }
                         ?: channel.epgChannelId?.toLongOrNull()
-                    channelRepository.getStreamInfo(channel).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = channelRepository.getStreamInfo(channel)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        // Propagate the underlying error so the caller can show it to the user
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }
@@ -89,10 +100,20 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 movieRepository.getMovie(internalContentId)?.let { movie ->
                     fallbackStreamId = movie.streamId.takeIf { it > 0L }
                     fallbackContainerExtension = movie.containerExtension
-                    movieRepository.getStreamInfo(movie).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = movieRepository.getStreamInfo(movie)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }
@@ -111,10 +132,20 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 episode?.let {
                     fallbackStreamId = it.episodeId.takeIf { episodeId -> episodeId > 0L } ?: it.id
                     fallbackContainerExtension = it.containerExtension
-                    seriesRepository.getEpisodeStreamInfo(it).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = seriesRepository.getEpisodeStreamInfo(it)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Fixes #79

### Problem
When a channel has no stream URL (e.g. due to partial sync failure or M3U entries without URLs), the user sees a generic error or no message at all instead of a clear explanation.

Root cause: `channelRepository.getStreamInfo(channel)` returns `Result.error('No stream URL available for channel: XYZ')`, but `getOrNull()` silently discards this error, causing the player to fall through to fallback URL resolution with no actionable message shown.

### Changes
In `PlayerContentResolutionSupport.resolvePlayerPlaybackStreamInfo`:
- For LIVE, MOVIE, and SERIES content types, check `isSuccess`/`isError` explicitly instead of using `getOrNull()`
- When `getStreamInfo` returns an error, propagate the error message as `resolutionFailureMessage` so `PlayerViewModel` can show it to the user via `showPlayerNotice`

This ensures users see meaningful errors like "No stream URL available for channel: XYZ" instead of silent failure or generic error messages.