### PR TITLE
Jellyfin provider support with QR pairing fix

### DIFF
--- a/app/src/main/java/com/streamvault/app/pairing/ProviderQrPairingManager.kt
+++ b/app/src/main/java/com/streamvault/app/pairing/ProviderQrPairingManager.kt
@@ -14,8 +14,6 @@ import com.google.zxing.qrcode.QRCodeWriter
 import com.streamvault.domain.model.ProviderEpgSyncMode
 import com.streamvault.domain.model.ProviderXtreamLiveSyncMode
 import com.streamvault.domain.model.StalkerAuthMode
-import com.streamvault.data.remote.jellyfin.JellyfinProvider
-import com.streamvault.domain.model.Provider
 import com.streamvault.domain.repository.ProviderRepository
 import com.streamvault.domain.usecase.JellyfinProviderSetupCommand
 import com.streamvault.domain.usecase.M3uProviderSetupCommand
@@ -58,8 +56,7 @@ private const val TAG = "ProviderQrPairing"
 class ProviderQrPairingManager @Inject constructor(
     @ApplicationContext private val context: Context,
     private val validateAndAddProvider: ValidateAndAddProvider,
-    private val providerRepository: ProviderRepository,
-    private val jellyfinProvider: JellyfinProvider
+    private val providerRepository: ProviderRepository
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private val secureRandom = SecureRandom()
@@ -202,19 +199,11 @@ class ProviderQrPairingManager @Inject constructor(
                         status = ProviderQrPairingStatus.RECEIVING,
                         message = "Phone submitted provider details. Validating..."
                     )
-                    val providerName = form["name"].orEmpty().ifBlank {
-                        when (form["type"].orEmpty().lowercase(Locale.US)) {
-                            "m3u" -> "Phone M3U Playlist"
-                            "stalker" -> "Phone Stalker Portal"
-                            "jellyfin" -> "Phone Jellyfin"
-                            else -> "Phone Xtream Provider"
-                        }
-                    }
-                    val saveResult = saveProviderOnly(form, providerName)
+                    val saveResult = addProviderFromForm(form)
                     when (saveResult) {
                         is ProviderPairingSubmitResult.Success -> {
-                            writeHtml(client.getOutputStream(), 200, successPage(providerName))
-                            invalidateAfterSuccess(providerName)
+                            writeHtml(client.getOutputStream(), 200, successPage(saveResult.providerName))
+                            invalidateAfterSuccess(saveResult.providerName)
                         }
                         is ProviderPairingSubmitResult.Error -> {
                             _state.value = _state.value.copy(
@@ -230,48 +219,6 @@ class ProviderQrPairingManager @Inject constructor(
         }
     }
 
-    private suspend fun saveProviderOnly(form: Map<String, String>, providerName: String): ProviderPairingSubmitResult {
-        val type = form["type"].orEmpty().lowercase(Locale.US)
-        return try {
-            val provider = when (type) {
-                "m3u" -> {
-                    val url = form["m3uUrl"].orEmpty()
-                    if (url.isBlank()) return ProviderPairingSubmitResult.Error("Please enter M3U URL")
-                    Provider(name = providerName, type = com.streamvault.domain.model.ProviderType.M3U, serverUrl = "", m3uUrl = url, isActive = false, status = com.streamvault.domain.model.ProviderStatus.PARTIAL)
-                }
-                "stalker" -> {
-                    val portalUrl = form["serverUrl"].orEmpty()
-                    val macAddress = form["macAddress"].orEmpty()
-                    if (portalUrl.isBlank()) return ProviderPairingSubmitResult.Error("Please enter portal URL")
-                    Provider(name = providerName, type = com.streamvault.domain.model.ProviderType.STALKER_PORTAL, serverUrl = portalUrl, stalkerMacAddress = macAddress, username = form["username"].orEmpty(), password = form["password"].orEmpty(), isActive = false, status = com.streamvault.domain.model.ProviderStatus.PARTIAL)
-                }
-                "jellyfin" -> {
-                    val serverUrl = form["serverUrl"].orEmpty()
-                    val username = form["username"].orEmpty()
-                    val password = form["password"].orEmpty()
-                    if (serverUrl.isBlank()) return ProviderPairingSubmitResult.Error("Please enter server URL")
-                    if (password.isBlank()) return ProviderPairingSubmitResult.Error("Please enter password")
-                    val authResult = jellyfinProvider.authenticate(serverUrl, username, password)
-                    val accessToken = when (authResult) {
-                        is com.streamvault.domain.model.Result.Success -> authResult.data
-                        is com.streamvault.domain.model.Result.Error -> return ProviderPairingSubmitResult.Error("Jellyfin authentication failed: ${authResult.message}")
-                        is com.streamvault.domain.model.Result.Loading -> return ProviderPairingSubmitResult.Error("Authentication failed")
-                    }
-                    Provider(name = providerName, type = com.streamvault.domain.model.ProviderType.JELLYFIN, serverUrl = serverUrl, username = username, password = accessToken, isActive = false, status = com.streamvault.domain.model.ProviderStatus.PARTIAL)
-                }
-                else -> {
-                    val serverUrl = form["serverUrl"].orEmpty()
-                    if (serverUrl.isBlank()) return ProviderPairingSubmitResult.Error("Please enter server URL")
-                    Provider(name = providerName, type = com.streamvault.domain.model.ProviderType.XTREAM_CODES, serverUrl = serverUrl, username = form["username"].orEmpty(), password = form["password"].orEmpty(), isActive = false, status = com.streamvault.domain.model.ProviderStatus.PARTIAL)
-                }
-            }
-            val providerId = providerRepository.addProvider(provider).getOrNull()
-                ?: return ProviderPairingSubmitResult.Error("Failed to save provider")
-            ProviderPairingSubmitResult.Success(providerName)
-        } catch (e: Exception) {
-            ProviderPairingSubmitResult.Error("Failed to save provider: ${e.message ?: "unknown error"}")
-        }
-    }
 
     private suspend fun addProviderFromForm(form: Map<String, String>): ProviderPairingSubmitResult {
         val type = form["type"].orEmpty().lowercase(Locale.US)

--- a/data/src/main/java/com/streamvault/data/remote/jellyfin/JellyfinProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/jellyfin/JellyfinProvider.kt
@@ -225,9 +225,9 @@ class JellyfinProvider @Inject constructor(
         return MovieEntity(
             streamId = stableRemoteId(remoteId),
             name = item.name.orEmpty(),
-            posterUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary")),
+            posterUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary"), provider.password),
             backdropUrl = item.backdropImageTags?.firstOrNull()?.let { tag ->
-                buildImageUrl(provider.serverUrl, remoteId, "Backdrop", tag, imageIndex = 0)
+                buildImageUrl(provider.serverUrl, remoteId, "Backdrop", tag, provider.password, imageIndex = 0)
             },
             categoryId = MOVIE_CATEGORY_ID,
             categoryName = "Movies",
@@ -253,9 +253,9 @@ class JellyfinProvider @Inject constructor(
             seriesId = stableRemoteId(remoteId),
             providerSeriesId = remoteId,
             name = item.name.orEmpty(),
-            posterUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary")),
+            posterUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary"), provider.password),
             backdropUrl = item.backdropImageTags?.firstOrNull()?.let { tag ->
-                buildImageUrl(provider.serverUrl, remoteId, "Backdrop", tag, imageIndex = 0)
+                buildImageUrl(provider.serverUrl, remoteId, "Backdrop", tag, provider.password, imageIndex = 0)
             },
             categoryId = SERIES_CATEGORY_ID,
             categoryName = "Series",
@@ -282,7 +282,7 @@ class JellyfinProvider @Inject constructor(
             seasonNumber = item.parentIndexNumber ?: 0,
             streamUrl = buildStreamUrl(provider.serverUrl, remoteId),
             containerExtension = item.primaryMediaSource?.container?.takeIf { it.isNotBlank() },
-            coverUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary")),
+            coverUrl = buildImageUrl(provider.serverUrl, remoteId, "Primary", item.imageTags?.get("Primary"), provider.password),
             plot = item.overview,
             duration = item.runTimeTicks?.let(::ticksToDurationString),
             durationSeconds = item.runTimeTicks?.let(::ticksToSeconds)?.toInt() ?: 0,
@@ -323,8 +323,9 @@ class JellyfinProvider @Inject constructor(
     private fun buildStreamUrl(baseUrl: String, itemId: String): String =
         "${baseUrl.trimEnd('/')}/Videos/$itemId/stream"
 
-    private fun buildImageUrl(baseUrl: String, itemId: String, imageType: String, tag: String?, imageIndex: Int? = null): String {
+    private fun buildImageUrl(baseUrl: String, itemId: String, imageType: String, tag: String?, apiKey: String?, imageIndex: Int? = null): String {
         val qs = buildList {
+            apiKey?.takeIf { it.isNotBlank() }?.let { add("api_key=${enc(it)}") }
             tag?.takeIf { it.isNotBlank() }?.let { add("tag=${enc(it)}") }
         }.joinToString("&")
         val path = if (imageIndex != null) "/Items/$itemId/Images/$imageType/$imageIndex" else "/Items/$itemId/Images/$imageType"


### PR DESCRIPTION
Add Jellyfin as a new provider type for browsing and playing movies and series from a Jellyfin media server.

- JellyfinProvider: authenticates via password or Quick Connect, fetches movies, series, and episodes from the Jellyfin API
- QR pairing flow: exchanges password for access token before saving
- On-demand episode fetching when opening series detail
- Provider setup UI with Quick Connect button, QR code display, and Cancel button
- Sync via syncJellyfin method with proper credential decryption
- Quick Connect code shown inside the progress dialog with Cancel button
- All HTTP calls wrapped in Dispatchers.IO to avoid NetworkOnMainThreadException

Fixes:
- QR pairing regression: restored addProviderFromForm() call path so Xtream/Stalker/M3U providers added via phone pairing get the full onboarding (authenticate -> sync -> activate) instead of being saved as isActive=false / PARTIAL

Cherry-picked from disclosurez:master PR #125 onto disclosurez develop branch. Resolved conflicts with develop's Stalker hardening, attachMoviePresentation/attachSeriesPresentation, and other integrated PRs.