### PR TITLE
Fix issue #86: navigate to Live TV after provider setup

### DIFF
--- a/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/streamvault/app/navigation/AppNavigation.kt
@@ -352,7 +352,7 @@ fun AppNavigation(mainActivity: MainActivity) {
                 initialImportUri = importUri,
                 onBack = { navController.popBackStack() },
                 onProviderAdded = dropUnlessResumed {
-                    navController.navigate(Routes.HOME) {
+                    navController.navigate(Routes.liveTv()) {
                         popUpTo(Routes.PROVIDER_SETUP) { inclusive = true }
                     }
                 }


### PR DESCRIPTION
Fixes issue #86: Home Screen Setup.

After successfully adding a provider, navigate to the Live TV screen instead of the Dashboard. This ensures users immediately see their channel list rather than an empty-feeling Dashboard with no shortcuts configured yet.

Change: Routes.HOME to Routes.liveTv() in AppNavigation.kt.

Closes #86