### PR TITLE
Reduce storage usage: OkHttp cache, EPG retention, DB maintenance on startup

### DIFF
--- a/app/src/main/java/com/streamvault/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/streamvault/app/di/NetworkModule.kt
@@ -65,7 +65,7 @@ object NetworkModule {
             .cache(
                 Cache(
                     directory = File(context.cacheDir, "streamvault_http_cache"),
-                    maxSize = 256L * 1024 * 1024
+                    maxSize = 16L * 1024 * 1024
                 )
             )
             .connectTimeout(NetworkTimeoutConfig.CONNECT_TIMEOUT_SECONDS, SECONDS)

--- a/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.streamvault.app.ui.model.orderedByRequestedRawIds
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.sync.DatabaseMaintenanceManager
 import com.streamvault.data.sync.SyncManager
 import com.streamvault.app.update.AppUpdateActionState
 import com.streamvault.app.update.AppUpdateInstaller
@@ -58,6 +59,8 @@ import com.streamvault.domain.util.AdultContentVisibilityPolicy
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -76,7 +79,8 @@ class DashboardViewModel @Inject constructor(
     private val getCustomCategories: GetCustomCategories,
     private val syncManager: SyncManager,
     private val appUpdateInstaller: AppUpdateInstaller,
-    private val recordingManager: RecordingManager
+    private val recordingManager: RecordingManager,
+    private val databaseMaintenanceManager: DatabaseMaintenanceManager
 ) : ViewModel() {
     private companion object {
         const val FAVORITE_CHANNEL_LIMIT = 12
@@ -97,6 +101,12 @@ class DashboardViewModel @Inject constructor(
     val scheduledChannelIds: StateFlow<Set<Long>> = _scheduledChannelIds.asStateFlow()
 
     init {
+        viewModelScope.launch {
+            try {
+                withContext(Dispatchers.IO) { databaseMaintenanceManager.runDailyMaintenance() }
+            } catch (_: Exception) { }
+        }
+
         viewModelScope.launch {
             recordingManager.observeRecordingItems().collect { items ->
                 _recordingChannelIds.value = items

--- a/data/src/main/java/com/streamvault/data/sync/DatabaseMaintenanceManager.kt
+++ b/data/src/main/java/com/streamvault/data/sync/DatabaseMaintenanceManager.kt
@@ -206,7 +206,7 @@ class DatabaseMaintenanceManager @Inject constructor(
     companion object {
         private const val TAG = "DbMaintenance"
         private const val MILLIS_PER_DAY = 24L * 60 * 60 * 1000L
-        private const val PROGRAM_MIN_RETENTION_MILLIS = MILLIS_PER_DAY
+        private const val PROGRAM_MIN_RETENTION_MILLIS = 12L * 60 * 60 * 1000L
         private const val PROGRAM_REMINDER_RETENTION_MILLIS = MILLIS_PER_DAY
         private const val SEARCH_HISTORY_RETENTION_MILLIS = 90L * MILLIS_PER_DAY
         private const val MIN_RECLAIMABLE_BYTES = 32L * 1024 * 1024


### PR DESCRIPTION
Reduces OkHttp disk cache from 256MB to 16MB, shortens EPG retention from 24h to 12h, and triggers database maintenance (PRAGMA optimize + WAL checkpoint) on app launch to compact storage.

Files changed:
- app/.../di/NetworkModule.kt
- data/.../sync/DatabaseMaintenanceManager.kt
- app/.../dashboard/DashboardViewModel.kt