### PR TITLE
feat: user-selectable Xtream live stream format (Auto / HLS / MPEG-TS)

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPlaybackSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPlaybackSection.kt
@@ -10,11 +10,17 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
@@ -23,6 +29,7 @@ import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnBackground
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.Primary
+import com.streamvault.domain.model.LiveStreamFormatMode
 
 internal fun LazyListScope.settingsPlaybackSection(
     uiState: SettingsUiState,
@@ -72,6 +79,33 @@ internal fun LazyListScope.settingsPlaybackSection(
     onShowEthernetQualityDialogChange: (Boolean) -> Unit
 ) {
     item {
+        val liveStreamFormatMode by viewModel.playerLiveStreamFormatMode.collectAsStateWithLifecycle()
+        var showLiveStreamFormatDialog by rememberSaveable { mutableStateOf(false) }
+        val liveStreamFormatOptions = remember {
+            listOf(
+                LiveStreamFormatMode.AUTO,
+                LiveStreamFormatMode.HLS,
+                LiveStreamFormatMode.MPEG_TS
+            )
+        }
+        if (showLiveStreamFormatDialog) {
+            PremiumSelectionDialog(
+                title = "Live stream format",
+                onDismiss = { showLiveStreamFormatDialog = false }
+            ) {
+                liveStreamFormatOptions.forEachIndexed { index, mode ->
+                    LevelOption(
+                        level = index,
+                        text = formatLiveStreamFormatModeLabel(mode),
+                        currentLevel = if (liveStreamFormatMode == mode) index else -1,
+                        onSelect = {
+                            viewModel.setPlayerLiveStreamFormatMode(mode)
+                            showLiveStreamFormatDialog = false
+                        }
+                    )
+                }
+            }
+        }
         TvClickableSurface(
             onClick = { viewModel.setPreventStandbyDuringPlayback(!uiState.preventStandbyDuringPlayback) },
             shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
@@ -206,6 +240,11 @@ internal fun LazyListScope.settingsPlaybackSection(
             style = MaterialTheme.typography.bodySmall,
             color = OnBackground.copy(alpha = 0.6f),
             modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+        )
+        ClickableSettingsRow(
+            label = "Live stream format",
+            value = formatLiveStreamFormatModeLabel(liveStreamFormatMode),
+            onClick = { showLiveStreamFormatDialog = true }
         )
         HorizontalDivider(color = Color.White.copy(alpha = 0.07f), modifier = Modifier.padding(vertical = 4.dp))
         TvClickableSurface(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenState.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenState.kt
@@ -11,6 +11,7 @@ import com.streamvault.app.util.OfficialBuildStatus
 import com.streamvault.domain.model.AppLandingDestination
 import com.streamvault.domain.model.AppTimeFormat
 import com.streamvault.domain.model.AudioOutputPreference
+import com.streamvault.domain.model.LiveStreamFormatMode
 import com.streamvault.domain.model.VodHttpProtocolMode
 
 internal data class SettingsScreenLabels(
@@ -251,6 +252,12 @@ internal fun formatVodHttpProtocolModeLabel(
 ): String = when (mode) {
     VodHttpProtocolMode.COMPATIBILITY_HTTP1 -> context.getString(R.string.settings_vod_http_protocol_compatibility)
     VodHttpProtocolMode.AUTO -> context.getString(R.string.settings_vod_http_protocol_auto)
+}
+
+internal fun formatLiveStreamFormatModeLabel(mode: LiveStreamFormatMode): String = when (mode) {
+    LiveStreamFormatMode.AUTO -> "Auto"
+    LiveStreamFormatMode.HLS -> "HLS (m3u8)"
+    LiveStreamFormatMode.MPEG_TS -> "MPEG-TS (ts)"
 }
 
 private fun formatExternalPlaybackModeLabel(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -46,6 +46,7 @@ import com.streamvault.domain.model.CombinedM3uProfile
 import com.streamvault.domain.model.GroupedChannelLabelMode
 import com.streamvault.domain.model.AudioOutputPreference
 import com.streamvault.domain.model.LiveChannelGroupingMode
+import com.streamvault.domain.model.LiveStreamFormatMode
 import com.streamvault.domain.model.LiveVariantPreferenceMode
 import com.streamvault.domain.model.VodHttpProtocolMode
 import com.streamvault.domain.model.ProviderStatus
@@ -125,6 +126,12 @@ class SettingsViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+    val playerLiveStreamFormatMode: StateFlow<LiveStreamFormatMode> =
+        preferencesRepository.playerLiveStreamFormatMode.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = LiveStreamFormatMode.AUTO
+        )
     private val activeProviderIdFlow = providerRepository.getActiveProvider().map { it?.id }
     private val appUpdateActions = SettingsAppUpdateActions(
         appContext = application,
@@ -743,6 +750,12 @@ class SettingsViewModel @Inject constructor(
     fun setPlayerSurfaceMode(mode: com.streamvault.domain.model.PlayerSurfaceMode) {
         viewModelScope.launch {
             preferencesRepository.setPlayerSurfaceMode(mode)
+        }
+    }
+
+    fun setPlayerLiveStreamFormatMode(mode: LiveStreamFormatMode) {
+        viewModelScope.launch {
+            preferencesRepository.setPlayerLiveStreamFormatMode(mode)
         }
     }
 

--- a/data/src/main/java/com/streamvault/data/manager/BackupManagerImpl.kt
+++ b/data/src/main/java/com/streamvault/data/manager/BackupManagerImpl.kt
@@ -92,6 +92,7 @@ class BackupManagerImpl @Inject constructor(
                 put("playerAudioOutputPreference", preferencesRepository.playerAudioOutputPreference.first().name)
                 put("playerCompatibilityMemoryEnabled", preferencesRepository.playerCompatibilityMemoryEnabled.first().toString())
                 put("playerSurfaceMode", preferencesRepository.playerSurfaceMode.first().name)
+                put("playerLiveStreamFormatMode", preferencesRepository.playerLiveStreamFormatMode.first().name)
                 put("playerVodHttpProtocolMode", preferencesRepository.playerVodHttpProtocolMode.first().name)
                 put("playerPlaybackSpeed", preferencesRepository.playerPlaybackSpeed.first().toString())
                 put("playerAudioVideoSyncEnabled", preferencesRepository.playerAudioVideoSyncEnabled.first().toString())
@@ -585,6 +586,13 @@ class BackupManagerImpl @Inject constructor(
                 .firstOrNull { entry -> entry.name == savedMode }
             if (surfaceMode != null) {
                 preferencesRepository.setPlayerSurfaceMode(surfaceMode)
+            }
+        }
+        prefs["playerLiveStreamFormatMode"]?.takeIf { it.isNotBlank() }?.let { savedMode ->
+            val formatMode = com.streamvault.domain.model.LiveStreamFormatMode.entries
+                .firstOrNull { entry -> entry.name == savedMode }
+            if (formatMode != null) {
+                preferencesRepository.setPlayerLiveStreamFormatMode(formatMode)
             }
         }
         (prefs["playerVodHttpProtocolMode"] ?: prefs["playerMovieHttpProtocolMode"])?.takeIf { it.isNotBlank() }?.let { savedMode ->

--- a/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
+++ b/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
@@ -27,6 +27,7 @@ import com.streamvault.domain.model.AppLandingDestination
 import com.streamvault.domain.model.AppTimeFormat
 import com.streamvault.domain.model.LiveChannelGroupingMode
 import com.streamvault.domain.model.LiveChannelObservedQuality
+import com.streamvault.domain.model.LiveStreamFormatMode
 import com.streamvault.domain.model.LiveVariantPreferenceMode
 import com.streamvault.domain.model.VodHttpProtocolMode
 import com.streamvault.domain.model.PlayerSurfaceMode
@@ -130,6 +131,7 @@ class PreferencesRepository @Inject constructor(
         val PLAYER_FAST_RETRY_ON_TRANSIENT_FAILURES =
             booleanPreferencesKey("player_fast_retry_on_transient_failures")
         val PLAYER_DECODER_MODE = stringPreferencesKey("player_decoder_mode")
+        val PLAYER_LIVE_STREAM_FORMAT_MODE = stringPreferencesKey("player_live_stream_format_mode")
         val PLAYER_VOD_HTTP_PROTOCOL_MODE = stringPreferencesKey("player_vod_http_protocol_mode")
         val LEGACY_PLAYER_MOVIE_HTTP_PROTOCOL_MODE = stringPreferencesKey("player_movie_http_protocol_mode")
         val PLAYER_AUDIO_OUTPUT_PREFERENCE = stringPreferencesKey("player_audio_output_preference")
@@ -296,6 +298,12 @@ class PreferencesRepository @Inject constructor(
         preferences[PreferencesKeys.PLAYER_SURFACE_MODE]
             ?.let { saved -> PlayerSurfaceMode.entries.firstOrNull { it.name == saved } }
             ?: PlayerSurfaceMode.AUTO
+    }
+
+    val playerLiveStreamFormatMode: Flow<LiveStreamFormatMode> = context.dataStore.data.map { preferences ->
+        preferences[PreferencesKeys.PLAYER_LIVE_STREAM_FORMAT_MODE]
+            ?.let { saved -> LiveStreamFormatMode.entries.firstOrNull { it.name == saved } }
+            ?: LiveStreamFormatMode.AUTO
     }
 
     val playerVodHttpProtocolMode: Flow<VodHttpProtocolMode> = context.dataStore.data.map { preferences ->
@@ -860,6 +868,12 @@ class PreferencesRepository @Inject constructor(
     suspend fun setPlayerSurfaceMode(mode: PlayerSurfaceMode) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.PLAYER_SURFACE_MODE] = mode.name
+        }
+    }
+
+    suspend fun setPlayerLiveStreamFormatMode(mode: LiveStreamFormatMode) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.PLAYER_LIVE_STREAM_FORMAT_MODE] = mode.name
         }
     }
 

--- a/data/src/main/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolver.kt
+++ b/data/src/main/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolver.kt
@@ -2,6 +2,7 @@ package com.streamvault.data.remote.xtream
 
 import com.streamvault.data.local.dao.ProviderDao
 import com.streamvault.data.local.entity.ProviderEntity
+import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.data.remote.http.toGenericRequestProfile
 import com.streamvault.data.remote.stalker.StalkerProvider
 import com.streamvault.data.remote.stalker.StalkerApiService
@@ -14,6 +15,7 @@ import com.streamvault.data.remote.stalker.buildStalkerPlaybackDescriptor
 import com.streamvault.data.security.CredentialCrypto
 import com.streamvault.data.util.UrlSecurityPolicy
 import com.streamvault.domain.model.ContentType
+import com.streamvault.domain.model.LiveStreamFormatMode
 import com.streamvault.domain.model.StalkerAuthMode
 import com.streamvault.domain.model.StalkerBootstrapRecipe
 import com.streamvault.domain.model.StalkerCookieMode
@@ -26,6 +28,7 @@ import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
 
 data class ResolvedStreamUrl(
     val url: String,
@@ -39,7 +42,8 @@ data class ResolvedStreamUrl(
 class XtreamStreamUrlResolver @Inject constructor(
     private val providerDao: ProviderDao,
     private val credentialCrypto: CredentialCrypto,
-    private val stalkerApiService: StalkerApiService
+    private val stalkerApiService: StalkerApiService,
+    private val preferencesRepository: PreferencesRepository
 ) {
     private data class CachedStalkerProvider(
         val serverUrl: String,
@@ -136,6 +140,7 @@ class XtreamStreamUrlResolver @Inject constructor(
                 val kind = xtreamToken?.kind ?: fallbackContentType?.let(XtreamUrlFactory::kindForContentType) ?: return null
                 val streamId = xtreamToken?.streamId ?: fallbackStreamId?.takeIf { it > 0 } ?: return null
                 val ext = xtreamToken?.containerExtension ?: fallbackContainerExtension
+                val resolvedExt = resolveLiveContainerExtension(kind, ext)
                 val directSource = xtreamToken?.directSource
                     ?.takeIf { kind != XtreamStreamKind.LIVE }
                     ?.takeIf(UrlSecurityPolicy::isAllowedStreamEntryUrl)
@@ -147,15 +152,15 @@ class XtreamStreamUrlResolver @Inject constructor(
                     password = decryptedPassword,
                     kind = kind,
                     streamId = streamId,
-                    containerExtension = ext
+                    containerExtension = resolvedExt
                 )
                 val resolvedUrl = if (preferStableUrl) fallbackResolvedUrl else (directSource ?: fallbackResolvedUrl)
 
                 resolvedProvider.applyPlaybackRequestProfile(
                     ResolvedStreamUrl(
-                    url = resolvedUrl,
-                    expirationTime = extractStreamExpirationTime(resolvedUrl),
-                    containerExtension = ext
+                        url = resolvedUrl,
+                        expirationTime = extractStreamExpirationTime(resolvedUrl),
+                        containerExtension = resolvedExt
                     )
                 )
             }
@@ -214,7 +219,7 @@ class XtreamStreamUrlResolver @Inject constructor(
         )
     }
 
-    private fun resolveDirectXtreamUrl(
+    private suspend fun resolveDirectXtreamUrl(
         provider: ProviderEntity,
         url: String,
         fallbackStreamId: Long?,
@@ -228,6 +233,7 @@ class XtreamStreamUrlResolver @Inject constructor(
         }
         val streamId = parsed?.streamId ?: fallbackStreamId?.takeIf { it > 0L } ?: return null
         val ext = parsed?.containerExtension ?: fallbackContainerExtension
+        val resolvedExt = resolveLiveContainerExtension(kind, ext)
         val decryptedPassword = credentialCrypto.decryptIfNeeded(provider.password)
         val resolvedUrl = XtreamUrlFactory.buildPlaybackUrl(
             serverUrl = provider.serverUrl,
@@ -235,15 +241,29 @@ class XtreamStreamUrlResolver @Inject constructor(
             password = decryptedPassword,
             kind = kind,
             streamId = streamId,
-            containerExtension = ext
+            containerExtension = resolvedExt
         )
         return provider.applyPlaybackRequestProfile(
             ResolvedStreamUrl(
                 url = resolvedUrl,
                 expirationTime = extractStreamExpirationTime(resolvedUrl),
-                containerExtension = ext
+                containerExtension = resolvedExt
             )
         )
+    }
+
+    private suspend fun resolveLiveContainerExtension(
+        kind: XtreamStreamKind,
+        containerExtension: String?
+    ): String? {
+        if (kind != XtreamStreamKind.LIVE) {
+            return containerExtension
+        }
+        return when (preferencesRepository.playerLiveStreamFormatMode.first()) {
+            LiveStreamFormatMode.AUTO -> containerExtension
+            LiveStreamFormatMode.HLS -> "m3u8"
+            LiveStreamFormatMode.MPEG_TS -> "ts"
+        }
     }
 
     private suspend fun resolveDirectStalkerUrl(

--- a/data/src/test/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolverTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolverTest.kt
@@ -3,6 +3,7 @@ package com.streamvault.data.remote.xtream
 import com.google.common.truth.Truth.assertThat
 import com.streamvault.data.local.dao.ProviderDao
 import com.streamvault.data.local.entity.ProviderEntity
+import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.data.remote.stalker.StalkerApiService
 import com.streamvault.data.remote.stalker.StalkerCommandVariant
 import com.streamvault.data.remote.stalker.StalkerCategoryRecord
@@ -22,11 +23,14 @@ import com.streamvault.data.remote.stalker.StalkerStreamKind
 import com.streamvault.data.remote.stalker.StalkerUrlFactory
 import com.streamvault.domain.model.ContentType
 import com.streamvault.data.security.CredentialCrypto
+import com.streamvault.domain.model.LiveStreamFormatMode
 import com.streamvault.domain.model.Result
 import com.streamvault.domain.model.ProviderType
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class XtreamStreamUrlResolverTest {
     private val credentialCrypto = object : CredentialCrypto {
@@ -35,6 +39,30 @@ class XtreamStreamUrlResolverTest {
     }
 
     private val stalkerApiService = FakeStalkerApiService()
+
+    private fun preferencesRepository(
+        liveStreamFormatMode: LiveStreamFormatMode = LiveStreamFormatMode.AUTO
+    ): PreferencesRepository = mock<PreferencesRepository>().apply {
+        whenever(playerLiveStreamFormatMode).thenReturn(flowOf(liveStreamFormatMode))
+    }
+
+    private fun xtreamResolver(
+        liveStreamFormatMode: LiveStreamFormatMode = LiveStreamFormatMode.AUTO
+    ): XtreamStreamUrlResolver = XtreamStreamUrlResolver(
+        providerDao = FakeProviderDao(xtreamProvider()),
+        credentialCrypto = credentialCrypto,
+        stalkerApiService = stalkerApiService,
+        preferencesRepository = preferencesRepository(liveStreamFormatMode)
+    )
+
+    private fun xtreamProvider(): ProviderEntity = ProviderEntity(
+        id = 9,
+        name = "Xtream",
+        type = ProviderType.XTREAM_CODES,
+        serverUrl = "https://portal.example.com",
+        username = "alice",
+        password = "secret"
+    )
 
 
     @Test
@@ -67,6 +95,87 @@ class XtreamStreamUrlResolverTest {
     }
 
     @Test
+    fun resolveWithMetadata_overrides_live_internal_url_to_mpegTs_when_preferred() {
+        runBlocking {
+        val resolver = xtreamResolver(LiveStreamFormatMode.MPEG_TS)
+        val url = XtreamUrlFactory.buildInternalStreamUrl(
+            providerId = 9,
+            kind = XtreamStreamKind.LIVE,
+            streamId = 456,
+            containerExtension = "m3u8"
+        )
+
+        val resolved = resolver.resolveWithMetadata(url)
+
+        assertThat(resolved?.url).isEqualTo("https://portal.example.com/live/alice/secret/456.ts")
+        assertThat(resolved?.containerExtension).isEqualTo("ts")
+        }
+    }
+
+    @Test
+    fun resolveWithMetadata_overrides_live_internal_url_to_hls_when_preferred() {
+        runBlocking {
+        val resolver = xtreamResolver(LiveStreamFormatMode.HLS)
+        val url = XtreamUrlFactory.buildInternalStreamUrl(
+            providerId = 9,
+            kind = XtreamStreamKind.LIVE,
+            streamId = 456,
+            containerExtension = "ts"
+        )
+
+        val resolved = resolver.resolveWithMetadata(url)
+
+        assertThat(resolved?.url).isEqualTo("https://portal.example.com/live/alice/secret/456.m3u8")
+        assertThat(resolved?.containerExtension).isEqualTo("m3u8")
+        }
+    }
+
+    @Test
+    fun resolveWithMetadata_keeps_live_internal_url_extension_in_auto_mode() {
+        runBlocking {
+        val resolver = xtreamResolver(LiveStreamFormatMode.AUTO)
+        val url = XtreamUrlFactory.buildInternalStreamUrl(
+            providerId = 9,
+            kind = XtreamStreamKind.LIVE,
+            streamId = 456,
+            containerExtension = "m3u8"
+        )
+
+        val resolved = resolver.resolveWithMetadata(url)
+
+        assertThat(resolved?.url).isEqualTo("https://portal.example.com/live/alice/secret/456.m3u8")
+        assertThat(resolved?.containerExtension).isEqualTo("m3u8")
+        }
+    }
+
+    @Test
+    fun resolveWithMetadata_does_not_apply_live_format_preference_to_vod_or_series() {
+        runBlocking {
+        val resolver = xtreamResolver(LiveStreamFormatMode.MPEG_TS)
+        val movieUrl = XtreamUrlFactory.buildInternalStreamUrl(
+            providerId = 9,
+            kind = XtreamStreamKind.MOVIE,
+            streamId = 456,
+            containerExtension = "mp4"
+        )
+        val seriesUrl = XtreamUrlFactory.buildInternalStreamUrl(
+            providerId = 9,
+            kind = XtreamStreamKind.SERIES,
+            streamId = 789,
+            containerExtension = "mkv"
+        )
+
+        val movie = resolver.resolveWithMetadata(movieUrl)
+        val series = resolver.resolveWithMetadata(seriesUrl)
+
+        assertThat(movie?.url).isEqualTo("https://portal.example.com/movie/alice/secret/456.mp4")
+        assertThat(movie?.containerExtension).isEqualTo("mp4")
+        assertThat(series?.url).isEqualTo("https://portal.example.com/series/alice/secret/789.mkv")
+        assertThat(series?.containerExtension).isEqualTo("mkv")
+        }
+    }
+
+    @Test
     fun resolveWithMetadata_prefers_allowed_direct_source_for_vod() {
         runBlocking {
         val resolver = XtreamStreamUrlResolver(
@@ -81,7 +190,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = stalkerApiService
+            stalkerApiService = stalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val url = XtreamUrlFactory.buildInternalStreamUrl(
             providerId = 9,
@@ -115,7 +225,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = stalkerApiService
+            stalkerApiService = stalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val url = XtreamUrlFactory.buildInternalStreamUrl(
             providerId = 9,
@@ -150,7 +261,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = stalkerApiService
+            stalkerApiService = stalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
 
         val resolved = resolver.resolveWithMetadata(
@@ -181,7 +293,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = stalkerApiService
+            stalkerApiService = stalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val url = XtreamUrlFactory.buildInternalStreamUrl(
             providerId = 9,
@@ -212,7 +325,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = stalkerApiService
+            stalkerApiService = stalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
 
         val resolved = resolver.resolveWithMetadata(
@@ -274,7 +388,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val internalUrl = StalkerUrlFactory.buildInternalStreamUrl(
             providerId = 14,
@@ -324,7 +439,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val directCmd = "http://0connect.top:8080/9UTXtQcxuxkk/9fa4ed5x07/443?play_token=iwdgLK23Yl"
         val internalUrl = StalkerUrlFactory.buildInternalStreamUrl(
@@ -366,7 +482,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val internalUrl = StalkerUrlFactory.buildInternalStreamUrl(
             providerId = 14,
@@ -409,7 +526,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val internalUrl = StalkerUrlFactory.buildInternalStreamUrl(
             providerId = 14,
@@ -447,7 +565,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
         val descriptor = StalkerPlaybackDescriptor(
             primaryMode = StalkerPlaybackMode.MULTI_CMD,
@@ -501,7 +620,8 @@ class XtreamStreamUrlResolverTest {
                 )
             ),
             credentialCrypto = credentialCrypto,
-            stalkerApiService = fakeStalkerApiService
+            stalkerApiService = fakeStalkerApiService,
+            preferencesRepository = preferencesRepository()
         )
 
         val resolved = resolver.resolveWithMetadata(

--- a/domain/src/main/java/com/streamvault/domain/model/StreamInfo.kt
+++ b/domain/src/main/java/com/streamvault/domain/model/StreamInfo.kt
@@ -81,3 +81,9 @@ enum class VodHttpProtocolMode {
     COMPATIBILITY_HTTP1,
     AUTO
 }
+
+enum class LiveStreamFormatMode {
+    AUTO,
+    HLS,
+    MPEG_TS
+}


### PR DESCRIPTION
## Summary

Live TV playback gets a user-selectable stream format: Auto (today's behavior), HLS (m3u8), or MPEG-TS (ts). The preference is enforced at the single playback choke point, `XtreamStreamUrlResolver`, by overriding the container extension when resolving a live `xtream://` token, so no provider re-sync is needed and VOD/series URLs are untouched.

## Why this matters

The reporter in #77 has an Xtream provider whose live channels fail over HLS ("Retrying HLS 1/1 in 1s" and then "we couldn't start this stream on the available paths") while the same channels play fine as MPEG-TS in IPTV Smarters Pro and VLC. `XtreamProvider.preferredLiveContainerExtension()` prefers `m3u8` whenever the provider advertises both formats, that extension is baked into the stored stream URL at sync time, and the HLS-to-TS recovery fallback does not rescue this provider. The reporter confirmed on 1.0.12 there is no format option anywhere in the app.

## Changes

- `LiveStreamFormatMode` enum in `domain/model/StreamInfo.kt`, persisted in `PreferencesRepository` following the existing `playerVodHttpProtocolMode` Flow + setter pattern, surfaced in the playback settings section like the VOD HTTP protocol selector.
- The new key is included in `BackupManagerImpl`'s preference export/restore lists alongside the neighboring player settings, so config backups and Drive sync preserve the choice.

## Testing

Resolver unit tests cover: live `m3u8` token resolving to `.ts` under MPEG-TS, live `ts` token resolving to `.m3u8` under HLS, Auto preserving the token's extension, and VOD/series resolution ignoring the live preference. Preference round-trip defaults to Auto.

Fixes #77
