### PR TITLE
Fix/epg collision

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/model/GuideLookupKey.kt
+++ b/app/src/main/java/com/streamvault/app/ui/model/GuideLookupKey.kt
@@ -2,7 +2,6 @@ package com.streamvault.app.ui.model
 
 import com.streamvault.domain.model.Channel
 
-fun Channel.guideLookupKey(): String? {
-    return epgChannelId?.trim()?.takeIf { it.isNotEmpty() }
-        ?: streamId.takeIf { it > 0L }?.toString()
-}
+fun Channel.guideLookupKey(): String? =
+    streamId.takeIf { it > 0L }?.toString()
+        ?: epgChannelId?.trim()?.takeIf { it.isNotEmpty() }

--- a/data/src/main/java/com/streamvault/data/epg/EpgResolutionEngine.kt
+++ b/data/src/main/java/com/streamvault/data/epg/EpgResolutionEngine.kt
@@ -308,8 +308,8 @@ class EpgResolutionEngine @Inject constructor(
 
             for (mapping in sourceMappings) {
                 val channel = channelById[mapping.providerChannelId] ?: continue
-                val lookupKey = channel.epgChannelId?.trim()?.takeIf(String::isNotEmpty)
-                    ?: channel.streamId.takeIf { it > 0L }?.toString()
+                val lookupKey = channel.streamId.takeIf { it > 0L }?.toString()
+                    ?: channel.epgChannelId?.trim()?.takeIf(String::isNotEmpty)
                     ?: continue
                 val progs = programsByXmltvId[mapping.xmltvChannelId]
                     ?.map { it.toDomainProgram(providerId) }
@@ -344,8 +344,8 @@ class EpgResolutionEngine @Inject constructor(
 
             for (mapping in providerMappings) {
                 val channel = channelById[mapping.providerChannelId] ?: continue
-                val lookupKey = channel.epgChannelId?.trim()?.takeIf(String::isNotEmpty)
-                    ?: channel.streamId.takeIf { it > 0L }?.toString()
+                val lookupKey = channel.streamId.takeIf { it > 0L }?.toString()
+                    ?: channel.epgChannelId?.trim()?.takeIf(String::isNotEmpty)
                     ?: continue
                 // Don't overwrite external data (external wins if already resolved)
                 if (lookupKey !in result) {

--- a/data/src/main/java/com/streamvault/data/repository/EpgRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/EpgRepositoryImpl.kt
@@ -387,7 +387,7 @@ class EpgRepositoryImpl @Inject constructor(
         endTime: Long
     ): List<Program> {
         val normalizedChannelId = epgChannelId?.trim()?.takeIf { it.isNotEmpty() }
-        val lookupKey = normalizedChannelId ?: streamId.takeIf { it > 0L }?.toString()
+        val lookupKey = streamId.takeIf { it > 0L }?.toString() ?: normalizedChannelId
         val offsetMs = shiftMsFor(providerId)
 
         if (internalChannelId > 0L && lookupKey != null) {


### PR DESCRIPTION
## Problem

The EPG guide displays the **same programme on multiple unrelated channels**
when the provider returns a non-unique `epg_channel_id`.

Some Xtream panels populate `epg_channel_id` poorly: dozens of unrelated
channels share a single placeholder value (the same id repeated across many
different channels). Each of these channels is correctly resolved to a
**distinct** external XMLTV `xmltv_channel_id`, yet the guide shows one
channel's programmes on all of them.

## Root cause

`getResolvedProgrammes()` fetches programmes correctly (via the unique
`xmltvChannelId` for external, `channelId` for provider-native), but **stores
them in the result map keyed by `epgChannelId`**:

```kotlin
val lookupKey = channel.epgChannelId?.trim()?.takeIf(String::isNotEmpty)
    ?: channel.streamId.takeIf { it > 0L }?.toString()
    ?: continue
result[lookupKey] = progs
```

When several channels share the same `epgChannelId`, they collide on the same
map entry — the last one processed wins, and every other channel inherits its
guide. The grid reads back with the same `epgChannelId`-first key
(`Channel.guideLookupKey()`), so the collision is consistent end to end.

## Reproduction

1. Provider returns the same `epg_channel_id` for several unrelated channels.
2. Each channel is resolved to a distinct EXTERNAL `xmltv_channel_id`.
3. Guide shows the same programme for all of them.

Example: two unrelated channels (say channel A and channel B) each map to
their own XMLTV entry with different programmes, but because both carry the
same provider `epg_channel_id`, the guide shows channel B's programme on
channel A as well.

Setting `channels.epg_channel_id = NULL` (without touching
`channel_epg_mappings`) immediately fixes the guide — isolating the key
collision as the cause.

## Fix

Prefer `streamId` (always unique per channel within a provider) as the guide
lookup key, in both the producer (`EpgResolutionEngine.getResolvedProgrammes`,
external + provider blocks), the consumer (`Channel.guideLookupKey`), and the
playback path (`getResolvedProgramsForPlaybackChannel`).

`epgChannelId` is **still used** for provider-native programme joins
(`ProgramDao.getForChannelsSync` joins on `channel_id = epgChannelId`), so:

- no schema change, no migration,
- provider-native guide behaviour is preserved,
- the change only affects the *identity* key used to bucket programmes per
  channel, never the *lookup* key used to fetch them.

## Testing

- `./gradlew testDebugUnitTest` passes.
- Verified on a real device: with the provider's duplicate `epg_channel_id`
  values intact in the DB, each channel now shows its own distinct programme.
  Before the patch, they shared one guide.

Fixes #210.