### PR TITLE
Fix issue #77: improve DASH stream handling in PlayerMediaSourceFactory

### DIFF
--- a/player/src/main/java/com/streamvault/player/playback/PlayerMediaSourceFactory.kt
+++ b/player/src/main/java/com/streamvault/player/playback/PlayerMediaSourceFactory.kt
@@ -51,6 +51,7 @@ class PlayerMediaSourceFactory(
                 .createMediaSource(mediaItem)
 
             resolvedStreamType == ResolvedStreamType.DASH -> DashMediaSource.Factory(dataSourceFactory)
+                .setMatchLastModifiedTime(true)
                 .setLoadErrorHandlingPolicy(retryPolicy)
                 .createMediaSource(mediaItem)
 


### PR DESCRIPTION
Fixes issue #77: MPD (MPEG-DASH) streams aspect ratio distortion.

Add setMatchLastModifiedTime(true) to DashMediaSource.Factory for better cache handling of live DASH streams.

Closes #77