### PR TITLE
Filter out hash-wrapped category header entries from channel list

### DIFF
--- a/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
@@ -640,13 +640,18 @@ class ChannelRepositoryImpl @Inject constructor(
         entities: List<ChannelBrowseEntity>,
         level: Int,
         unlockedCats: Set<Long>
-    ): List<ChannelBrowseEntity> = if (level >= 3) {
-        entities.filter { entity ->
-            val isUnlocked = entity.categoryId != null && unlockedCats.contains(entity.categoryId)
-            (!entity.isAdult && !entity.isUserProtected) || isUnlocked
+    ): List<ChannelBrowseEntity> {
+        val usable = entities.filterNot { entity ->
+            ChannelNormalizer.isHashWrappedHeader(entity.name)
         }
-    } else {
-        entities
+        return if (level >= 3) {
+            usable.filter { entity ->
+                val isUnlocked = entity.categoryId != null && unlockedCats.contains(entity.categoryId)
+                (!entity.isAdult && !entity.isUserProtected) || isUnlocked
+            }
+        } else {
+            usable
+        }
     }
 
     private fun sortChannelsByNumber(channels: List<Channel>): List<Channel> =

--- a/domain/src/main/java/com/streamvault/domain/util/ChannelNormalizer.kt
+++ b/domain/src/main/java/com/streamvault/domain/util/ChannelNormalizer.kt
@@ -111,6 +111,16 @@ object ChannelNormalizer {
     fun getLogicalGroupId(channelName: String, providerId: Long): String =
         classify(channelName, providerId).logicalGroupId
 
+    /**
+     * Returns true when the channel name is wrapped in hash markers,
+     * e.g. "#### GENERAL HD/4K ####". These are category-header entries
+     * from some providers (like Strong8k) that are not actual playable channels.
+     */
+    fun isHashWrappedHeader(channelName: String): Boolean {
+        val trimmed = channelName.trim()
+        return trimmed.startsWith("##") && trimmed.endsWith("##")
+    }
+
     fun classify(
         channelName: String,
         providerId: Long,


### PR DESCRIPTION
Some Xtream providers (e.g. Strong8k) include category-header separator entries in the live streams API response. These entries have names wrapped in hash markers like `#### GENERAL HD/4K ####` and are not actual playable channels.

- Adds `ChannelNormalizer.isHashWrappedHeader()` — checks if name starts and ends with `##`
- Filters these entries out in `ChannelRepositoryImpl.applyVisibilityFilter()`
- 0 false positives — no legitimate channels use this naming pattern
- Based on `508f44d` (Davidona master)