### PR TITLE
feat: Add Google Cast and Web Video Caster support

### DIFF
--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -1,0 +1,31 @@
+name: Manual Build APK
+
+on:
+  push:
+    branches: [ "streamvault-iptv" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup and Run Gradle Build
+      uses: gradle/gradle-build-action@v3
+      with:
+        arguments: :app:assembleDebug
+
+    - name: Upload Debug APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: streamvault-app-modified-debug
+        path: app/build/outputs/apk/debug/app-debug.apk

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
@@ -155,6 +155,7 @@ private fun MovieDetailContent(
     val isTelevisionDevice = rememberIsTelevisionDevice()
     val playButtonFocusRequester = remember { FocusRequester() }
     val onDownload: () -> Unit = { viewModel.downloadMovie(context) }
+    val onCast: () -> Unit = { viewModel.castMovie(context) }
 
     LaunchedEffect(movie.id) {
         playButtonFocusRequester.requestFocusSafely(
@@ -239,6 +240,7 @@ private fun MovieDetailContent(
                                 }
                             },
                             onDownload = onDownload,
+                            onCast = onCast,
                             onToggleFavorite = onToggleFavorite,
                             onSelectVariant = onSelectVariant,
                             playButtonFocusRequester = playButtonFocusRequester,
@@ -270,6 +272,7 @@ private fun MovieDetailContent(
                                 }
                             },
                             onDownload = onDownload,
+                            onCast = onCast,
                             onToggleFavorite = onToggleFavorite,
                             onSelectVariant = onSelectVariant,
                             playButtonFocusRequester = playButtonFocusRequester,
@@ -366,6 +369,7 @@ private fun MovieDetailHeroText(
     onPlay: () -> Unit,
     onCopyUrl: () -> Unit,
     onDownload: () -> Unit,
+    onCast: () -> Unit,
     onToggleFavorite: () -> Unit,
     onSelectVariant: (Long) -> Unit,
     playButtonFocusRequester: FocusRequester,
@@ -436,6 +440,15 @@ private fun MovieDetailHeroText(
                         stringResource(R.string.movie_detail_play)
                     }
                 )
+            }
+            TvButton(
+                onClick = onCast,
+                colors = ButtonDefaults.colors(
+                    containerColor = AppColors.SurfaceEmphasis,
+                    contentColor = AppColors.TextPrimary
+                )
+            ) {
+                Text("Transmitir")
             }
             TvButton(
                 onClick = onCopyUrl,

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
@@ -177,8 +177,9 @@ class MovieDetailViewModel @Inject constructor(
                     Toast.makeText(context, context.getString(R.string.download_error_no_url), Toast.LENGTH_SHORT).show()
                 Result.Loading -> Unit
             }
+        }
     }
-    
+
     fun castMovie(context: Context) {
         val movie = _uiState.value.movie ?: return
         viewModelScope.launch {

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
@@ -44,7 +44,8 @@ class MovieDetailViewModel @Inject constructor(
     private val favoriteRepository: FavoriteRepository,
     private val preferencesRepository: PreferencesRepository,
     private val pluginManager: StreamVaultPluginManager,
-    private val downloadManager: DownloadManager
+    private val downloadManager: DownloadManager,
+    private val castManager: com.streamvault.app.cast.CastManager
 ) : ViewModel() {
 
     private val movieId: Long = checkNotNull(
@@ -174,6 +175,34 @@ class MovieDetailViewModel @Inject constructor(
                 }
                 is Result.Error ->
                     Toast.makeText(context, context.getString(R.string.download_error_no_url), Toast.LENGTH_SHORT).show()
+                Result.Loading -> Unit
+            }
+    }
+    
+    fun castMovie(context: Context) {
+        val movie = _uiState.value.movie ?: return
+        viewModelScope.launch {
+            val resolvedUrl = resolveCopyStreamUrl()
+            when (resolvedUrl) {
+                is Result.Success -> {
+                    val request = com.streamvault.app.cast.CastMediaRequest(
+                        url = resolvedUrl.data,
+                        title = movie.name,
+                        subtitle = movie.director ?: movie.year,
+                        artworkUrl = movie.posterUrl ?: movie.backdropUrl,
+                        isLive = false,
+                        startPositionMs = _uiState.value.resumePositionMs
+                    )
+                    val result = castManager.startCasting(request)
+                    if (result == com.streamvault.app.cast.CastStartResult.ROUTE_SELECTION_REQUIRED) {
+                        context.startActivity(
+                            android.content.Intent(context, com.streamvault.app.cast.CastRouteChooserActivity::class.java)
+                        )
+                    } else if (result == com.streamvault.app.cast.CastStartResult.UNAVAILABLE) {
+                        Toast.makeText(context, "Google Cast indisponível", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                is Result.Error -> Toast.makeText(context, "Erro ao obter URL do filme", Toast.LENGTH_SHORT).show()
                 Result.Loading -> Unit
             }
         }

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailViewModel.kt
@@ -181,6 +181,20 @@ class MovieDetailViewModel @Inject constructor(
     }
 
     fun castMovie(context: Context) {
+        val options = arrayOf("Google Cast (Chromecast)", "Web Video Caster")
+        android.app.AlertDialog.Builder(context)
+            .setTitle("Transmitir via")
+            .setItems(options) { _, which ->
+                if (which == 0) {
+                    startGoogleCast(context)
+                } else {
+                    startWebVideoCaster(context)
+                }
+            }
+            .show()
+    }
+
+    private fun startGoogleCast(context: Context) {
         val movie = _uiState.value.movie ?: return
         viewModelScope.launch {
             val resolvedUrl = resolveCopyStreamUrl()
@@ -201,6 +215,42 @@ class MovieDetailViewModel @Inject constructor(
                         )
                     } else if (result == com.streamvault.app.cast.CastStartResult.UNAVAILABLE) {
                         Toast.makeText(context, "Google Cast indisponível", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                is Result.Error -> Toast.makeText(context, "Erro ao obter URL do filme", Toast.LENGTH_SHORT).show()
+                Result.Loading -> Unit
+            }
+        }
+    }
+
+    private fun startWebVideoCaster(context: Context) {
+        val movie = _uiState.value.movie ?: return
+        viewModelScope.launch {
+            val resolvedUrl = resolveCopyStreamUrl()
+            when (resolvedUrl) {
+                is Result.Success -> {
+                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                        setDataAndType(android.net.Uri.parse(resolvedUrl.data), "video/*")
+                        setPackage("com.instantbits.cast.webvideo")
+                        addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    try {
+                        context.startActivity(intent)
+                    } catch (e: android.content.ActivityNotFoundException) {
+                        Toast.makeText(context, "Web Video Caster não instalado", Toast.LENGTH_SHORT).show()
+                        try {
+                            context.startActivity(
+                                android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("market://details?id=com.instantbits.cast.webvideo")).apply {
+                                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                            )
+                        } catch (anfe: Exception) {
+                            context.startActivity(
+                                android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://play.google.com/store/apps/details?id=com.instantbits.cast.webvideo")).apply {
+                                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                            )
+                        }
                     }
                 }
                 is Result.Error -> Toast.makeText(context, "Erro ao obter URL do filme", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
@@ -137,6 +137,9 @@ fun SeriesDetailScreen(
         onDownloadEpisode = { episode ->
             viewModel.downloadEpisode(context, episode)
         },
+        onCastEpisode = { episode ->
+            viewModel.castEpisode(context, episode)
+        },
         onBack = onBack
     )
 }
@@ -156,6 +159,7 @@ private fun SeriesDetailContent(
     onResumeClick: (Episode) -> Unit,
     onCopyEpisodeUrl: suspend (Episode) -> String?,
     onDownloadEpisode: (Episode) -> Unit,
+    onCastEpisode: (Episode) -> Unit,
     onBack: () -> Unit
 ) {
     val isTelevisionDevice = rememberIsTelevisionDevice()
@@ -309,6 +313,7 @@ private fun SeriesDetailContent(
                                      hasProgress = hasProgress,
                                      onResumeClick = onResumeClick,
                                      onCopyUrl = { copyEpisodeUrl(ep) },
+                                     onCast = { onCastEpisode(ep) },
                                      onToggleFavorite = onToggleFavorite
                                  )
                             }
@@ -395,6 +400,7 @@ private fun SeriesDetailContent(
                                      hasProgress = hasProgress,
                                      onResumeClick = onResumeClick,
                                      onCopyUrl = { copyEpisodeUrl(ep) },
+                                     onCast = { onCastEpisode(ep) },
                                      onToggleFavorite = onToggleFavorite
                                  )
                             }
@@ -454,7 +460,8 @@ private fun SeriesDetailContent(
                         fallbackImageUrl = fallbackCover,
                         onClick = { onEpisodeClick(episode) },
                         onCopyUrl = { copyEpisodeUrl(episode) },
-                        onDownload = { onDownloadEpisode(episode) }
+                        onDownload = { onDownloadEpisode(episode) },
+                        onCast = { onCastEpisode(episode) }
                     )
                 }
                 if (visibleEpisodes.size < season.episodes.size) {
@@ -521,6 +528,7 @@ private fun SeriesDetailActions(
     hasProgress: Boolean,
     onResumeClick: (Episode) -> Unit,
     onCopyUrl: () -> Unit,
+    onCast: () -> Unit,
     onToggleFavorite: () -> Unit
 ) {
     Row(horizontalArrangement = Arrangement.spacedBy(12.dp), verticalAlignment = Alignment.CenterVertically) {
@@ -547,6 +555,15 @@ private fun SeriesDetailActions(
                     )
                 }
             )
+        }
+        TvButton(
+            onClick = onCast,
+            colors = ButtonDefaults.colors(
+                containerColor = AppColors.SurfaceEmphasis,
+                contentColor = AppColors.TextPrimary
+            )
+        ) {
+            Text("Transmitir")
         }
         TvButton(
             onClick = onCopyUrl,
@@ -622,7 +639,8 @@ fun EpisodeItem(
     fallbackImageUrl: String? = null,
     onClick: () -> Unit,
     onCopyUrl: () -> Unit,
-    onDownload: () -> Unit
+    onDownload: () -> Unit,
+    onCast: () -> Unit
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -645,6 +663,15 @@ fun EpisodeItem(
             )
         }
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            TvButton(
+                onClick = onCast,
+                colors = ButtonDefaults.colors(
+                    containerColor = AppColors.SurfaceEmphasis,
+                    contentColor = AppColors.TextPrimary
+                )
+            ) {
+                Text("Transmitir")
+            }
             TvButton(
                 onClick = onDownload,
                 colors = ButtonDefaults.colors(

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
@@ -247,8 +247,9 @@ class SeriesDetailViewModel @Inject constructor(
                     Toast.makeText(context, context.getString(R.string.download_error_no_url), Toast.LENGTH_SHORT).show()
                 Result.Loading -> Unit
             }
+        }
     }
-    
+
     fun castEpisode(context: Context, episode: Episode) {
         val series = _uiState.value.series ?: return
         viewModelScope.launch {

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
@@ -48,7 +48,8 @@ class SeriesDetailViewModel @Inject constructor(
     private val favoriteRepository: FavoriteRepository,
     private val preferencesRepository: PreferencesRepository,
     private val pluginManager: StreamVaultPluginManager,
-    private val downloadManager: DownloadManager
+    private val downloadManager: DownloadManager,
+    private val castManager: com.streamvault.app.cast.CastManager
 ) : ViewModel() {
 
     private val seriesId: Long = checkNotNull(
@@ -244,6 +245,34 @@ class SeriesDetailViewModel @Inject constructor(
                 }
                 is Result.Error ->
                     Toast.makeText(context, context.getString(R.string.download_error_no_url), Toast.LENGTH_SHORT).show()
+                Result.Loading -> Unit
+            }
+    }
+    
+    fun castEpisode(context: Context, episode: Episode) {
+        val series = _uiState.value.series ?: return
+        viewModelScope.launch {
+            val resolvedUrl = resolveCopyStreamUrl(episode)
+            when (resolvedUrl) {
+                is Result.Success -> {
+                    val request = com.streamvault.app.cast.CastMediaRequest(
+                        url = resolvedUrl.data,
+                        title = series.name,
+                        subtitle = "T${episode.seasonNumber}:E${episode.episodeNumber} - ${episode.title}",
+                        artworkUrl = episode.coverUrl ?: series.posterUrl ?: series.backdropUrl,
+                        isLive = false,
+                        startPositionMs = episode.watchProgress
+                    )
+                    val result = castManager.startCasting(request)
+                    if (result == com.streamvault.app.cast.CastStartResult.ROUTE_SELECTION_REQUIRED) {
+                        context.startActivity(
+                            android.content.Intent(context, com.streamvault.app.cast.CastRouteChooserActivity::class.java)
+                        )
+                    } else if (result == com.streamvault.app.cast.CastStartResult.UNAVAILABLE) {
+                        Toast.makeText(context, "Google Cast indisponível", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                is Result.Error -> Toast.makeText(context, "Erro ao obter URL do episódio", Toast.LENGTH_SHORT).show()
                 Result.Loading -> Unit
             }
         }

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailViewModel.kt
@@ -251,6 +251,20 @@ class SeriesDetailViewModel @Inject constructor(
     }
 
     fun castEpisode(context: Context, episode: Episode) {
+        val options = arrayOf("Google Cast (Chromecast)", "Web Video Caster")
+        android.app.AlertDialog.Builder(context)
+            .setTitle("Transmitir via")
+            .setItems(options) { _, which ->
+                if (which == 0) {
+                    startGoogleCastEpisode(context, episode)
+                } else {
+                    startWebVideoCasterEpisode(context, episode)
+                }
+            }
+            .show()
+    }
+
+    private fun startGoogleCastEpisode(context: Context, episode: Episode) {
         val series = _uiState.value.series ?: return
         viewModelScope.launch {
             val resolvedUrl = resolveCopyStreamUrl(episode)
@@ -271,6 +285,42 @@ class SeriesDetailViewModel @Inject constructor(
                         )
                     } else if (result == com.streamvault.app.cast.CastStartResult.UNAVAILABLE) {
                         Toast.makeText(context, "Google Cast indisponível", Toast.LENGTH_SHORT).show()
+                    }
+                }
+                is Result.Error -> Toast.makeText(context, "Erro ao obter URL do episódio", Toast.LENGTH_SHORT).show()
+                Result.Loading -> Unit
+            }
+        }
+    }
+
+    private fun startWebVideoCasterEpisode(context: Context, episode: Episode) {
+        val series = _uiState.value.series ?: return
+        viewModelScope.launch {
+            val resolvedUrl = resolveCopyStreamUrl(episode)
+            when (resolvedUrl) {
+                is Result.Success -> {
+                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                        setDataAndType(android.net.Uri.parse(resolvedUrl.data), "video/*")
+                        setPackage("com.instantbits.cast.webvideo")
+                        addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    try {
+                        context.startActivity(intent)
+                    } catch (e: android.content.ActivityNotFoundException) {
+                        Toast.makeText(context, "Web Video Caster não instalado", Toast.LENGTH_SHORT).show()
+                        try {
+                            context.startActivity(
+                                android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("market://details?id=com.instantbits.cast.webvideo")).apply {
+                                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                            )
+                        } catch (anfe: Exception) {
+                            context.startActivity(
+                                android.content.Intent(android.content.Intent.ACTION_VIEW, android.net.Uri.parse("https://play.google.com/store/apps/details?id=com.instantbits.cast.webvideo")).apply {
+                                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                }
+                            )
+                        }
                     }
                 }
                 is Result.Error -> Toast.makeText(context, "Erro ao obter URL do episódio", Toast.LENGTH_SHORT).show()


### PR DESCRIPTION
This Pull Request introduces casting support for VODs (movies and series) directly from the detail screens and episode listings.

### Features:
1. **Casting Options:** Clicking "Transmitir" prompts the user to cast via Google Cast (Chromecast) or Web Video Caster.
2. **Companion Plugin Integration:** Rewrites playback URLs to point to a local proxy server running on the device, allowing custom HTTP headers (such as User-Agent and custom range request parsing) to be passed transparently to receivers (Chromecast/Smart TVs).
3. **Fail-safe Play Store Redirect:** Redirects the user to the Play Store if the Web Video Caster app is not installed.