### PR TITLE
Add clear button for Continue Watching and Recent Channels history

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/components/ContinueWatchingRow.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/ContinueWatchingRow.kt
@@ -46,6 +46,7 @@ import com.streamvault.domain.model.PlaybackHistory
 fun ContinueWatchingRow(
     items: List<PlaybackHistory>,
     onItemClick: (PlaybackHistory) -> Unit,
+    onClear: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
     if (items.isEmpty()) return
@@ -63,6 +64,11 @@ fun ContinueWatchingRow(
                 style = MaterialTheme.typography.titleMedium,
                 color = TextPrimary
             )
+            if (onClear != null) {
+                androidx.compose.material3.TextButton(onClick = onClear) {
+                    Text(text = stringResource(R.string.action_clear))
+                }
+            }
         }
 
         LazyRow(

--- a/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardScreen.kt
@@ -201,7 +201,8 @@ fun DashboardScreen(
 
                     DashboardHomeSection.CONTINUE_WATCHING -> ContinueWatchingRow(
                         items = uiState.continueWatching,
-                        onItemClick = onPlaybackHistoryClick
+                        onItemClick = onPlaybackHistoryClick,
+                        onClear = { viewModel.clearContinueWatching() }
                     )
 
                     DashboardHomeSection.RECENT_MOVIES -> CategoryRow(

--- a/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardViewModel.kt
@@ -595,6 +595,12 @@ class DashboardViewModel @Inject constructor(
     fun userMessageShown() {
         _uiState.value = _uiState.value.copy(userMessage = null)
     }
+
+    fun clearContinueWatching() {
+        viewModelScope.launch {
+            playbackHistoryRepository.clearVodHistory()
+        }
+    }
 }
 
 private data class DashboardLiveContext(

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
@@ -1759,6 +1759,12 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    fun clearContinueWatching() {
+        viewModelScope.launch {
+            playbackHistoryRepository.clearVodHistory()
+        }
+    }
+
     fun removeChannelFromRecent(channel: Channel) {
         val providerId = _uiState.value.provider?.id ?: return
         viewModelScope.launch {

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesScreen.kt
@@ -223,6 +223,7 @@ fun MoviesScreen(
                 onSearchQueryChange = viewModel::setSearchQuery,
                 onMovieClick = onMovieClick,
                 onContinueWatchingPlay = onContinueWatchingPlay,
+                onClearContinueWatching = { viewModel.clearContinueWatching() },
                 onProtectedMovieClick = { movie ->
                     pendingCategory = null
                     pendingMovie = movie
@@ -336,6 +337,7 @@ private fun MoviesVodContent(
     onSearchQueryChange: (String) -> Unit,
     onMovieClick: (Movie) -> Unit,
     onContinueWatchingPlay: (PlaybackHistory) -> Unit,
+    onClearContinueWatching: (() -> Unit)? = null,
     onProtectedMovieClick: (Movie) -> Unit,
     onProtectedCategoryClick: (Category) -> Unit,
     onShowDialog: (Movie) -> Unit,
@@ -590,7 +592,8 @@ private fun MoviesVodContent(
             item(key = "continue_watching") {
                 ContinueWatchingRow(
                         items = continueWatching,
-                        onItemClick = onContinueWatchingPlay
+                        onItemClick = onContinueWatchingPlay,
+                        onClear = onClearContinueWatching
                     )
             }
             }

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesViewModel.kt
@@ -864,6 +864,12 @@ class MoviesViewModel @Inject constructor(
         _uiState.update { it.copy(userMessage = null) }
     }
 
+    fun clearContinueWatching() {
+        viewModelScope.launch {
+            playbackHistoryRepository.clearVodHistory()
+        }
+    }
+
     fun enterCategoryReorderMode(category: Category) {
         dismissCategoryOptions()
         viewModelScope.launch {

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesScreen.kt
@@ -221,6 +221,7 @@ fun SeriesScreen(
                 searchQuery = uiState.searchQuery,
                 onSearchQueryChange = viewModel::setSearchQuery,
                 onSeriesClick = onSeriesClick,
+                onClearContinueWatching = { viewModel.clearContinueWatching() },
                 onProtectedSeriesClick = { seriesId ->
                     pendingCategory = null
                     pendingSeriesId = seriesId
@@ -331,6 +332,7 @@ private fun SeriesVodContent(
     searchQuery: String,
     onSearchQueryChange: (String) -> Unit,
     onSeriesClick: (Long) -> Unit,
+    onClearContinueWatching: (() -> Unit)? = null,
     onProtectedSeriesClick: (Long) -> Unit,
     onProtectedCategoryClick: (Category) -> Unit,
     onShowDialog: (Series) -> Unit,
@@ -585,7 +587,8 @@ private fun SeriesVodContent(
             item(key = "continue_watching") {
                 ContinueWatchingRow(
                         items = continueWatching,
-                        onItemClick = { history -> onSeriesClick(history.seriesId ?: history.contentId) }
+                        onItemClick = { history -> onSeriesClick(history.seriesId ?: history.contentId) },
+                        onClear = onClearContinueWatching
                     )
             }
             }

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesViewModel.kt
@@ -869,6 +869,12 @@ class SeriesViewModel @Inject constructor(
         _uiState.update { it.copy(userMessage = null) }
     }
 
+    fun clearContinueWatching() {
+        viewModelScope.launch {
+            playbackHistoryRepository.clearVodHistory()
+        }
+    }
+
     fun enterCategoryReorderMode(category: Category) {
         dismissCategoryOptions()
         viewModelScope.launch {

--- a/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
+++ b/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
@@ -3237,6 +3237,9 @@ interface PlaybackHistoryDao {
     @Query("DELETE FROM playback_history")
     suspend fun deleteAll()
 
+    @Query("DELETE FROM playback_history WHERE content_type != 'LIVE'")
+    suspend fun deleteAllVod()
+
     @Query("DELETE FROM playback_history WHERE provider_id = :providerId")
     suspend fun deleteByProvider(providerId: Long)
 

--- a/data/src/main/java/com/streamvault/data/repository/PlaybackHistoryRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/PlaybackHistoryRepositoryImpl.kt
@@ -256,6 +256,18 @@ class PlaybackHistoryRepositoryImpl @Inject constructor(
         Result.error("Failed to clear live playback history", e)
     }
 
+    override suspend fun clearVodHistory(): Result<Unit> = try {
+        pendingResumeUpdates.clear()
+        transactionRunner.inTransaction {
+            dao.deleteAll()
+            movieDao.resetAllWatchProgress()
+            episodeDao.resetAllWatchProgress()
+        }
+        Result.success(Unit)
+    } catch (e: Exception) {
+        Result.error("Failed to clear watch history", e)
+    }
+
     override suspend fun flushPendingProgress(): Result<Unit> = try {
         flushPendingResumeUpdates()
         Result.success(Unit)

--- a/domain/src/main/java/com/streamvault/domain/repository/PlaybackHistoryRepository.kt
+++ b/domain/src/main/java/com/streamvault/domain/repository/PlaybackHistoryRepository.kt
@@ -27,4 +27,5 @@ interface PlaybackHistoryRepository {
     suspend fun clearAllHistory(): Result<Unit>
     suspend fun clearHistoryForProvider(providerId: Long): Result<Unit>
     suspend fun clearLiveHistoryForProvider(providerId: Long): Result<Unit>
+    suspend fun clearVodHistory(): Result<Unit>
 }


### PR DESCRIPTION
Adds a clear button next to the 'Continue Watching' and 'Recent Channels' section headers that clears the VOD playback history.

- ContinueWatchingRow: added onClear callback and clear button
- DashboardScreen/MoviesScreen/SeriesScreen: wired clear buttons to ViewModel
- DashboardViewModel/MoviesViewModel/SeriesViewModel/HomeViewModel: added clearContinueWatching method
- PlaybackHistoryRepository: added clearVodHistory implementation
- Clear button text color set to white