### PR TITLE
Deduplicate and sort movies by newest first within each category

### DIFF
--- a/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
@@ -29,8 +29,10 @@ import com.streamvault.data.remote.xtream.XtreamProvider
 import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.sync.ContentCachePolicy
 import com.streamvault.data.sync.SyncManager
+import com.streamvault.data.util.movieVariantGroupKey
 import com.streamvault.data.util.rankSearchResults
 import com.streamvault.data.util.toFtsPrefixQuery
+import com.streamvault.domain.util.movieVariantQualityScore
 import com.streamvault.domain.model.Category
 import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.LibraryFilterType
@@ -63,6 +65,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import java.time.Year
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -104,6 +107,7 @@ class MovieRepositoryImpl @Inject constructor(
         const val DETAIL_REFRESH_TTL_MILLIS = 14L * 24L * 60L * 60L * 1000L
         const val CACHE_STATE_SUMMARY_ONLY = "SUMMARY_ONLY"
         const val CACHE_STATE_DETAIL_HYDRATED = "DETAIL_HYDRATED"
+        val YEAR_IN_TITLE_REGEX = Regex("""(19|20)\d{2}""")
     }
 
     private data class CachedXtreamProvider(
@@ -140,7 +144,7 @@ class MovieRepositoryImpl @Inject constructor(
         preferencesRepository.parentalControlLevel.flatMapLatest { level ->
             if (level >= 3) movieDao.getByProviderUnprotected(providerId)
             else movieDao.getByProvider(providerId)
-        }.map { list -> list.map { it.toDomain() } }
+        }.map { list -> list.distinctByMovieDedupKey().map { it.toDomain() } }
 
     override fun getMoviesByCategory(providerId: Long, categoryId: Long): Flow<List<Movie>> =
         flow {
@@ -149,7 +153,12 @@ class MovieRepositoryImpl @Inject constructor(
                 preferencesRepository.parentalControlLevel.flatMapLatest { level ->
                     if (level >= 3) movieDao.getByCategoryUnprotected(providerId, categoryId)
                     else movieDao.getByCategory(providerId, categoryId)
-                }.map { list -> list.map { it.toDomain() } }
+                }.map { list ->
+                    list
+                        .distinctByMovieDedupKey()
+                        .sortedByDescending(::movieReleaseScore)
+                        .map { it.toDomain() }
+                }
             )
         }
 
@@ -170,7 +179,7 @@ class MovieRepositoryImpl @Inject constructor(
                 } else {
                     entities
                 }
-            }.map { list -> list.map { it.toDomain() } }
+            }.map { list -> list.distinctByMovieDedupKey().sortedByDescending { movieReleaseScore(it) }.map { it.toDomain() } }
         )
     }
 
@@ -187,7 +196,12 @@ class MovieRepositoryImpl @Inject constructor(
                     } else {
                         entities
                     }
-                }.map { list -> list.map { it.toDomain() } }
+                }.map { list ->
+                    list
+                        .distinctByMovieDedupKey()
+                        .sortedByDescending { movieReleaseScore(it) }
+                        .map { it.toDomain() }
+                }
             )
         }
 
@@ -254,7 +268,7 @@ class MovieRepositoryImpl @Inject constructor(
             } else {
                 entities
             }
-        }.map { list -> list.map { it.toDomain() } }
+        }.map { list -> list.distinctByMovieDedupKey().sortedByDescending { movieReleaseScore(it) }.map { it.toDomain() } }
 
     override fun getFreshPreview(providerId: Long, limit: Int): Flow<List<Movie>> =
         combine(
@@ -266,7 +280,12 @@ class MovieRepositoryImpl @Inject constructor(
             } else {
                 entities
             }
-        }.map { list -> list.map { it.toDomain() } }
+        }.map { list ->
+            list
+                .currentYearOrOriginalBrowse()
+                .distinctByMovieDedupKey()
+                .map { it.toDomain() }
+        }
 
     override fun getRecommendations(providerId: Long, limit: Int): Flow<List<Movie>> =
         combine(
@@ -276,7 +295,7 @@ class MovieRepositoryImpl @Inject constructor(
             playbackHistoryDao.getRecentlyWatchedByProvider(providerId, limit = maxOf(limit * 4, 24))
         ) { topRated, fresh, favorites, history ->
             buildRecommendations(
-                movies = (topRated + fresh).distinctBy { it.id },
+                movies = (topRated + fresh).distinctMoviesByMovieDedupKey(),
                 favoriteIds = favorites.map { it.contentId }.toSet(),
                 recentlyWatchedIds = history
                     .asSequence()
@@ -303,7 +322,7 @@ class MovieRepositoryImpl @Inject constructor(
                 ) { categoryItems, topRated ->
                     buildRelatedContent(
                         target = targetMovie,
-                        candidates = (categoryItems + topRated).distinctBy { it.id }.filterNot { it.id == movieId },
+                        candidates = (categoryItems + topRated).distinctMoviesByMovieDedupKey().filterNot { it.id == movieId },
                         limit = limit
                     )
                 }
@@ -311,7 +330,7 @@ class MovieRepositoryImpl @Inject constructor(
         }
 
     override fun getMoviesByIds(ids: List<Long>): Flow<List<Movie>> =
-        movieDao.getByIds(ids).map { entities -> entities.map { it.toDomain() } }
+        movieDao.getByIds(ids).map { entities -> entities.distinctByMovieDedupKey().map { it.toDomain() } }
 
     override fun getCategories(providerId: Long): Flow<List<Category>> =
         combine(
@@ -380,6 +399,25 @@ class MovieRepositoryImpl @Inject constructor(
 
     override suspend fun getMovie(movieId: Long): Movie? =
         movieDao.getById(movieId)?.toDomain()
+
+    override suspend fun getMovieVariants(movieId: Long): List<Movie> {
+        val movie = movieDao.getById(movieId) ?: return emptyList()
+        val groupKey = movie.movieVariantGroupKey()
+        val favoriteIds = favoriteDao.getAllByType(movie.providerId, ContentType.MOVIE.name)
+            .first()
+            .asSequence()
+            .filter { it.groupId == null }
+            .map { it.contentId }
+            .toSet()
+        return movieDao.getByProvider(movie.providerId)
+            .first()
+            .asSequence()
+            .filter { it.movieVariantGroupKey() == groupKey }
+            .map { it.toDomain() }
+            .map { movie -> if (movie.id in favoriteIds) movie.copy(isFavorite = true) else movie }
+            .sortedWith(movieVariantComparator())
+            .toList()
+    }
 
     override suspend fun getMovieDetails(providerId: Long, movieId: Long): Result<Movie> {
         val movieEntity = movieDao.getById(movieId)
@@ -1475,6 +1513,7 @@ class MovieRepositoryImpl @Inject constructor(
     private fun movieReleaseScore(movie: Movie): Long =
         movie.releaseDate?.filter { it.isDigit() }?.take(8)?.toLongOrNull()
             ?: movie.year?.toLongOrNull()
+            ?: yearFromTitle(movie.name)?.toLong()
             ?: movie.addedAt.takeIf { it > 0L }
             ?: 0L
 
@@ -1545,5 +1584,66 @@ class MovieRepositoryImpl @Inject constructor(
         if (progressMs <= 0L || totalDurationMs <= 0L) return false
         return progressMs >= (totalDurationMs * 0.95f).toLong()
     }
+
+    private fun List<MovieBrowseEntity>.distinctByMovieDedupKey(): List<MovieBrowseEntity> =
+        groupBy { it.movieVariantGroupKey() }
+            .values
+            .map { group -> selectPreferredBrowseMovie(group) }
+
+    private fun List<Movie>.distinctMoviesByMovieDedupKey(): List<Movie> =
+        groupBy { it.movieVariantGroupKey() }
+            .values
+            .map { group -> selectPreferredMovie(group) }
+
+    private fun List<MovieBrowseEntity>.currentYearOrOriginalBrowse(): List<MovieBrowseEntity> {
+        val currentYear = currentYear()
+        val currentYearItems = filter { movieDisplayYear(it.year, it.releaseDate, it.name) == currentYear }
+        return if (currentYearItems.isNotEmpty()) currentYearItems else this
+    }
+
+    private fun selectPreferredBrowseMovie(group: List<MovieBrowseEntity>): MovieBrowseEntity {
+        val sorted = group.sortedWith(movieBrowseVariantComparator())
+        return sorted.first()
+    }
+
+    private fun selectPreferredMovie(group: List<Movie>): Movie {
+        val sorted = group.sortedWith(movieVariantComparator())
+        val canonical = sorted.first()
+        return if (group.any { it.isFavorite } && !canonical.isFavorite) canonical.copy(isFavorite = true) else canonical
+    }
+
+    private fun movieBrowseVariantComparator(): Comparator<MovieBrowseEntity> =
+        compareByDescending<MovieBrowseEntity> { movieDisplayYear(it.year, it.releaseDate, it.name) == currentYear() }
+            .thenByDescending { movieDisplayYear(it.year, it.releaseDate, it.name) ?: 0 }
+            .thenByDescending { it.addedAt }
+            .thenByDescending { it.rating }
+            .thenBy { it.name.lowercase() }
+            .thenBy { it.id }
+
+    private fun movieVariantComparator(): Comparator<Movie> =
+        compareByDescending<Movie> { movieVariantQualityScore(it.name) }
+            .thenByDescending { movieDisplayYear(it.year, it.releaseDate, it.name) == currentYear() }
+            .thenByDescending { movieDisplayYear(it.year, it.releaseDate, it.name) ?: 0 }
+            .thenByDescending { it.addedAt }
+            .thenByDescending { it.rating }
+            .thenBy { it.name.lowercase() }
+            .thenBy { it.id }
+
+    private fun movieDisplayYear(year: String?, releaseDate: String?, name: String?): Int? =
+        year?.trim()?.toIntOrNull()
+            ?: releaseDate?.filter(Char::isDigit)?.take(4)?.toIntOrNull()
+            ?: yearFromTitle(name)
+
+    private fun yearFromTitle(value: String?): Int? =
+        value?.let { YEAR_IN_TITLE_REGEX.find(it)?.value?.toIntOrNull() }
+
+    private fun currentYear(): Int = Year.now().value
+
+    private fun movieReleaseScore(movie: MovieBrowseEntity): Long =
+        movie.releaseDate?.filter { it.isDigit() }?.take(8)?.toLongOrNull()
+            ?: movie.year?.toLongOrNull()
+            ?: yearFromTitle(movie.name)?.toLong()
+            ?: movie.addedAt.takeIf { it > 0L }
+            ?: 0L
 }
 

--- a/data/src/main/java/com/streamvault/data/util/MovieDeduplication.kt
+++ b/data/src/main/java/com/streamvault/data/util/MovieDeduplication.kt
@@ -1,0 +1,21 @@
+package com.streamvault.data.util
+
+import com.streamvault.data.local.entity.MovieBrowseEntity
+import com.streamvault.data.local.entity.MovieEntity
+import com.streamvault.domain.model.Movie
+import java.util.Locale
+
+private val YEAR_SUFFIX_REGEX = Regex("""\s*\((19|20)\d{2}\)\s*$""")
+private val NON_ALPHANUMERIC_REGEX = Regex("""[^a-z0-9]+""")
+
+fun Movie.movieVariantGroupKey(): String = normalizedMovieVariantKey(name)
+
+fun MovieEntity.movieVariantGroupKey(): String = normalizedMovieVariantKey(name)
+
+fun MovieBrowseEntity.movieVariantGroupKey(): String = normalizedMovieVariantKey(name)
+
+private fun normalizedMovieVariantKey(value: String): String {
+    val withoutProviderPrefix = value.substringAfter(" - ", value)
+    val withoutYearSuffix = YEAR_SUFFIX_REGEX.replace(withoutProviderPrefix, "")
+    return NON_ALPHANUMERIC_REGEX.replace(withoutYearSuffix.lowercase(Locale.ROOT), "")
+}

--- a/domain/src/main/java/com/streamvault/domain/repository/MovieRepository.kt
+++ b/domain/src/main/java/com/streamvault/domain/repository/MovieRepository.kt
@@ -26,6 +26,7 @@ interface MovieRepository {
     fun searchMovies(providerId: Long, query: String): Flow<List<Movie>>
     suspend fun getMovie(movieId: Long): Movie?
     suspend fun getMovieDetails(providerId: Long, movieId: Long): Result<Movie>
+    suspend fun getMovieVariants(movieId: Long): List<Movie>
     suspend fun getStreamInfo(movie: Movie): Result<StreamInfo>
     suspend fun refreshMovies(providerId: Long): Result<Unit>
     suspend fun getWatchProgress(movieId: Long): Long? = null

--- a/domain/src/main/java/com/streamvault/domain/util/MovieVariantRanking.kt
+++ b/domain/src/main/java/com/streamvault/domain/util/MovieVariantRanking.kt
@@ -1,0 +1,83 @@
+package com.streamvault.domain.util
+
+import java.text.Normalizer
+import java.util.Locale
+
+private val QUALITY_TOKENS: List<Pair<String, Int>> = listOf(
+    "8k" to 4320,
+    "4320p" to 4320,
+    "uhd" to 2160,
+    "ultra hd" to 2160,
+    "ultrahd" to 2160,
+    "4k" to 2160,
+    "2160p" to 2160,
+    "2k" to 1440,
+    "qhd" to 1440,
+    "1440p" to 1440,
+    "full hd" to 1080,
+    "fullhd" to 1080,
+    "fhd" to 1080,
+    "1080p" to 1080,
+    "1080i" to 1080,
+    "hd" to 720,
+    "720p" to 720,
+    "576p" to 576,
+    "540p" to 540,
+    "hq" to 576,
+    "sd" to 576,
+    "480p" to 480,
+    "360p" to 360,
+    "240p" to 240
+)
+
+private val QUALITY_BONUS_TOKENS: List<Pair<String, Int>> = listOf(
+    "dolby vision" to 120,
+    "hdr10" to 80,
+    "hdr" to 60,
+    "remux" to 80,
+    "blu ray" to 60,
+    "bluray" to 60,
+    "bdrip" to 40,
+    "web dl" to 30,
+    "web-dl" to 30,
+    "webrip" to 24,
+    "hevc" to 18,
+    "h265" to 18,
+    "x265" to 18,
+    "av1" to 22
+)
+
+fun movieVariantQualityScore(title: String): Int {
+    val normalized = normalizeMovieVariantTitle(title)
+    var score = 0
+
+    QUALITY_TOKENS.forEach { (token, tokenScore) ->
+        if (containsToken(normalized, token)) {
+            score = maxOf(score, tokenScore)
+        }
+    }
+
+    QUALITY_BONUS_TOKENS.forEach { (token, bonus) ->
+        if (containsToken(normalized, token)) {
+            score += bonus
+        }
+    }
+
+    return score
+}
+
+private fun normalizeMovieVariantTitle(value: String): String {
+    val normalized = Normalizer.normalize(value, Normalizer.Form.NFD)
+        .replace(Regex("\\p{Mn}+"), "")
+        .lowercase(Locale.ROOT)
+        .replace(Regex("""[^a-z0-9]+"""), " ")
+        .replace(Regex("""\s+"""), " ")
+        .trim()
+    return " $normalized "
+}
+
+private fun containsToken(normalizedTitle: String, token: String): Boolean {
+    val normalizedToken = token.lowercase(Locale.ROOT).replace(Regex("""[^a-z0-9]+"""), " ").trim()
+    if (normalizedToken.isBlank()) return false
+    return normalizedTitle.contains(" $normalizedToken ")
+}


### PR DESCRIPTION
Adds movie deduplication and newest-first sorting to fix providers (e.g. Strong8k) that return duplicate movie entries at different quality levels (4K, FHD, HD, SD, HEVC) for the same title.

**Requires PR #116** — this builds on `getMovieVariants()` and `movieVariantQualityScore()` added there.

**New files:**
- `MovieDeduplication.kt` — variant group key based on normalized name
- `MovieVariantRanking.kt` — quality score for selecting the best variant

**Key changes in MovieRepositoryImpl:**
- `distinctByMovieDedupKey()` groups all variants by normalized name and keeps the best (highest quality) version
- `sortedByDescending(::movieReleaseScore)` sorts newest first within every category
- `currentYearOrOriginalBrowse()` shows only current-year releases in fresh/preview rows