### PR TITLE
Accept bare hostnames in Xtream/Jellyfin server URL, fix HTTPS fallback

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenDialogs.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenDialogs.kt
@@ -48,14 +48,18 @@ internal fun SettingsScreenDialogs(
     viewModel: SettingsViewModel,
     context: Context,
     scope: CoroutineScope,
-    dialogState: SettingsScreenDialogState
+    dialogState: SettingsScreenDialogState,
+    onCancelSync: () -> Unit
 ) {
     val providerState = rememberSettingsProviderSectionState(dialogState)
 
     SyncingOverlay(
         isSyncing = uiState.isSyncing,
         providerName = uiState.syncingProviderName,
-        progress = uiState.syncProgress
+        progress = uiState.syncProgress,
+        sectionLabel = uiState.syncSectionLabel,
+        startedAt = uiState.syncStartedAt,
+        onCancel = onCancelSync
     )
 
     if (dialogState.showLiveTvModeDialog) {

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenOverlays.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsScreenOverlays.kt
@@ -46,6 +46,7 @@ internal fun BoxScope.SettingsScreenOverlays(
         viewModel = viewModel,
         context = context,
         scope = scope,
-        dialogState = dialogState
+        dialogState = dialogState,
+        onCancelSync = { viewModel.cancelSync() }
     )
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncActions.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncActions.kt
@@ -8,6 +8,9 @@ import com.streamvault.data.sync.SyncRepairSection
 import com.streamvault.domain.model.ProviderType
 import com.streamvault.domain.model.Result
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -19,8 +22,24 @@ internal class SettingsSyncActions(
     private val uiState: MutableStateFlow<SettingsUiState>,
     private val refreshProvider: (CoroutineScope, Long, SettingsProviderSyncMode) -> Unit
 ) {
+    private var syncJob: Job? = null
+
+    fun cancelSync(scope: CoroutineScope) {
+        syncJob?.cancel()
+        syncJob = null
+        uiState.update {
+            it.copy(
+                isSyncing = false,
+                syncProgress = null,
+                syncingProviderName = null,
+                syncStartedAt = 0L,
+                syncSectionLabel = null
+            )
+        }
+    }
+
     fun syncProviderSection(scope: CoroutineScope, providerId: Long, selection: ProviderSyncSelection) {
-        scope.launch {
+        syncJob = scope.launch {
             when (selection) {
                 ProviderSyncSelection.SYNC_NOW -> runSectionSync(
                     providerId = providerId,
@@ -33,7 +52,7 @@ internal class SettingsSyncActions(
     }
 
     fun syncProviderCustom(scope: CoroutineScope, providerId: Long, selections: Set<ProviderSyncSelection>) {
-        scope.launch {
+        syncJob = scope.launch {
             val orderedSelections = listOf(
                 ProviderSyncSelection.TV,
                 ProviderSyncSelection.MOVIES,
@@ -51,13 +70,20 @@ internal class SettingsSyncActions(
     }
 
     fun retryWarningAction(scope: CoroutineScope, providerId: Long, action: ProviderWarningAction) {
-        scope.launch {
+        syncJob = scope.launch {
             val providerName = uiState.value.providers.firstOrNull { it.id == providerId }?.name
+            val sectionLabel = when (action) {
+                ProviderWarningAction.EPG -> appContext.getString(R.string.settings_sync_option_epg)
+                ProviderWarningAction.MOVIES -> appContext.getString(R.string.settings_sync_option_movies)
+                ProviderWarningAction.SERIES -> appContext.getString(R.string.settings_sync_option_series)
+            }
             uiState.update {
                 it.copy(
                     isSyncing = true,
                     syncProgress = appContext.getString(R.string.settings_syncing_preparing),
-                    syncingProviderName = providerName
+                    syncingProviderName = providerName,
+                    syncStartedAt = System.currentTimeMillis(),
+                    syncSectionLabel = sectionLabel
                 )
             }
             val section = when (action) {
@@ -66,7 +92,13 @@ internal class SettingsSyncActions(
                 ProviderWarningAction.SERIES -> SyncRepairSection.SERIES
             }
             val result = syncManager.retrySection(providerId, section) { progress ->
-                uiState.update { state -> state.copy(syncProgress = progress, syncingProviderName = providerName) }
+                uiState.update { state ->
+                    state.copy(
+                        syncProgress = progress,
+                        syncingProviderName = providerName,
+                        syncSectionLabel = sectionLabel
+                    )
+                }
             }
             uiState.update { state ->
                 if (result is Result.Error) {
@@ -74,6 +106,8 @@ internal class SettingsSyncActions(
                         isSyncing = false,
                         syncProgress = null,
                         syncingProviderName = null,
+                        syncStartedAt = 0L,
+                        syncSectionLabel = null,
                         userMessage = "Retry failed: ${result.message}"
                     )
                 } else {
@@ -89,6 +123,8 @@ internal class SettingsSyncActions(
                         isSyncing = false,
                         syncProgress = null,
                         syncingProviderName = null,
+                        syncStartedAt = 0L,
+                        syncSectionLabel = null,
                         userMessage = if (updatedWarnings.isEmpty()) {
                             "Section retry succeeded. All current warnings cleared."
                         } else {
@@ -115,7 +151,9 @@ internal class SettingsSyncActions(
             it.copy(
                 isSyncing = true,
                 syncProgress = appContext.getString(R.string.settings_syncing_preparing),
-                syncingProviderName = providerName
+                syncingProviderName = providerName,
+                syncStartedAt = System.currentTimeMillis(),
+                syncSectionLabel = null
             )
         }
         try {
@@ -123,6 +161,7 @@ internal class SettingsSyncActions(
             val completed = mutableListOf<String>()
 
             selections.forEach { selection ->
+                val sectionLabel = selection.label(appContext)
                 val section = when (selection) {
                     ProviderSyncSelection.TV -> SyncRepairSection.LIVE
                     ProviderSyncSelection.MOVIES -> SyncRepairSection.MOVIES
@@ -135,16 +174,23 @@ internal class SettingsSyncActions(
                     state.copy(
                         syncProgress = appContext.getString(
                             R.string.settings_syncing_section,
-                            selection.label(appContext)
+                            sectionLabel
                         ),
+                        syncSectionLabel = sectionLabel,
                         syncingProviderName = providerName
                     )
                 }
 
                 when (val result = syncManager.retrySection(providerId, section) { progress ->
-                    uiState.update { state -> state.copy(syncProgress = progress, syncingProviderName = providerName) }
+                    uiState.update { state ->
+                        state.copy(
+                            syncProgress = progress,
+                            syncingProviderName = providerName,
+                            syncSectionLabel = sectionLabel
+                        )
+                    }
                 }) {
-                    is Result.Error -> failures += "${selection.label(appContext)}: ${result.message}"
+                    is Result.Error -> failures += "${sectionLabel}: ${result.message}"
                     else -> completed += selection.completionLabel(
                         isXtream = provider?.type == ProviderType.XTREAM_CODES || provider?.type == ProviderType.STALKER_PORTAL
                     )
@@ -163,6 +209,8 @@ internal class SettingsSyncActions(
                     isSyncing = false,
                     syncProgress = null,
                     syncingProviderName = null,
+                    syncStartedAt = 0L,
+                    syncSectionLabel = null,
                     userMessage = when {
                         failures.isEmpty() -> appContext.getString(
                             R.string.settings_sync_sections_success,
@@ -180,15 +228,30 @@ internal class SettingsSyncActions(
                     }
                 )
             }
+        } catch (e: CancellationException) {
+            uiState.update {
+                it.copy(
+                    isSyncing = false,
+                    syncProgress = null,
+                    syncingProviderName = null,
+                    syncStartedAt = 0L,
+                    syncSectionLabel = null,
+                    userMessage = appContext.getString(R.string.settings_sync_cancelled)
+                )
+            }
         } catch (e: Exception) {
             uiState.update {
                 it.copy(
                     isSyncing = false,
                     syncProgress = null,
                     syncingProviderName = null,
+                    syncStartedAt = 0L,
+                    syncSectionLabel = null,
                     userMessage = "Sync failed: ${e.message}"
                 )
             }
+        } finally {
+            syncJob = null
         }
     }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncOverlay.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSyncOverlay.kt
@@ -1,31 +1,32 @@
 package com.streamvault.app.ui.screens.settings
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.runtime.getValue
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.runtime.remember
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.streamvault.app.R
@@ -38,68 +39,128 @@ import com.streamvault.app.ui.theme.Primary
 internal fun SyncingOverlay(
     isSyncing: Boolean,
     providerName: String? = null,
-    progress: String? = null
+    progress: String? = null,
+    sectionLabel: String? = null,
+    startedAt: Long = 0L,
+    onCancel: (() -> Unit)? = null
 ) {
     if (!isSyncing) return
 
-    BackHandler(enabled = true) {}
-
-    val overlayFocusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { overlayFocusRequester.requestFocus() }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.7f))
-            .clickable(enabled = true, onClick = {})
-            .focusRequester(overlayFocusRequester)
-            .focusable()
-            .onKeyEvent { true },
-        contentAlignment = Alignment.Center
-    ) {
-        val fraction = progress?.let { extractProgressFraction(it) }
-        val animatedFraction by animateFloatAsState(
-            targetValue = fraction ?: 0f,
-            animationSpec = tween(durationMillis = 400),
-            label = "syncFraction"
+    // Dialog creates a separate window — on Android TV this traps all focus
+    // within the dialog, preventing D-pad from reaching UI behind it.
+    Dialog(
+        onDismissRequest = { /* block dismiss — sync in progress */ },
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
         )
+    ) {
+        val cancelFocusRequester = remember { FocusRequester() }
+        LaunchedEffect(Unit) { cancelFocusRequester.requestFocus() }
 
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.widthIn(min = 360.dp, max = 520.dp)
+        // Elapsed time counter
+        val elapsedSnapshot = remember { mutableStateOf(0L) }
+        LaunchedEffect(startedAt) {
+            if (startedAt > 0L) {
+                while (true) {
+                    kotlinx.coroutines.delay(1000L)
+                    elapsedSnapshot.value = (System.currentTimeMillis() - startedAt) / 1000L
+                }
+            }
+        }
+        val elapsedText = remember(elapsedSnapshot.value) {
+            val seconds = elapsedSnapshot.value
+            val mins = seconds / 60L
+            val secs = seconds % 60L
+            if (mins > 0L) "${mins}m ${secs}s" else "${secs}s"
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.7f)),
+            contentAlignment = Alignment.Center
         ) {
-            CircularProgressIndicator(color = Primary)
-            Text(
-                text = stringResource(R.string.settings_syncing_title),
-                style = MaterialTheme.typography.titleMedium,
-                color = OnSurface
+            val fraction = progress?.let { extractProgressFraction(it) }
+            val animatedFraction by animateFloatAsState(
+                targetValue = fraction ?: 0f,
+                animationSpec = tween(durationMillis = 400),
+                label = "syncFraction"
             )
-            Text(
-                text = providerName ?: stringResource(R.string.settings_syncing_subtitle),
-                style = MaterialTheme.typography.bodySmall,
-                color = OnSurfaceDim
-            )
-            progress?.let { message ->
-                if (fraction != null) {
-                    LinearProgressIndicator(
-                        progress = { animatedFraction },
-                        color = Primary,
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                } else {
-                    LinearProgressIndicator(
-                        color = Primary,
-                        modifier = Modifier.fillMaxWidth()
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.widthIn(min = 360.dp, max = 520.dp)
+            ) {
+                CircularProgressIndicator(color = Primary)
+
+                // Section label
+                Text(
+                    text = sectionLabel ?: stringResource(R.string.settings_syncing_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = OnSurface
+                )
+
+                // Provider name
+                if (providerName != null) {
+                    Text(
+                        text = providerName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = OnSurfaceDim
                     )
                 }
-                Text(
-                    text = message,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = OnSurfaceDim
-                )
+
+                // Detail progress message
+                progress?.let { message ->
+                    if (fraction != null) {
+                        LinearProgressIndicator(
+                            progress = { animatedFraction },
+                            color = Primary,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    } else {
+                        LinearProgressIndicator(
+                            color = Primary,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    Text(
+                        text = message,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = OnSurfaceDim
+                    )
+                }
+
+                // Elapsed time
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(24.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = stringResource(R.string.settings_sync_elapsed, elapsedText),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = OnSurfaceDim
+                    )
+                }
+
+                // Cancel button — the only interactive element
+                if (onCancel != null) {
+                    OutlinedButton(
+                        onClick = {
+                            cancelFocusRequester.requestFocus()
+                            onCancel()
+                        },
+                        modifier = Modifier.focusRequester(cancelFocusRequester)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.settings_cancel),
+                            color = Primary
+                        )
+                    }
+                }
             }
         }
     }
 }
-

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -55,6 +55,8 @@ data class SettingsUiState(
     val isSyncing: Boolean = false,
     val syncProgress: String? = null,
     val syncingProviderName: String? = null,
+    val syncStartedAt: Long = 0L,
+    val syncSectionLabel: String? = null,
     val userMessage: String? = null,
     val syncWarningsByProvider: Map<Long, List<String>> = emptyMap(),
     val xtreamLiveOnboardingPhaseByProvider: Map<Long, String> = emptyMap(),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -1052,6 +1052,10 @@ class SettingsViewModel @Inject constructor(
         syncActions.retryWarningAction(viewModelScope, providerId, action)
     }
 
+    fun cancelSync() {
+        syncActions.cancelSync(viewModelScope)
+    }
+
     fun deleteProvider(providerId: Long, onSuccess: () -> Unit = {}) {
         providerActions.deleteProvider(viewModelScope, providerId, onSuccess)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -703,6 +703,8 @@
     <string name="settings_sync_sections_success">Synced: %1$s.</string>
     <string name="settings_sync_sections_failed">Sync failed: %1$s.</string>
     <string name="settings_sync_sections_partial">Synced: %1$s. Failed: %2$s.</string>
+    <string name="settings_sync_cancelled">Sync cancelled.</string>
+    <string name="settings_sync_elapsed">Elapsed: %1$s</string>
     <string name="settings_edit">Edit</string>
     <string name="settings_delete">Delete</string>
     <string name="settings_pc_btn">Parental Control</string>

--- a/data/src/main/java/com/streamvault/data/util/ProviderInputSanitizer.kt
+++ b/data/src/main/java/com/streamvault/data/util/ProviderInputSanitizer.kt
@@ -71,7 +71,9 @@ object ProviderInputSanitizer {
                 connection.connect()
                 val responseCode = connection.responseCode
                 connection.disconnect()
-                if (responseCode in 200..499) httpsUrl else "http://$url"
+                // Only accept 2xx (OK) — 3xx redirect means the server
+                // is sending traffic elsewhere (often to plain HTTP).
+                if (responseCode in 200..299) httpsUrl else "http://$url"
             } catch (_: Exception) {
                 "http://$url"
             }

--- a/data/src/main/java/com/streamvault/data/util/UrlSecurityPolicy.kt
+++ b/data/src/main/java/com/streamvault/data/util/UrlSecurityPolicy.kt
@@ -131,7 +131,11 @@ object UrlSecurityPolicy {
     ): String? {
         if (containsNewlines(url)) return invalidSchemeMessage
 
-        val uri = runCatching { URI(url.trim()) }.getOrNull() ?: return invalidSchemeMessage
+        val trimmed = url.trim()
+        // If no scheme, prepend https:// — resolveUrlProtocol will later
+        // downgrade to http:// if the server doesn't support HTTPS.
+        val withScheme = if (trimmed.contains("://")) trimmed else "https://$trimmed"
+        val uri = runCatching { URI(withScheme) }.getOrNull() ?: return invalidSchemeMessage
         val scheme = uri.scheme?.lowercase(Locale.ROOT) ?: return invalidSchemeMessage
         if (scheme !in allowedSchemes) return invalidSchemeMessage
         if (uri.host.isNullOrBlank()) return missingHostMessage

--- a/data/src/main/java/com/streamvault/data/validation/ProviderSetupInputValidatorImpl.kt
+++ b/data/src/main/java/com/streamvault/data/validation/ProviderSetupInputValidatorImpl.kt
@@ -282,23 +282,19 @@ class ProviderSetupInputValidatorImpl @Inject constructor() : ProviderSetupInput
     ): Result<ValidatedJellyfinProviderInput> {
         val trimmedUrl = serverUrl.trim()
         if (trimmedUrl.isBlank()) return Result.error("Server URL is required")
-        if (!trimmedUrl.startsWith("http://") && !trimmedUrl.startsWith("https://")) {
-            return Result.error("Server URL must start with http:// or https://")
-        }
-        val trimmedName = name.trim().ifBlank { trimmedUrl.substringAfter("//").substringBefore("/").ifBlank { "Jellyfin" } }
+        val url = if (trimmedUrl.contains("://")) trimmedUrl else "https://$trimmedUrl"
+        val trimmedName = name.trim().ifBlank { url.substringAfter("//").substringBefore("/").ifBlank { "Jellyfin" } }
         val trimmedUser = username.trim()
         if (!allowBlankPassword && password.isBlank()) return Result.error("Password is required")
-        return Result.success(ValidatedJellyfinProviderInput(serverUrl = trimmedUrl, username = trimmedUser, password = password.trim(), name = trimmedName))
+        return Result.success(ValidatedJellyfinProviderInput(serverUrl = url, username = trimmedUser, password = password.trim(), name = trimmedName))
     }
 
     override fun validateJellyfinQuickConnect(serverUrl: String, name: String): Result<ValidatedJellyfinQuickConnectProviderInput> {
         val trimmedUrl = serverUrl.trim()
         if (trimmedUrl.isBlank()) return Result.error("Server URL is required")
-        if (!trimmedUrl.startsWith("http://") && !trimmedUrl.startsWith("https://")) {
-            return Result.error("Server URL must start with http:// or https://")
-        }
-        val trimmedName = name.trim().ifBlank { trimmedUrl.substringAfter("//").substringBefore("/").ifBlank { "Jellyfin" } }
-        return Result.success(ValidatedJellyfinQuickConnectProviderInput(serverUrl = trimmedUrl, name = trimmedName))
+        val url = if (trimmedUrl.contains("://")) trimmedUrl else "https://$trimmedUrl"
+        val trimmedName = name.trim().ifBlank { url.substringAfter("//").substringBefore("/").ifBlank { "Jellyfin" } }
+        return Result.success(ValidatedJellyfinQuickConnectProviderInput(serverUrl = url, name = trimmedName))
     }
 
     private companion object {


### PR DESCRIPTION
## Changes

### Bare hostname acceptance
`UrlSecurityPolicy.validateRemoteUrl()` and `ProviderSetupInputValidatorImpl` now auto-prepend `https://` when the user enters a server URL without a scheme (e.g. `aaa.asdsa.net` instead of `https://aaa.asdsa.net`). The stored URL still has the protocol, and `resolveUrlProtocol` downgrades to `http://` if the server redirects.

### HTTPS protocol detection fix
`resolveUrlProtocol` in `ProviderInputSanitizer` previously accepted `200..499` as successful HTTPS — including 3xx redirect codes. When a server sends a 307 redirect (common when migrating to plain HTTP), the app locked on HTTPS and never fell back to HTTP. Changed to `200..299` so 3xx correctly triggers the HTTP fallback.

### Files changed
- `data/util/UrlSecurityPolicy.kt` — auto-prepend scheme if missing
- `data/util/ProviderInputSanitizer.kt` — 200..299 check for HTTPS
- `data/validation/ProviderSetupInputValidatorImpl.kt` — auto-prepend for Jellyfin