### PR TITLE
Allow portrait mode on mobile devices, lock TVs to landscape

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
             android:configChanges="keyboard|keyboardHidden|navigation|orientation|screenSize|screenLayout|smallestScreenSize"
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true"
-            android:screenOrientation="landscape"
+            android:screenOrientation="unspecified"
             android:windowSoftInputMode="adjustResize">
 
             <intent-filter>

--- a/app/src/main/java/com/streamvault/app/MainActivity.kt
+++ b/app/src/main/java/com/streamvault/app/MainActivity.kt
@@ -132,6 +132,9 @@ class MainActivity : ComponentActivity() {
         _pictureInPictureModeFlow.value = isInPictureInPictureMode
         handleExternalIntent(intent)
         if (isTelevisionDevice()) {
+            // Lock TVs to landscape — the manifest uses "unspecified" so phones/tablets
+            // can freely rotate, but TV UI is designed for landscape only.
+            requestedOrientation = android.content.pm.ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
             lifecycleScope.launch {
                 watchNextManager.refreshWatchNext()
                 launcherRecommendationsManager.refreshRecommendations()


### PR DESCRIPTION
Changes `android:screenOrientation` from `"landscape"` to `"unspecified"` in the manifest so phones and tablets can rotate freely.

For TV devices, `MainActivity` locks orientation to landscape at runtime via `requestedOrientation = SCREEN_ORIENTATION_SENSOR_LANDSCAPE`. This ensures the TV UI, which is designed for landscape, never accidentally rotates.

Only 2 files changed:
- app/src/main/AndroidManifest.xml — landscape → unspecified
- app/src/main/java/.../MainActivity.kt — TV runtime orientation lock