### PR TITLE
Sort movie/series categories and items by year descending (newest first)

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
@@ -100,7 +100,7 @@ internal fun observeSettingsPreferenceSnapshot(
             liveVariantPreferenceMode = LiveVariantPreferenceMode.BALANCED,
             vodViewMode = VodViewMode.MODERN,
             vodInfiniteScroll = true,
-            vodDuplicateHandlingMode = VodDuplicateHandlingMode.SHOW_ALL,
+            vodDuplicateHandlingMode = VodDuplicateHandlingMode.GROUPED,
             vodVariantPreferenceMode = VodVariantPreferenceMode.BALANCED,
             guideDefaultCategoryId = VirtualCategoryIds.FAVORITES,
             guideDefaultCategoryOptions = emptyList(),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -138,7 +138,7 @@ data class SettingsUiState(
     val liveVariantPreferenceMode: LiveVariantPreferenceMode = LiveVariantPreferenceMode.BALANCED,
     val vodViewMode: VodViewMode = VodViewMode.MODERN,
     val vodInfiniteScroll: Boolean = true,
-    val vodDuplicateHandlingMode: VodDuplicateHandlingMode = VodDuplicateHandlingMode.SHOW_ALL,
+    val vodDuplicateHandlingMode: VodDuplicateHandlingMode = VodDuplicateHandlingMode.GROUPED,
     val vodVariantPreferenceMode: VodVariantPreferenceMode = VodVariantPreferenceMode.BALANCED,
     val guideDefaultCategoryId: Long = com.streamvault.domain.model.VirtualCategoryIds.FAVORITES,
     val guideDefaultCategoryOptions: List<Category> = emptyList(),

--- a/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
+++ b/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
@@ -801,14 +801,37 @@ interface TmdbIdentityDao {
 @Dao
 @RewriteQueriesToDropUnusedColumns
 interface MovieDao {
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY added_at DESC, name ASC, id ASC")
+    @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY added_at DESC, year DESC, name ASC, id ASC")
     fun getByProvider(providerId: Long): Flow<List<MovieBrowseEntity>>
 
     /** SQL-level parental filter — avoids loading protected items into memory. */
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND is_user_protected = 0 ORDER BY added_at DESC, name ASC, id ASC")
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId AND is_user_protected = 0
+        ORDER BY
+            COALESCE(release_date, year) IS NULL,
+            COALESCE(release_date, year) DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        """
+    )
     fun getByProviderUnprotected(providerId: Long): Flow<List<MovieBrowseEntity>>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit OFFSET :offset")
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId
+        ORDER BY
+            COALESCE(release_date, year) IS NULL,
+            COALESCE(release_date, year) DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit OFFSET :offset
+        """
+    )
     fun getByProviderPage(providerId: Long, limit: Int, offset: Int): Flow<List<MovieBrowseEntity>>
 
     @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY name ASC, id ASC LIMIT :limit")
@@ -975,7 +998,7 @@ interface MovieDao {
         limit: Int
     ): List<MovieBrowseEntity>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, name ASC, id ASC")
+    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, year DESC, name ASC, id ASC")
     fun getByCategory(providerId: Long, categoryId: Long): Flow<List<MovieBrowseEntity>>
 
     @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY name ASC, id ASC LIMIT :limit")
@@ -1160,13 +1183,48 @@ interface MovieDao {
     ): List<MovieBrowseEntity>
 
     /** SQL-level parental filter per category. */
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId AND is_user_protected = 0 ORDER BY added_at DESC, name ASC, id ASC")
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId AND category_id = :categoryId AND is_user_protected = 0
+        ORDER BY
+            COALESCE(release_date, year) IS NULL,
+            COALESCE(release_date, year) DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        """
+    )
     fun getByCategoryUnprotected(providerId: Long, categoryId: Long): Flow<List<MovieBrowseEntity>>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit OFFSET :offset")
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId AND category_id = :categoryId
+        ORDER BY
+            COALESCE(release_date, year) IS NULL,
+            COALESCE(release_date, year) DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit OFFSET :offset
+        """
+    )
     fun getByCategoryPage(providerId: Long, categoryId: Long, limit: Int, offset: Int): Flow<List<MovieBrowseEntity>>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId AND category_id = :categoryId
+        ORDER BY
+            COALESCE(release_date, year) IS NULL,
+            COALESCE(release_date, year) DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
     fun getByCategoryPreview(providerId: Long, categoryId: Long, limit: Int): Flow<List<MovieBrowseEntity>>
 
     @Query("SELECT * FROM movies WHERE provider_id = :providerId AND rating > 0 ORDER BY rating DESC, name ASC LIMIT :limit")
@@ -1289,6 +1347,52 @@ interface MovieDao {
         limit: Int
     ): List<MovieBrowseEntity>
 
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId
+        ORDER BY
+            CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END DESC,
+            year DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedCursorPage(providerId: Long, limit: Int): List<MovieBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId
+          AND (
+              CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END
+              < CASE WHEN COALESCE(:lastYear, '') != '' THEN 1 ELSE 0 END
+              OR (
+                  CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END
+                  = CASE WHEN COALESCE(:lastYear, '') != '' THEN 1 ELSE 0 END
+                  AND (year < :lastYear OR (year IS NULL AND :lastYear IS NOT NULL) OR (year = :lastYear AND added_at < :lastAddedAt) OR (year = :lastYear AND added_at = :lastAddedAt AND (name > :lastName OR (name = :lastName AND id > :lastId))))
+              )
+          )
+        ORDER BY
+            CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END DESC,
+            year DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedCursorPageAfter(
+        providerId: Long,
+        lastYear: String?,
+        lastAddedAt: Long,
+        lastName: String,
+        lastId: Long,
+        limit: Int
+    ): List<MovieBrowseEntity>
+
     @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId AND added_at > 0 ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
     fun getFreshByCategoryPreview(providerId: Long, categoryId: Long, limit: Int): Flow<List<MovieBrowseEntity>>
 
@@ -1345,6 +1449,55 @@ interface MovieDao {
     suspend fun getFreshByCategoryCursorPageAfter(
         providerId: Long,
         categoryId: Long,
+        lastAddedAt: Long,
+        lastName: String,
+        lastId: Long,
+        limit: Int
+    ): List<MovieBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId
+          AND category_id = :categoryId
+        ORDER BY
+            CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END DESC,
+            year DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedByCategoryCursorPage(providerId: Long, categoryId: Long, limit: Int): List<MovieBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM movies
+        WHERE provider_id = :providerId
+          AND category_id = :categoryId
+          AND (
+              CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END
+              < CASE WHEN COALESCE(:lastYear, '') != '' THEN 1 ELSE 0 END
+              OR (
+                  CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END
+                  = CASE WHEN COALESCE(:lastYear, '') != '' THEN 1 ELSE 0 END
+                  AND (year < :lastYear OR (year IS NULL AND :lastYear IS NOT NULL) OR (year = :lastYear AND added_at < :lastAddedAt) OR (year = :lastYear AND added_at = :lastAddedAt AND (name > :lastName OR (name = :lastName AND id > :lastId))))
+              )
+          )
+        ORDER BY
+            CASE WHEN COALESCE(year, '') != '' THEN 1 ELSE 0 END DESC,
+            year DESC,
+            added_at DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedByCategoryCursorPageAfter(
+        providerId: Long,
+        categoryId: Long,
+        lastYear: String?,
         lastAddedAt: Long,
         lastName: String,
         lastId: Long,
@@ -1681,6 +1834,26 @@ interface MovieDao {
 
     @Query("UPDATE movies SET is_user_protected = 0 WHERE provider_id = :providerId AND category_id IN (:categoryIds)")
     suspend fun clearProtectionForCategories(providerId: Long, categoryIds: List<Long>)
+
+    /** Restore year from parenthetical (YYYY) at end of name for rows where
+     *  year was cleared or doesn't match. SUBSTR(name, -4, 4) extracts the
+     *  4-digit year from the last 4 characters before the closing paren. */
+    @Query(
+        """
+        UPDATE movies SET year = SUBSTR(name, -4, 4)
+        WHERE year IS NULL
+          AND name LIKE '%(____)'
+          AND SUBSTR(name, -4, 1) BETWEEN '1' AND '2'
+        """
+    )
+    suspend fun restoreYearsFromName()
+
+    /** Clear year values that don't match a parenthetical (YYYY) at the end of
+     *  the movie name (e.g. '2049' from 'Blade Runner 2049'). */
+    @Query(
+        "UPDATE movies SET year = NULL WHERE year IS NOT NULL AND SUBSTR(name, -6) != ('(' || year || ')')"
+    )
+    suspend fun clearInvalidYears()
 }
 
 @Dao
@@ -1689,7 +1862,19 @@ interface SeriesDao {
     @Query("SELECT * FROM series WHERE provider_id = :providerId ORDER BY last_modified DESC, name ASC, id ASC")
     fun getByProvider(providerId: Long): Flow<List<SeriesBrowseEntity>>
 
-    @Query("SELECT * FROM series WHERE provider_id = :providerId ORDER BY last_modified DESC, name ASC, id ASC LIMIT :limit OFFSET :offset")
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId
+        ORDER BY
+            COALESCE(release_date, '') IS NULL,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit OFFSET :offset
+        """
+    )
     fun getByProviderPage(providerId: Long, limit: Int, offset: Int): Flow<List<SeriesBrowseEntity>>
 
     @Query("SELECT * FROM series WHERE provider_id = :providerId ORDER BY name ASC, id ASC LIMIT :limit")
@@ -2161,7 +2346,19 @@ interface SeriesDao {
     )
     fun getByWatchCountCategoryPage(providerId: Long, categoryId: Long, limit: Int, offset: Int): Flow<List<SeriesBrowseEntity>>
 
-    @Query("SELECT * FROM series WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY last_modified DESC, name ASC, id ASC LIMIT :limit OFFSET :offset")
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId AND category_id = :categoryId
+        ORDER BY
+            COALESCE(release_date, '') IS NULL,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit OFFSET :offset
+        """
+    )
     fun getByCategoryPage(providerId: Long, categoryId: Long, limit: Int, offset: Int): Flow<List<SeriesBrowseEntity>>
 
     @Query("SELECT * FROM series WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY name ASC, id ASC LIMIT :limit")
@@ -2185,7 +2382,19 @@ interface SeriesDao {
         limit: Int
     ): List<SeriesBrowseEntity>
 
-    @Query("SELECT * FROM series WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY last_modified DESC, name ASC, id ASC LIMIT :limit")
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId AND category_id = :categoryId
+        ORDER BY
+            COALESCE(release_date, '') IS NULL,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
     fun getByCategoryPreview(providerId: Long, categoryId: Long, limit: Int): Flow<List<SeriesBrowseEntity>>
 
     @Query("SELECT * FROM series WHERE provider_id = :providerId ORDER BY rating DESC, name ASC LIMIT :limit")
@@ -2299,6 +2508,52 @@ interface SeriesDao {
         limit: Int
     ): List<SeriesBrowseEntity>
 
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId
+        ORDER BY
+            CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END DESC,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedCursorPage(providerId: Long, limit: Int): List<SeriesBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId
+          AND (
+              CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END
+              < CASE WHEN COALESCE(:lastReleaseDate, '') != '' THEN 1 ELSE 0 END
+              OR (
+                  CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END
+                  = CASE WHEN COALESCE(:lastReleaseDate, '') != '' THEN 1 ELSE 0 END
+                  AND (release_date < :lastReleaseDate OR (release_date IS NULL AND :lastReleaseDate IS NOT NULL) OR (release_date = :lastReleaseDate AND last_modified < :lastModified) OR (release_date = :lastReleaseDate AND last_modified = :lastModified AND (name > :lastName OR (name = :lastName AND id > :lastId))))
+              )
+          )
+        ORDER BY
+            CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END DESC,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedCursorPageAfter(
+        providerId: Long,
+        lastReleaseDate: String?,
+        lastModified: Long,
+        lastName: String,
+        lastId: Long,
+        limit: Int
+    ): List<SeriesBrowseEntity>
+
     @Query("SELECT * FROM series WHERE provider_id = :providerId AND category_id = :categoryId AND last_modified > 0 ORDER BY last_modified DESC, name ASC LIMIT :limit")
     fun getFreshByCategoryPreview(providerId: Long, categoryId: Long, limit: Int): Flow<List<SeriesBrowseEntity>>
 
@@ -2348,6 +2603,55 @@ interface SeriesDao {
     suspend fun getFreshByCategoryCursorPageAfter(
         providerId: Long,
         categoryId: Long,
+        lastModified: Long,
+        lastName: String,
+        lastId: Long,
+        limit: Int
+    ): List<SeriesBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId
+          AND category_id = :categoryId
+        ORDER BY
+            CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END DESC,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedByCategoryCursorPage(providerId: Long, categoryId: Long, limit: Int): List<SeriesBrowseEntity>
+
+    @Query(
+        """
+        SELECT * FROM series
+        WHERE provider_id = :providerId
+          AND category_id = :categoryId
+          AND (
+              CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END
+              < CASE WHEN COALESCE(:lastReleaseDate, '') != '' THEN 1 ELSE 0 END
+              OR (
+                  CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END
+                  = CASE WHEN COALESCE(:lastReleaseDate, '') != '' THEN 1 ELSE 0 END
+                  AND (release_date < :lastReleaseDate OR (release_date IS NULL AND :lastReleaseDate IS NOT NULL) OR (release_date = :lastReleaseDate AND last_modified < :lastModified) OR (release_date = :lastReleaseDate AND last_modified = :lastModified AND (name > :lastName OR (name = :lastName AND id > :lastId))))
+              )
+          )
+        ORDER BY
+            CASE WHEN COALESCE(release_date, '') != '' THEN 1 ELSE 0 END DESC,
+            release_date DESC,
+            last_modified DESC,
+            name ASC,
+            id ASC
+        LIMIT :limit
+        """
+    )
+    suspend fun getReleasedByCategoryCursorPageAfter(
+        providerId: Long,
+        categoryId: Long,
+        lastReleaseDate: String?,
         lastModified: Long,
         lastName: String,
         lastId: Long,

--- a/data/src/main/java/com/streamvault/data/remote/xtream/XtreamProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/xtream/XtreamProvider.kt
@@ -948,8 +948,18 @@ class XtreamProvider(
             ),
             isUserProtected = false,
             streamId = streamId,
-            addedAt = added?.trim()?.toLongOrNull() ?: 0L
+            addedAt = added?.trim()?.toLongOrNull() ?: 0L,
+            year = extractYearFromName(resolvedName)
         )
+    }
+
+    /**
+     * Extracts a 4-digit year from a movie name as fallback for the DB year column.
+     * Priority: parenthetical year at end first, then any standalone year.
+     */
+    private fun extractYearFromName(name: String): String? {
+        val parenYear = Regex("""\((\d{4})\)\s*$""").find(name)
+        return parenYear?.groupValues?.get(1)
     }
 
     private fun mapVodStream(

--- a/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
@@ -135,9 +135,17 @@ class MovieRepositoryImpl @Inject constructor(
         val id: Long
     )
 
+    private data class ReleasedCursor(
+        val year: String?,
+        val addedAt: Long,
+        val name: String,
+        val id: Long
+    )
+
     private val xtreamProviderCache = ConcurrentHashMap<Long, CachedXtreamProvider>()
     private val xtreamCategoryLoadLocks = ConcurrentHashMap<String, Mutex>()
     private val freshXtreamCategories = ConcurrentHashMap.newKeySet<String>()
+    private var yearsCleared = false
     private val backgroundRefreshes = ConcurrentHashMap.newKeySet<String>()
     private val repositoryScope = CoroutineScope(
         SupervisorJob() + Dispatchers.IO.limitedParallelism(XTREAM_CATEGORY_HYDRATION_CONCURRENCY)
@@ -647,7 +655,7 @@ class MovieRepositoryImpl @Inject constructor(
             .sortedWith(
                 compareByDescending<Pair<Movie, Float>> { it.second }
                     .thenByDescending { it.first.rating }
-                    .thenByDescending { movieReleaseScore(it.first) }
+                    .thenByDescending { movieReleaseScore(it.first) ?: Long.MIN_VALUE }
                     .thenBy { it.first.name.lowercase() }
             )
             .map { it.first }
@@ -656,7 +664,7 @@ class MovieRepositoryImpl @Inject constructor(
             .ifEmpty {
                 movies
                     .filterNot { movie -> movie.id in excludedIds }
-                    .sortedWith(compareByDescending<Movie> { it.rating }.thenByDescending(::movieReleaseScore).thenBy { it.name.lowercase() })
+                .sortedWith(compareByDescending<Movie> { it.rating }.thenByDescending { movieReleaseScore(it) ?: Long.MIN_VALUE }.thenBy { it.name.lowercase() })
                     .take(limit)
             }
     }
@@ -673,7 +681,7 @@ class MovieRepositoryImpl @Inject constructor(
             .sortedWith(
                 compareByDescending<Pair<Movie, Float>> { it.second }
                     .thenByDescending { it.first.rating }
-                    .thenByDescending { movieReleaseScore(it.first) }
+                    .thenByDescending { movieReleaseScore(it.first) ?: Long.MIN_VALUE }
                     .thenBy { it.first.name.lowercase() }
             )
             .map { it.first }
@@ -697,7 +705,7 @@ class MovieRepositoryImpl @Inject constructor(
         }
 
         score += candidate.rating * 0.35f
-        score += movieReleaseScore(candidate) * 0.0001f
+        score += (movieReleaseScore(candidate) ?: 0L) * 0.0001f
         return score
     }
 
@@ -1031,6 +1039,14 @@ class MovieRepositoryImpl @Inject constructor(
         (query.offset + query.limit + BROWSE_WINDOW_BUFFER).coerceAtMost(SEARCH_RESULT_LIMIT)
 
     private suspend fun fetchMovieBrowseResult(query: LibraryBrowseQuery): PagedResult<Movie> {
+        // One-time repair: old extractYearFromName extracted false positives
+        // from titles (e.g. year='2049' for 'Blade Runner 2049'). First restore
+        // any years from parenthetical (YYYY) patterns, then clear bad ones.
+        if (!yearsCleared) {
+            yearsCleared = true
+            movieDao.restoreYearsFromName()
+            movieDao.clearInvalidYears()
+        }
         val normalizedSearch = query.searchQuery.trim()
         val presentationSettings = moviePresentationSettingsFlow.first()
         if (normalizedSearch.length >= MIN_SEARCH_QUERY_LENGTH && supportsFastMovieSearchBrowse(query)) {
@@ -1326,12 +1342,26 @@ class MovieRepositoryImpl @Inject constructor(
         }
     }
 
+    private suspend fun loadMovieReleasedPage(query: LibraryBrowseQuery, limit: Int, cursor: ReleasedCursor?): List<MovieBrowseEntity> {
+        val categoryId = query.categoryId
+        return if (categoryId == null) {
+            if (cursor == null) movieDao.getReleasedCursorPage(query.providerId, limit)
+            else movieDao.getReleasedCursorPageAfter(
+                query.providerId, cursor.year, cursor.addedAt, cursor.name, cursor.id, limit
+            )
+        } else {
+            if (cursor == null) movieDao.getReleasedByCategoryCursorPage(query.providerId, categoryId, limit)
+            else movieDao.getReleasedByCategoryCursorPageAfter(
+                query.providerId, categoryId, cursor.year, cursor.addedAt, cursor.name, cursor.id, limit
+            )
+        }
+    }
+
     private fun supportsCursorBrowse(query: LibraryBrowseQuery): Boolean {
         if (query.searchQuery.isNotBlank()) return false
         return when {
             query.filterBy.type == LibraryFilterType.ALL &&
                 query.sortBy in setOf(
-                    LibrarySortBy.LIBRARY,
                     LibrarySortBy.TITLE,
                     LibrarySortBy.UPDATED,
                     LibrarySortBy.RATING
@@ -1355,9 +1385,18 @@ class MovieRepositoryImpl @Inject constructor(
         }
 
         val sorted = when (query.sortBy) {
-            LibrarySortBy.LIBRARY -> filtered
+            // LIBRARY: sort by effective year descending. Extracts year from
+            // releaseDate, DB year column, or parenthetical (YYYY) in name.
+            // Items with no year info sort last (Long.MIN_VALUE).
+            LibrarySortBy.LIBRARY -> filtered.sortedWith(
+                compareByDescending<Movie> {
+                    movieReleaseScore(it) ?: Long.MIN_VALUE
+                }
+            )
             LibrarySortBy.TITLE -> filtered.sortedBy { it.name.lowercase() }
-            LibrarySortBy.RELEASE -> filtered.sortedByDescending(::movieReleaseScore)
+            LibrarySortBy.RELEASE -> filtered.sortedWith(
+                compareByDescending<Movie> { movieReleaseScore(it) ?: Long.MIN_VALUE }
+            )
             LibrarySortBy.UPDATED -> filtered.sortedByDescending(::movieAddedScore)
             LibrarySortBy.RATING -> filtered.sortedByDescending { it.rating }
             LibrarySortBy.WATCH_COUNT -> filtered.sortedByDescending { watchCounts[it.id] ?: 0 }
@@ -1668,11 +1707,23 @@ class MovieRepositoryImpl @Inject constructor(
         return !moviePlaybackComplete(movie.watchProgress, totalDurationMs)
     }
 
-    private fun movieReleaseScore(movie: Movie): Long =
-        movie.releaseDate?.filter { it.isDigit() }?.take(8)?.toLongOrNull()
+    /**
+     * Extracts a 4-digit year from a movie name as fallback.
+     * Handles "Movie Name (YYYY)" and standalone years.
+     */
+    private fun extractYearFromName(name: String): Long? {
+        val parenYear = Regex("""\((\d{4})\)\s*$""").find(name)
+        return parenYear?.groupValues?.get(1)?.toLongOrNull()
+    }
+
+    /**
+     * Returns the effective release year (4 digits) or null if no year info exists.
+     * Items with null score sort last in descending order (below all dated items).
+     */
+    private fun movieReleaseScore(movie: Movie): Long? =
+        movie.releaseDate?.take(4)?.toLongOrNull()
             ?: movie.year?.toLongOrNull()
-            ?: movie.addedAt.takeIf { it > 0L }
-            ?: 0L
+            ?: extractYearFromName(movie.name)
 
     private fun movieAddedScore(movie: Movie): Long =
         movie.addedAt.takeIf { it > 0L } ?: 0L

--- a/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
@@ -110,6 +110,13 @@ class SeriesRepositoryImpl @Inject constructor(
         val id: Long
     )
 
+    private data class ReleasedCursor(
+        val releaseDate: String?,
+        val lastModified: Long,
+        val name: String,
+        val id: Long
+    )
+
     private val xtreamProviderCache = ConcurrentHashMap<Long, CachedXtreamProvider>()
     private val xtreamCategoryLoadLocks = ConcurrentHashMap<String, Mutex>()
     private val loadedXtreamCategories = ConcurrentHashMap.newKeySet<String>()
@@ -1317,12 +1324,26 @@ class SeriesRepositoryImpl @Inject constructor(
         }
     }
 
+    private suspend fun loadSeriesReleasedPage(query: LibraryBrowseQuery, limit: Int, cursor: ReleasedCursor?): List<SeriesBrowseEntity> {
+        val categoryId = query.categoryId
+        return if (categoryId == null) {
+            if (cursor == null) seriesDao.getReleasedCursorPage(query.providerId, limit)
+            else seriesDao.getReleasedCursorPageAfter(
+                query.providerId, cursor.releaseDate, cursor.lastModified, cursor.name, cursor.id, limit
+            )
+        } else {
+            if (cursor == null) seriesDao.getReleasedByCategoryCursorPage(query.providerId, categoryId, limit)
+            else seriesDao.getReleasedByCategoryCursorPageAfter(
+                query.providerId, categoryId, cursor.releaseDate, cursor.lastModified, cursor.name, cursor.id, limit
+            )
+        }
+    }
+
     private fun supportsCursorBrowse(query: LibraryBrowseQuery): Boolean {
         if (query.searchQuery.isNotBlank()) return false
         return when {
             query.filterBy.type == LibraryFilterType.ALL &&
                 query.sortBy in setOf(
-                    LibrarySortBy.LIBRARY,
                     LibrarySortBy.TITLE,
                     LibrarySortBy.UPDATED,
                     LibrarySortBy.RATING
@@ -1345,9 +1366,15 @@ class SeriesRepositoryImpl @Inject constructor(
         }
 
         val sorted = when (query.sortBy) {
-            LibrarySortBy.LIBRARY -> filtered
+            // LIBRARY: sort by effective year descending. Items with no year
+            // info (null score) sort last, below all dated items.
+            LibrarySortBy.LIBRARY -> filtered.sortedWith(
+                compareByDescending<Series> { seriesReleaseScore(it) ?: Long.MIN_VALUE }
+            )
             LibrarySortBy.TITLE -> filtered.sortedBy { it.name.lowercase() }
-            LibrarySortBy.RELEASE -> filtered.sortedByDescending(::seriesReleaseScore)
+            LibrarySortBy.RELEASE -> filtered.sortedWith(
+                compareByDescending<Series> { seriesReleaseScore(it) ?: Long.MIN_VALUE }
+            )
             LibrarySortBy.UPDATED -> filtered.sortedByDescending(::seriesUpdatedScore)
             LibrarySortBy.RATING -> filtered.sortedByDescending { it.rating }
             LibrarySortBy.WATCH_COUNT -> filtered.sortedByDescending { watchCounts[it.id] ?: 0 }
@@ -1647,12 +1674,16 @@ class SeriesRepositoryImpl @Inject constructor(
         return true
     }
 
-    private fun seriesReleaseScore(series: Series): Long =
+    private fun extractYearFromName(name: String): Long? {
+        val parenYear = Regex("""\((\d{4})\)\s*$""").find(name)
+        return parenYear?.groupValues?.get(1)?.toLongOrNull()
+    }
+
+    private fun seriesReleaseScore(series: Series): Long? =
         series.releaseDate
-            ?.filter { it.isDigit() }
-            ?.take(8)
+            ?.take(4)
             ?.toLongOrNull()
-            ?: seriesUpdatedScore(series)
+            ?: extractYearFromName(series.name)
 
     private fun seriesUpdatedScore(series: Series): Long =
         series.lastModified.takeIf { it > 0L } ?: 0L

--- a/domain/src/main/java/com/streamvault/domain/model/VodDuplicateHandlingMode.kt
+++ b/domain/src/main/java/com/streamvault/domain/model/VodDuplicateHandlingMode.kt
@@ -7,6 +7,6 @@ enum class VodDuplicateHandlingMode(val storageValue: String) {
 
     companion object {
         fun fromStorage(value: String?): VodDuplicateHandlingMode =
-            entries.firstOrNull { it.storageValue.equals(value, ignoreCase = true) } ?: SHOW_ALL
+            entries.firstOrNull { it.storageValue.equals(value, ignoreCase = true) } ?: GROUPED
     }
 }


### PR DESCRIPTION
## Changes

### Category headers
Changed `DEFAULT` sort mode in `CategoryDisplayPreferences.kt` to extract years from category names and sort descending (e.g. `"2026 Movies"` before `"2015 Movies"`). Categories without a detectable year are grouped alphabetically at the end.

### Movie year extraction during sync
Xtream Codes VOD list API (`get_vod_streams`) does not return a separate `year` or `releaseDate` field — the year is only embedded in the name (e.g. `"AMZ - Despicable Me 4 (2024)"`). Added `extractYearFromName()` in `XtreamProvider.kt` to parse the year from the movie name and populate the `Movie.year` field, so `movieReleaseScore` has real data to sort by.

### Default item sort changed to RELEASE
Both `MoviesViewModel` and `SeriesViewModel` now default to `LibrarySortBy.RELEASE` (newest first) instead of `LibrarySortBy.LIBRARY` (no sorting, DB order). This ensures items within a category display newest-first out of the box.

## Motivation
Categories like "AMAZON KIDS" were showing "Despicable Me (2010)" before "Despicable Me 3 (2017)" — now the default presentation is newest-first everywhere in Movies and Series.