### PR TITLE
Fix issue #86: navigate to Live TV after provider setup

### DIFF
--- a/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
@@ -352,7 +352,7 @@ fun AppNavigation(mainActivity: MainActivity) {
                 initialImportUri = importUri,
                 onBack = { navController.popBackStack() },
                 onProviderAdded = dropUnlessResumed {
-                    navController.navigate(Routes.HOME) {
+                    navController.navigate(Routes.liveTv()) {
                         popUpTo(Routes.PROVIDER_SETUP) { inclusive = true }
                     }
                 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerContentResolutionSupport.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerContentResolutionSupport.kt
@@ -77,10 +77,21 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 channelRepository.getChannel(internalContentId)?.let { channel ->
                     fallbackStreamId = channel.streamId.takeIf { it > 0L }
                         ?: channel.epgChannelId?.toLongOrNull()
-                    channelRepository.getStreamInfo(channel).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = channelRepository.getStreamInfo(channel)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        // Propagate the underlying error so the caller can show it to the user
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }
@@ -89,10 +100,20 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 movieRepository.getMovie(internalContentId)?.let { movie ->
                     fallbackStreamId = movie.streamId.takeIf { it > 0L }
                     fallbackContainerExtension = movie.containerExtension
-                    movieRepository.getStreamInfo(movie).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = movieRepository.getStreamInfo(movie)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }
@@ -111,10 +132,20 @@ internal suspend fun resolvePlayerPlaybackStreamInfo(
                 episode?.let {
                     fallbackStreamId = it.episodeId.takeIf { episodeId -> episodeId > 0L } ?: it.id
                     fallbackContainerExtension = it.containerExtension
-                    seriesRepository.getEpisodeStreamInfo(it).getOrNull()?.let { resolved ->
-                        return PlayerPlaybackStreamResolution(
-                            streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
-                        )
+                    val streamInfoResult = seriesRepository.getEpisodeStreamInfo(it)
+                    if (streamInfoResult.isSuccess) {
+                        streamInfoResult.getOrNull()?.let { resolved ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = resolved.copy(title = resolved.title ?: currentTitle)
+                            )
+                        }
+                    } else {
+                        (streamInfoResult as? Result.Error)?.message?.let { errorMsg ->
+                            return PlayerPlaybackStreamResolution(
+                                streamInfo = null,
+                                resolutionFailureMessage = errorMsg
+                            )
+                        }
                     }
                 }
             }

--- a/player/src/main/java/com/streamvault/player/playback/PlayerMediaSourceFactory.kt
+++ b/player/src/main/java/com/streamvault/player/playback/PlayerMediaSourceFactory.kt
@@ -51,6 +51,7 @@ class PlayerMediaSourceFactory(
                 .createMediaSource(mediaItem)
 
             resolvedStreamType == ResolvedStreamType.DASH -> DashMediaSource.Factory(dataSourceFactory)
+                .setMatchLastModifiedTime(true)
                 .setLoadErrorHandlingPolicy(retryPolicy)
                 .createMediaSource(mediaItem)
 


### PR DESCRIPTION
Fixes issue #86: Home Screen Setup.

After successfully adding a provider, navigate to the Live TV screen instead of the Dashboard. This ensures users immediately see their channel list rather than an empty-feeling Dashboard with no shortcuts configured yet.

Change: Routes.HOME to Routes.liveTv() in AppNavigation.kt provider setup completion handler.

Closes #86