### PR TITLE
fix(epg): chunk native-program lookup to stay under SQLite's variable…

### DIFF
--- a/data/src/main/java/com/streamvault/data/epg/EpgResolutionEngine.kt
+++ b/data/src/main/java/com/streamvault/data/epg/EpgResolutionEngine.kt
@@ -109,7 +109,15 @@ class EpgResolutionEngine @Inject constructor(
         // Check which channels have provider-native EPG data
         val providerEpgChannelIds = channels.mapNotNull { it.epgChannelId?.trim()?.takeIf(String::isNotEmpty) }
         val providerNativeChannelIds = if (providerEpgChannelIds.isNotEmpty()) {
-            programDao.getChannelIdsWithPrograms(providerId, providerEpgChannelIds).toHashSet()
+            // SQLite bind-variable cap is 999 on older Android; keep chunks small
+            // (same pattern as EpgRepositoryImpl.getPrograms).
+            if (providerEpgChannelIds.size <= 500) {
+                programDao.getChannelIdsWithPrograms(providerId, providerEpgChannelIds)
+            } else {
+                providerEpgChannelIds.chunked(500).flatMap { chunk ->
+                    programDao.getChannelIdsWithPrograms(providerId, chunk)
+                }
+            }.toHashSet()
         } else {
             emptySet()
         }

--- a/data/src/test/java/com/streamvault/data/epg/EpgResolutionEngineTest.kt
+++ b/data/src/test/java/com/streamvault/data/epg/EpgResolutionEngineTest.kt
@@ -25,7 +25,9 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -491,6 +493,23 @@ class EpgResolutionEngineTest {
         val result = engine.getResolvedProgrammes(PROVIDER_ID, listOf(1L), now - 3600_000, now + 3600_000)
 
         assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `resolveForProvider_overFiveHundredChannels_chunks_native_program_lookup`() = runTest {
+        val channels = (1..600).map { i ->
+            makeChannel(id = i.toLong(), name = "Channel $i", epgChannelId = "ch.$i")
+        }
+        whenever(channelDao.getByProviderSync(PROVIDER_ID)).thenReturn(channels)
+        whenever(providerEpgSourceDao.getEnabledForProviderSync(PROVIDER_ID)).thenReturn(emptyList())
+        whenever(channelEpgMappingDao.getForProvider(PROVIDER_ID)).thenReturn(emptyList())
+
+        engine.resolveForProvider(PROVIDER_ID)
+
+        val captor = argumentCaptor<List<String>>()
+        verify(programDao, times(2)).getChannelIdsWithPrograms(eq(PROVIDER_ID), captor.capture())
+        assertThat(captor.allValues.map { it.size }).isEqualTo(listOf(500, 100))
+        assertThat(captor.allValues.flatten().distinct().size).isEqualTo(600)
     }
 
     // ── Helpers ────────────────────────────────────────────────────


### PR DESCRIPTION
… cap

resolveForProvider passed every channel's epgChannelId as a bind variable to a single IN (...) query. On Android <= 11 (SQLite < 3.32) SQLITE_MAX_VARIABLE_NUMBER is 999, so any provider with 1,000+ channels fails EPG import with "too many SQL variables" — reproduced on an NVIDIA SHIELD (Android 11) with a 1,080-channel M3U.

Chunk at 500, mirroring the pattern already used at every sibling call site (EpgRepositoryImpl.getPrograms*/getNowPlaying*, EpgResolutionEngine's mapping/programme lookups) — this was the last un-chunked channel-list query. Adds a regression test asserting the chunk sizes (500 + 100 for 600 channels) and id coverage.