### PR TITLE
Fix browse pagination and infinite scroll for GROUPED duplicate handling

### DIFF
--- a/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
+++ b/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
@@ -1326,7 +1326,7 @@ interface MovieDao {
         limit: Int
     ): List<MovieBrowseEntity>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND added_at > 0 ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
+    @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
     fun getFreshPreview(providerId: Long, limit: Int): Flow<List<MovieBrowseEntity>>
 
         @Query(
@@ -1357,14 +1357,13 @@ interface MovieDao {
     )
     fun getFreshCountByProvider(providerId: Long): Flow<Int>
 
-        @Query("SELECT * FROM movies WHERE provider_id = :providerId AND added_at > 0 ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
+        @Query("SELECT * FROM movies WHERE provider_id = :providerId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
     suspend fun getFreshCursorPage(providerId: Long, limit: Int): List<MovieBrowseEntity>
 
     @Query(
         """
         SELECT * FROM movies
         WHERE provider_id = :providerId
-          AND added_at > 0
           AND (
               added_at < :lastAddedAt
               OR (
@@ -1384,7 +1383,7 @@ interface MovieDao {
         limit: Int
     ): List<MovieBrowseEntity>
 
-    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId AND added_at > 0 ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
+    @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
     fun getFreshByCategoryPreview(providerId: Long, categoryId: Long, limit: Int): Flow<List<MovieBrowseEntity>>
 
         @Query(
@@ -1417,7 +1416,7 @@ interface MovieDao {
     )
     fun getFreshCountByCategory(providerId: Long, categoryId: Long): Flow<Int>
 
-        @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId AND added_at > 0 ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
+        @Query("SELECT * FROM movies WHERE provider_id = :providerId AND category_id = :categoryId ORDER BY added_at DESC, name ASC, id ASC LIMIT :limit")
     suspend fun getFreshByCategoryCursorPage(providerId: Long, categoryId: Long, limit: Int): List<MovieBrowseEntity>
 
     @Query(
@@ -1425,7 +1424,6 @@ interface MovieDao {
         SELECT * FROM movies
         WHERE provider_id = :providerId
           AND category_id = :categoryId
-          AND added_at > 0
           AND (
               added_at < :lastAddedAt
               OR (

--- a/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
@@ -1082,7 +1082,7 @@ class MovieRepositoryImpl @Inject constructor(
             .map { it.contentId }
             .toSet()
 
-        val canUseCursorWindow = presentationSettings.duplicateHandlingMode == VodDuplicateHandlingMode.SHOW_ALL && supportsCursorBrowse(query)
+        val canUseCursorWindow = supportsCursorBrowse(query)
         val items = if (canUseCursorWindow) {
             fetchMovieCursorWindow(query, favoriteIds)
         } else {
@@ -1110,32 +1110,7 @@ class MovieRepositoryImpl @Inject constructor(
                 .take(query.limit)
         }
 
-        val totalCount = if (presentationSettings.duplicateHandlingMode == VodDuplicateHandlingMode.SHOW_ALL) {
-            rawTotalCount
-        } else {
-            val movies = movieBrowseSource(query).first()
-            val history = playbackHistoryDao.getByProvider(query.providerId).first()
-            val inProgressIds = history
-                .asSequence()
-                .filter { it.contentType == ContentType.MOVIE }
-                .filter { it.resumePositionMs > 0L && (it.totalDurationMs <= 0L || !moviePlaybackComplete(it.resumePositionMs, it.totalDurationMs)) }
-                .map { it.contentId }
-                .toSet()
-            val watchCounts = history
-                .asSequence()
-                .filter { it.contentType == ContentType.MOVIE }
-                .associate { it.contentId to it.watchCount }
-            buildPresentedMovies(
-                applyMovieBrowseQuery(
-                    movies = movies,
-                    query = query,
-                    favoriteIds = favoriteIds,
-                    inProgressIds = inProgressIds,
-                    watchCounts = watchCounts
-                ),
-                presentationSettings
-            ).size
-        }
+        val totalCount = rawTotalCount
 
         val hasMoreRemote = query.categoryId?.let { categoryId ->
             val provider = providerDao.getById(query.providerId)

--- a/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
@@ -1053,8 +1053,7 @@ class SeriesRepositoryImpl @Inject constructor(
             .map { it.contentId }
             .toSet()
 
-        val canUseCursorWindow = presentationSettings.duplicateHandlingMode == VodDuplicateHandlingMode.SHOW_ALL &&
-            supportsCursorBrowse(query)
+        val canUseCursorWindow = supportsCursorBrowse(query)
         val items = if (canUseCursorWindow) {
             fetchSeriesCursorWindow(query, favoriteIds)
         } else {
@@ -1095,45 +1094,7 @@ class SeriesRepositoryImpl @Inject constructor(
                 .take(query.limit)
         }
 
-        val totalCount = if (presentationSettings.duplicateHandlingMode == VodDuplicateHandlingMode.SHOW_ALL) {
-            rawTotalCount
-        } else {
-            val series = seriesBrowseSource(query).first()
-            val history = playbackHistoryDao.getByProvider(query.providerId).first()
-            val inProgressIds = history
-                .asSequence()
-                .filter { it.contentType == ContentType.SERIES || it.contentType == ContentType.SERIES_EPISODE }
-                .filter {
-                    it.resumePositionMs > 0L && (
-                        it.totalDurationMs <= 0L ||
-                            it.resumePositionMs < (it.totalDurationMs * 0.95f).toLong()
-                        )
-                }
-                .mapNotNull { it.seriesId ?: it.contentId }
-                .toSet()
-            val completedSeriesIds = history
-                .asSequence()
-                .filter { it.contentType == ContentType.SERIES_EPISODE }
-                .filter { it.totalDurationMs > 0L && it.resumePositionMs >= (it.totalDurationMs * 0.95f).toLong() }
-                .mapNotNull { it.seriesId }
-                .toSet()
-            val watchCounts = history
-                .asSequence()
-                .filter { it.contentType == ContentType.SERIES || it.contentType == ContentType.SERIES_EPISODE }
-                .groupBy { it.seriesId ?: it.contentId }
-                .mapValues { (_, entries) -> entries.maxOf { it.watchCount } }
-            buildPresentedSeries(
-                applySeriesBrowseQuery(
-                    series = series,
-                    query = query,
-                    favoriteIds = favoriteIds,
-                    inProgressIds = inProgressIds,
-                    completedSeriesIds = completedSeriesIds,
-                    watchCounts = watchCounts
-                ),
-                presentationSettings
-            ).size
-        }
+        val totalCount = rawTotalCount
 
         val hasMoreRemote = query.categoryId?.let { categoryId ->
             val provider = providerDao.getById(query.providerId)


### PR DESCRIPTION
Three fixes for browsing with GROUPED (or SMART) VOD duplicate handling mode:

1. **Allow cursor browsing with GROUPED** — `canUseCursorWindow` previously required `duplicateHandlingMode == SHOW_ALL`. Removed that check so GROUPED mode uses the efficient cursor pagination path instead of the capped 200-item non-cursor path.

2. **Fix `canLoadMore` for GROUPED** — The `totalCount` for GROUPED mode was computed from a full non-cursor load (capped at SEARCH_RESULT_LIMIT=200), but the cursor path could load more items than that. Once the cursor exceeded 200 items, `canLoadMore` became false, stopping infinite scroll prematurely. Now uses the actual database count (`rawTotalCount`) regardless of duplicate handling mode.

3. **Remove `added_at > 0` filter from FreshCursor queries** — Items with `added_at=0` (null/deprecated from provider) were excluded from cursor results but still counted in the total. This caused `canLoadMore` to stay true forever without loading new items. Removed the filter from all movie FreshCursor and FreshByCategoryCursor queries so the cursor returns all items matching the provider/category.

### Files changed
- `data/.../repository/MovieRepositoryImpl.kt` — canUseCursorWindow + totalCount
- `data/.../repository/SeriesRepositoryImpl.kt` — canUseCursorWindow + totalCount
- `data/.../local/dao/Daos.kt` — removed added_at>0 from 6 FreshCursor queries