### PR TITLE
feat: show measured frame rate and stream bitrate in player stats

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/PlayerScreen.kt
@@ -1399,7 +1399,7 @@ fun PlayerScreen(
                     onStopCasting = viewModel::stopCasting,
                     timeshiftUiState = timeshiftUiState,
                     onTransientPanelVisibilityChanged = { channelInfoSubPanelOpen = it },
-                    resolutionLabel = videoFormat.resolutionLabel.takeIf { it.isNotBlank() && !videoFormat.isEmpty }
+                    resolutionLabel = buildChannelInfoResolutionLabel(videoFormat)
                 )
             }
         }
@@ -1412,6 +1412,13 @@ private fun AspectRatio.toPlayerSurfaceResizeMode(): PlayerSurfaceResizeMode = w
     AspectRatio.ZOOM -> PlayerSurfaceResizeMode.ZOOM
 }
 
+/** Pill shown in the bottom channel info bar: "1080p" or "1080p · 25fps" once the frame rate is known. */
+private fun buildChannelInfoResolutionLabel(videoFormat: VideoFormat): String? {
+    if (videoFormat.isEmpty || videoFormat.resolutionLabel.isBlank()) return null
+    val frameRateLabel = videoFormat.frameRateLabel ?: return videoFormat.resolutionLabel
+    return "${videoFormat.resolutionLabel} · ${frameRateLabel}fps"
+}
+
 private fun buildResolutionBadgeLabel(
     videoFormat: VideoFormat,
     videoTracks: List<PlayerTrack>,
@@ -1419,11 +1426,14 @@ private fun buildResolutionBadgeLabel(
 ): String? {
     if (videoFormat.isEmpty) return null
     val selectedTrack = videoTracks.firstOrNull(PlayerTrack::isSelected)
-    return if (selectedTrack == null || selectedTrack.id == PLAYER_TRACK_AUTO_ID) {
+    val label = if (selectedTrack == null || selectedTrack.id == PLAYER_TRACK_AUTO_ID) {
         autoResolutionLabel
     } else {
         selectedTrack.name
     }
+    // Append the measured frame rate when the stream reports one (issue #220).
+    val frameRateLabel = videoFormat.frameRateLabel ?: return label
+    return "$label · ${frameRateLabel}fps"
 }
 
 @Composable

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerAuxiliaryOverlays.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerAuxiliaryOverlays.kt
@@ -874,7 +874,14 @@ fun DiagnosticsOverlay(
                         PlayerOverlaySectionLabel(stringResource(R.string.player_diagnostics_section_video))
                         PlayerMetaRow(stringResource(R.string.player_diagnostics_resolution), "${stats.width}x${stats.height}")
                         PlayerMetaRow(stringResource(R.string.player_diagnostics_video_codec), stats.videoCodec)
-                        PlayerMetaRow(stringResource(R.string.player_diagnostics_video_bitrate), "${stats.videoBitrate / 1000} kbps")
+                        PlayerMetaRow(stringResource(R.string.player_diagnostics_frame_rate), formatDiagnosticsFrameRateLabel(stats))
+                        PlayerMetaRow(stringResource(R.string.player_diagnostics_stream_bitrate), formatBitsPerSecondLabel(stats.measuredBitrate))
+                        if (stats.videoBitrate > 0) {
+                            PlayerMetaRow(stringResource(R.string.player_diagnostics_video_bitrate), "${stats.videoBitrate / 1000} kbps")
+                        }
+                        if (stats.bandwidthEstimate > 0L) {
+                            PlayerMetaRow(stringResource(R.string.player_diagnostics_bandwidth_estimate), formatBitsPerSecondLabel(stats.bandwidthEstimate))
+                        }
                         PlayerMetaRow(stringResource(R.string.player_diagnostics_dropped_frames), stats.droppedFrames.toString())
                         PlayerMetaRow(stringResource(R.string.player_diagnostics_video_stalls), diagnostics.videoStallCount.toString())
                         if (diagnostics.lastVideoFrameAgoMs > 0L) {
@@ -1000,6 +1007,29 @@ private fun DiagnosticsScrollCue(label: String) {
             textAlign = TextAlign.Center
         )
     }
+}
+
+/**
+ * Measured rendered frame rate, with the declared container value in brackets when the two are
+ * both known. Falls back to the declared value alone, then "Unknown". Many live MPEG-TS streams
+ * declare no frame rate at all, which is why the measured value comes first.
+ */
+private fun formatDiagnosticsFrameRateLabel(stats: PlayerStats): String {
+    val measured = com.streamvault.domain.model.formatFrameRateLabel(stats.measuredFrameRate)
+    val declared = com.streamvault.domain.model.formatFrameRateLabel(stats.frameRate)
+    return when {
+        measured != null && declared != null && measured != declared -> "$measured fps (stream $declared)"
+        measured != null -> "$measured fps"
+        declared != null -> "$declared fps"
+        else -> "Unknown"
+    }
+}
+
+/** Bits-per-second as "8.4 Mbps" / "640 kbps", or "Unknown" for 0. */
+private fun formatBitsPerSecondLabel(bps: Long): String = when {
+    bps <= 0L -> "Unknown"
+    bps >= 1_000_000L -> String.format(java.util.Locale.US, "%.1f Mbps", bps / 1_000_000.0)
+    else -> "${bps / 1000} kbps"
 }
 
 private fun formatOffsetLabel(offsetMs: Int): String = when {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1324,6 +1324,9 @@
     <string name="player_diagnostics_av_sync_custom">On (custom sync path)</string>
     <string name="player_diagnostics_av_sync_waiting">On (waiting for playback restart)</string>
     <string name="player_diagnostics_video_bitrate">Video Bitrate</string>
+    <string name="player_diagnostics_frame_rate">Frame Rate</string>
+    <string name="player_diagnostics_stream_bitrate">Stream Bitrate</string>
+    <string name="player_diagnostics_bandwidth_estimate">Network Bandwidth</string>
     <string name="player_diagnostics_dropped_frames">Dropped Frames</string>
     <string name="player_diagnostics_last_failure">Last Failure</string>
     <string name="player_diagnostics_recovery_actions">Recovery Actions</string>

--- a/domain/src/main/java/com/streamvault/domain/model/VideoFormat.kt
+++ b/domain/src/main/java/com/streamvault/domain/model/VideoFormat.kt
@@ -28,5 +28,22 @@ data class VideoFormat(
             else -> "Unknown"
         }
     
+    /**
+     * Frame rate as a compact label ("25", "29.97", "50"), or null when the stream did not
+     * report one. Many live MPEG-TS feeds omit it, so callers must handle null.
+     */
+    val frameRateLabel: String? get() = formatFrameRateLabel(frameRate)
+
     val isEmpty: Boolean get() = width == 0 && height == 0
+}
+
+/** Formats a frame rate without a trailing ".00" for whole numbers; null when unknown (<= 0). */
+fun formatFrameRateLabel(frameRate: Float): String? {
+    if (frameRate <= 0f) return null
+    val rounded = Math.round(frameRate * 100f) / 100f
+    return if (rounded == rounded.toInt().toFloat()) {
+        rounded.toInt().toString()
+    } else {
+        String.format(java.util.Locale.US, "%.2f", rounded).trimEnd('0')
+    }
 }

--- a/domain/src/test/java/com/streamvault/domain/model/VideoFormatTest.kt
+++ b/domain/src/test/java/com/streamvault/domain/model/VideoFormatTest.kt
@@ -1,0 +1,29 @@
+package com.streamvault.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VideoFormatTest {
+
+    @Test
+    fun `frameRateLabel is null when frame rate is unknown`() {
+        assertNull(VideoFormat(1920, 1080).frameRateLabel)
+        assertNull(formatFrameRateLabel(0f))
+        assertNull(formatFrameRateLabel(-1f))
+    }
+
+    @Test
+    fun `frameRateLabel drops fractional part for whole frame rates`() {
+        assertEquals("25", VideoFormat(1920, 1080, frameRate = 25f).frameRateLabel)
+        assertEquals("50", formatFrameRateLabel(50f))
+        assertEquals("60", formatFrameRateLabel(59.999f))
+    }
+
+    @Test
+    fun `frameRateLabel keeps up to two decimals for fractional frame rates`() {
+        assertEquals("29.97", formatFrameRateLabel(29.97f))
+        assertEquals("23.98", formatFrameRateLabel(23.976f))
+        assertEquals("24.5", formatFrameRateLabel(24.5f))
+    }
+}

--- a/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/Media3PlayerEngine.kt
@@ -85,7 +85,9 @@ import com.streamvault.player.playback.shouldRecoverPositionAdvancingReadyStalls
 import com.streamvault.player.playback.shouldRecoverReadyStalls
 import com.streamvault.player.playback.shouldReconnectLiveStall
 import com.streamvault.player.playback.shouldForceSoftwareForAmbiguousDecoderFallback
+import com.streamvault.player.stats.FrameRateDetector
 import com.streamvault.player.stats.PlayerStatsCollector
+import com.streamvault.player.stats.PlayerTransferByteCounter
 import com.streamvault.player.timeshift.DefaultLiveTimeshiftManager
 import com.streamvault.player.timeshift.LiveTimeshiftBackend
 import com.streamvault.player.timeshift.LiveTimeshiftState
@@ -308,17 +310,22 @@ class Media3PlayerEngine @Inject constructor(
     }
     override val isMuted: StateFlow<Boolean> = audioFocusController.isMuted
 
+    private val transferByteCounter = PlayerTransferByteCounter()
+    private val frameRateDetector = FrameRateDetector()
     private val statsCollector = PlayerStatsCollector(
         scopeProvider = { scope },
         currentPosition = _currentPosition,
         duration = _duration,
         videoFormat = _videoFormat,
         playerStats = _playerStats,
-        playbackState = _playbackState
+        playbackState = _playbackState,
+        networkBytesProvider = { transferByteCounter.totalNetworkBytes },
+        frameRateDetector = frameRateDetector
     ).also {
         it.bind { exoPlayer }
     }
-    private val dataSourceFactoryProvider = PlayerDataSourceFactoryProvider(context, okHttpClient)
+    private val dataSourceFactoryProvider =
+        PlayerDataSourceFactoryProvider(context, okHttpClient, transferByteCounter)
     private val mediaSourceFactory = PlayerMediaSourceFactory(dataSourceFactoryProvider)
     private val preloadCoordinator = PreloadCoordinator()
     private val compatibilityProfile: PlaybackCompatibilityProfile = DefaultPlaybackCompatibilityProfile
@@ -1205,6 +1212,7 @@ class Media3PlayerEngine @Inject constructor(
                 playbackParameters = PlaybackParameters(_playbackSpeed.value)
                 setVideoFrameMetadataListener { presentationTimeUs, _, _, _ ->
                     videoStallDetector.onVideoFrameRendered((presentationTimeUs / 1_000L).coerceAtLeast(0L))
+                    frameRateDetector.onFrame(presentationTimeUs)
                 }
                 addAnalyticsListener(createAnalyticsListener())
                 addListener(createPlayerListener())

--- a/player/src/main/java/com/streamvault/player/PlayerEngine.kt
+++ b/player/src/main/java/com/streamvault/player/PlayerEngine.kt
@@ -173,6 +173,12 @@ data class PlayerStats(
     val videoStallCount: Int = 0,
     val lastVideoFrameAgoMs: Long = 0,
     val videoBitrate: Int = 0,
+    /** Frame rate declared by the stream/container; 0 when not declared (common for MPEG-TS). */
+    val frameRate: Float = 0f,
+    /** Nominal frame rate detected once from frame timestamps and then locked; 0 until detected. */
+    val measuredFrameRate: Float = 0f,
+    /** Running average of the whole-stream network bitrate in bps, rounded to 0.1 Mbps; 0 until measured. */
+    val measuredBitrate: Long = 0L,
     val droppedFrames: Int = 0,
     val width: Int = 0,
     val height: Int = 0,

--- a/player/src/main/java/com/streamvault/player/playback/PlayerDataSourceFactoryProvider.kt
+++ b/player/src/main/java/com/streamvault/player/playback/PlayerDataSourceFactoryProvider.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.TransferListener
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import com.streamvault.domain.model.VodHttpProtocolMode
 import com.streamvault.domain.model.PlaybackTransportPolicy
@@ -24,7 +25,9 @@ internal fun shouldUsePlatformHttpDataSource(resolvedStreamType: ResolvedStreamT
 @UnstableApi
 class PlayerDataSourceFactoryProvider(
     private val context: Context,
-    private val baseClient: OkHttpClient
+    private val baseClient: OkHttpClient,
+    /** Receives byte counts for foreground (non-preload) playback; used for measured bitrate stats. */
+    private val transferListener: TransferListener? = null
 ) {
     private companion object {
         private const val TAG = "PlayerDataSource"
@@ -108,6 +111,9 @@ class PlayerDataSourceFactoryProvider(
             }
         }
         val defaultFactory = DefaultDataSource.Factory(context, upstreamFactory)
+        if (!preload && transferListener != null) {
+            defaultFactory.setTransferListener(transferListener)
+        }
         val factory = if (shouldWrapDataSourceReadStats(resolvedStreamType)) {
             PlayerDataSourceReadStatsFactory(
                 upstream = defaultFactory,

--- a/player/src/main/java/com/streamvault/player/stats/BitrateMeter.kt
+++ b/player/src/main/java/com/streamvault/player/stats/BitrateMeter.kt
@@ -1,0 +1,54 @@
+package com.streamvault.player.stats
+
+/**
+ * Running (exponentially smoothed) stream bitrate from a cumulative byte counter.
+ *
+ * Called once per stats tick with the cumulative network bytes; keeps two longs of state and does
+ * a handful of integer operations. The result is rounded to [ROUNDING_BPS] so the value published
+ * to the UI only changes when it moved by a visible amount, which avoids needless recompositions.
+ */
+class BitrateMeter(
+    /** Weight of the newest sample, 0..1. 0.25 ≈ a 4-second running average at 1-second ticks. */
+    private val alpha: Float = DEFAULT_ALPHA
+) {
+    private var lastBytes = Long.MIN_VALUE
+    private var lastTimeMs = 0L
+    private var smoothedBps = 0.0
+
+    /** Current smoothed bitrate in bits per second, rounded; 0 until two samples have been seen. */
+    var bitrateBps: Long = 0L
+        private set
+
+    fun reset() {
+        lastBytes = Long.MIN_VALUE
+        lastTimeMs = 0L
+        smoothedBps = 0.0
+        bitrateBps = 0L
+    }
+
+    fun addSample(timeMs: Long, cumulativeBytes: Long): Long {
+        val previousBytes = lastBytes
+        val previousTime = lastTimeMs
+        lastBytes = cumulativeBytes
+        lastTimeMs = timeMs
+        if (previousBytes == Long.MIN_VALUE) return bitrateBps
+
+        val deltaBytes = cumulativeBytes - previousBytes
+        val deltaMs = timeMs - previousTime
+        if (deltaBytes < 0L || deltaMs <= 0L) {
+            // Counter reset or clock went backwards: start over from this sample.
+            smoothedBps = 0.0
+            bitrateBps = 0L
+            return 0L
+        }
+        val instantBps = deltaBytes * 8_000.0 / deltaMs
+        smoothedBps = if (smoothedBps == 0.0) instantBps else smoothedBps + alpha * (instantBps - smoothedBps)
+        bitrateBps = (Math.round(smoothedBps / ROUNDING_BPS) * ROUNDING_BPS)
+        return bitrateBps
+    }
+
+    companion object {
+        const val DEFAULT_ALPHA = 0.25f
+        const val ROUNDING_BPS = 100_000L
+    }
+}

--- a/player/src/main/java/com/streamvault/player/stats/FrameRateDetector.kt
+++ b/player/src/main/java/com/streamvault/player/stats/FrameRateDetector.kt
@@ -1,0 +1,84 @@
+package com.streamvault.player.stats
+
+/**
+ * Detects the nominal frame rate of a stream from the presentation timestamps of rendered frames
+ * and then **locks**: after [framesToLock] usable frames it computes the rate once, snaps it to the
+ * nearest standard broadcast rate (23.976 / 24 / 25 / 29.97 / 30 / 50 / 59.94 / 60) and stops doing
+ * any work. This is deliberately cheaper than counting frames per second forever, and unlike a
+ * rendered-frames-per-second measurement it reports the *stream* rate even when a slow device is
+ * dropping frames, because it uses the smallest timestamp gap rather than the render throughput.
+ *
+ * Cost while detecting: one subtraction and one comparison per rendered frame. Cost after locking:
+ * a single volatile read per frame.
+ *
+ * Threading: [onFrame] is called on ExoPlayer's playback thread, [lockedFrameRate] is read from the
+ * Main thread, and [reset] may be called from Main. The working state is only touched on the
+ * playback thread; the published result is `@Volatile`.
+ */
+class FrameRateDetector(
+    private val framesToLock: Int = DEFAULT_FRAMES_TO_LOCK
+) {
+    @Volatile
+    private var locked = 0f
+
+    @Volatile
+    private var generation = 0
+
+    private var activeGeneration = -1
+    private var lastPresentationTimeUs = Long.MIN_VALUE
+    private var minDeltaUs = Long.MAX_VALUE
+    private var usableFrames = 0
+
+    /** Detected frame rate, or 0 until enough frames have been seen. */
+    val lockedFrameRate: Float get() = locked
+
+    /** Forget everything; the next stream is detected from scratch. Safe to call from any thread. */
+    fun reset() {
+        locked = 0f
+        generation++
+    }
+
+    /** Playback-thread only. */
+    fun onFrame(presentationTimeUs: Long) {
+        if (locked > 0f) return
+        if (activeGeneration != generation) {
+            activeGeneration = generation
+            lastPresentationTimeUs = Long.MIN_VALUE
+            minDeltaUs = Long.MAX_VALUE
+            usableFrames = 0
+        }
+        val last = lastPresentationTimeUs
+        lastPresentationTimeUs = presentationTimeUs
+        if (last == Long.MIN_VALUE) return
+
+        val delta = presentationTimeUs - last
+        // Ignore seeks/discontinuities and duplicate timestamps: only 5..240 fps gaps count.
+        if (delta < MIN_DELTA_US || delta > MAX_DELTA_US) return
+        if (delta < minDeltaUs) minDeltaUs = delta
+        usableFrames++
+        if (usableFrames >= framesToLock) {
+            locked = snapToStandardRate(1_000_000f / minDeltaUs)
+        }
+    }
+
+    companion object {
+        const val DEFAULT_FRAMES_TO_LOCK = 60
+        private const val MIN_DELTA_US = 1_000_000L / 240
+        private const val MAX_DELTA_US = 1_000_000L / 5
+        private val STANDARD_RATES = floatArrayOf(23.976f, 24f, 25f, 29.97f, 30f, 48f, 50f, 59.94f, 60f, 100f, 120f)
+
+        /** Snap to a standard rate when within 2 %, otherwise keep two decimals. */
+        fun snapToStandardRate(rate: Float): Float {
+            var best = 0f
+            var bestDistance = Float.MAX_VALUE
+            for (standard in STANDARD_RATES) {
+                val distance = kotlin.math.abs(rate - standard) / standard
+                if (distance < bestDistance) {
+                    bestDistance = distance
+                    best = standard
+                }
+            }
+            return if (bestDistance <= 0.02f) best else Math.round(rate * 100f) / 100f
+        }
+    }
+}

--- a/player/src/main/java/com/streamvault/player/stats/PlayerStatsCollector.kt
+++ b/player/src/main/java/com/streamvault/player/stats/PlayerStatsCollector.kt
@@ -1,5 +1,6 @@
 package com.streamvault.player.stats
 
+import android.os.SystemClock
 import androidx.media3.common.Format
 import androidx.media3.common.C
 import androidx.media3.exoplayer.ExoPlayer
@@ -40,7 +41,12 @@ class PlayerStatsCollector(
     private val duration: MutableStateFlow<Long>,
     private val videoFormat: MutableStateFlow<VideoFormat>,
     private val playerStats: MutableStateFlow<PlayerStats>,
-    private val playbackState: MutableStateFlow<PlaybackState>
+    private val playbackState: MutableStateFlow<PlaybackState>,
+    /** Cumulative network bytes received for playback; see [PlayerTransferByteCounter]. */
+    private val networkBytesProvider: () -> Long = { 0L },
+    /** Locked nominal frame rate detected from rendered-frame timestamps; see [FrameRateDetector]. */
+    private val frameRateDetector: FrameRateDetector = FrameRateDetector(),
+    private val clockMs: () -> Long = SystemClock::elapsedRealtime
 ) {
     // All fields are Main-thread-only. No @Volatile or AtomicInteger required.
     private var pollingJob: Job? = null
@@ -50,6 +56,7 @@ class PlayerStatsCollector(
     private var lastFrameRate = 0f
     private var lastBandwidthEstimate = 0L
     private var droppedFrames = 0
+    private val bitrateMeter = BitrateMeter()
 
     fun bind(playerProvider: () -> ExoPlayer?) {
         this.playerProvider = playerProvider
@@ -61,6 +68,8 @@ class PlayerStatsCollector(
         lastFrameRate = 0f
         lastBandwidthEstimate = 0L
         droppedFrames = 0
+        bitrateMeter.reset()
+        frameRateDetector.reset()
         currentPosition.value = 0L
         duration.value = 0L
         videoFormat.value = VideoFormat(0, 0)
@@ -141,11 +150,13 @@ class PlayerStatsCollector(
                         val video = lastVideoFormat
                         val audio = lastAudioFormat
                         val dropped = droppedFrames
+                        val measuredBitrate = bitrateMeter.addSample(clockMs(), networkBytesProvider())
+                        val measuredFrameRate = frameRateDetector.lockedFrameRate
 
                         videoFormat.value = VideoFormat(
                             width  = video?.width?.takeIf  { it > 0 } ?: 0,
                             height = video?.height?.takeIf { it > 0 } ?: 0,
-                            frameRate = lastFrameRate,
+                            frameRate = if (lastFrameRate > 0f) lastFrameRate else measuredFrameRate,
                             bitrate   = video?.bitrate?.takeIf { it > 0 } ?: 0,
                             codecV = video?.sampleMimeType ?: video?.codecs,
                             codecA = audio?.sampleMimeType ?: audio?.codecs,
@@ -162,6 +173,9 @@ class PlayerStatsCollector(
                                                 ?: playerStats.value.audioCodec,
                             videoBitrate      = video?.bitrate?.takeIf { it > 0 }
                                                 ?: playerStats.value.videoBitrate,
+                            frameRate         = lastFrameRate,
+                            measuredFrameRate = measuredFrameRate,
+                            measuredBitrate   = measuredBitrate,
                             droppedFrames     = dropped,
                             width             = video?.width?.takeIf  { it > 0 }
                                                 ?: playerStats.value.width,

--- a/player/src/main/java/com/streamvault/player/stats/PlayerTransferByteCounter.kt
+++ b/player/src/main/java/com/streamvault/player/stats/PlayerTransferByteCounter.kt
@@ -1,0 +1,32 @@
+package com.streamvault.player.stats
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.TransferListener
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Counts every network byte ExoPlayer pulls through the playback data sources so
+ * [PlayerStatsCollector] can compute a measured stream bitrate. Loader threads write, the
+ * Main thread reads, hence the [AtomicLong].
+ */
+@UnstableApi
+class PlayerTransferByteCounter : TransferListener {
+    private val networkBytes = AtomicLong(0L)
+
+    /** Cumulative network bytes since the counter was created. Never reset; consumers diff it. */
+    val totalNetworkBytes: Long get() = networkBytes.get()
+
+    override fun onTransferInitializing(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) = Unit
+
+    override fun onTransferStart(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) = Unit
+
+    override fun onBytesTransferred(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean, bytesTransferred: Int) {
+        if (isNetwork && bytesTransferred > 0) {
+            networkBytes.addAndGet(bytesTransferred.toLong())
+        }
+    }
+
+    override fun onTransferEnd(source: DataSource, dataSpec: DataSpec, isNetwork: Boolean) = Unit
+}

--- a/player/src/test/java/com/streamvault/player/stats/BitrateMeterTest.kt
+++ b/player/src/test/java/com/streamvault/player/stats/BitrateMeterTest.kt
@@ -1,0 +1,51 @@
+package com.streamvault.player.stats
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class BitrateMeterTest {
+
+    @Test
+    fun `unknown until two samples`() {
+        val meter = BitrateMeter()
+        assertThat(meter.addSample(timeMs = 0, cumulativeBytes = 0)).isEqualTo(0L)
+    }
+
+    @Test
+    fun `first interval is reported directly and rounded to 100 kbps`() {
+        val meter = BitrateMeter()
+        meter.addSample(timeMs = 0, cumulativeBytes = 0)
+        // 530,000 bytes in 1 s = 4.24 Mbps -> 4.2 Mbps
+        assertThat(meter.addSample(timeMs = 1_000, cumulativeBytes = 530_000)).isEqualTo(4_200_000L)
+    }
+
+    @Test
+    fun `smooths towards a new rate instead of jumping`() {
+        val meter = BitrateMeter(alpha = 0.5f)
+        meter.addSample(timeMs = 0, cumulativeBytes = 0)
+        meter.addSample(timeMs = 1_000, cumulativeBytes = 500_000) // 4 Mbps
+        val next = meter.addSample(timeMs = 2_000, cumulativeBytes = 1_500_000) // 8 Mbps instant
+
+        assertThat(next).isEqualTo(6_000_000L)
+        assertThat(meter.bitrateBps).isEqualTo(6_000_000L)
+    }
+
+    @Test
+    fun `counter reset starts over rather than going negative`() {
+        val meter = BitrateMeter()
+        meter.addSample(timeMs = 0, cumulativeBytes = 5_000_000)
+        meter.addSample(timeMs = 1_000, cumulativeBytes = 5_500_000)
+        assertThat(meter.addSample(timeMs = 2_000, cumulativeBytes = 100)).isEqualTo(0L)
+        assertThat(meter.addSample(timeMs = 3_000, cumulativeBytes = 500_100)).isEqualTo(4_000_000L)
+    }
+
+    @Test
+    fun `reset forgets history`() {
+        val meter = BitrateMeter()
+        meter.addSample(timeMs = 0, cumulativeBytes = 0)
+        meter.addSample(timeMs = 1_000, cumulativeBytes = 500_000)
+        meter.reset()
+        assertThat(meter.bitrateBps).isEqualTo(0L)
+        assertThat(meter.addSample(timeMs = 5_000, cumulativeBytes = 900_000)).isEqualTo(0L)
+    }
+}

--- a/player/src/test/java/com/streamvault/player/stats/FrameRateDetectorTest.kt
+++ b/player/src/test/java/com/streamvault/player/stats/FrameRateDetectorTest.kt
@@ -1,0 +1,91 @@
+package com.streamvault.player.stats
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FrameRateDetectorTest {
+
+    private fun feed(detector: FrameRateDetector, intervalUs: Long, frames: Int, startUs: Long = 0L) {
+        var pts = startUs
+        repeat(frames) {
+            detector.onFrame(pts)
+            pts += intervalUs
+        }
+    }
+
+    @Test
+    fun `stays unknown until enough frames were seen`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        feed(detector, intervalUs = 40_000, frames = 10) // 9 usable deltas
+
+        assertThat(detector.lockedFrameRate).isEqualTo(0f)
+    }
+
+    @Test
+    fun `locks to 25 fps for 40ms frame spacing`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        feed(detector, intervalUs = 40_000, frames = 11)
+
+        assertThat(detector.lockedFrameRate).isEqualTo(25f)
+    }
+
+    @Test
+    fun `snaps jittery 50 fps timestamps to 50`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        var pts = 0L
+        val jitter = longArrayOf(19_900, 20_100, 20_000, 19_950, 20_050)
+        repeat(12) { i ->
+            detector.onFrame(pts)
+            pts += jitter[i % jitter.size]
+        }
+
+        assertThat(detector.lockedFrameRate).isEqualTo(50f)
+    }
+
+    @Test
+    fun `reports the stream rate even when frames are being dropped`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        // 25 fps stream but the device renders only every other or third frame, except a few.
+        var pts = 0L
+        val gapsInFrames = intArrayOf(2, 3, 1, 2, 3, 3, 2, 1, 2, 3, 2)
+        for (gap in gapsInFrames) {
+            detector.onFrame(pts)
+            pts += 40_000L * gap
+        }
+
+        assertThat(detector.lockedFrameRate).isEqualTo(25f)
+    }
+
+    @Test
+    fun `snaps 23_976 and 29_97 to their standard rates`() {
+        assertThat(FrameRateDetector.snapToStandardRate(23.9f)).isEqualTo(23.976f)
+        assertThat(FrameRateDetector.snapToStandardRate(29.9f)).isEqualTo(29.97f)
+        assertThat(FrameRateDetector.snapToStandardRate(60.2f)).isEqualTo(60f)
+        assertThat(FrameRateDetector.snapToStandardRate(40f)).isEqualTo(40f)
+    }
+
+    @Test
+    fun `ignores discontinuities and stops working once locked`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        feed(detector, intervalUs = 40_000, frames = 5)
+        detector.onFrame(90_000_000L) // seek: huge gap must not count
+        feed(detector, intervalUs = 40_000, frames = 7, startUs = 90_040_000L)
+        assertThat(detector.lockedFrameRate).isEqualTo(25f)
+
+        // Once locked, wildly different spacing is ignored.
+        feed(detector, intervalUs = 16_667, frames = 30, startUs = 200_000_000L)
+        assertThat(detector.lockedFrameRate).isEqualTo(25f)
+    }
+
+    @Test
+    fun `reset allows a new stream to be detected`() {
+        val detector = FrameRateDetector(framesToLock = 10)
+        feed(detector, intervalUs = 40_000, frames = 11)
+        assertThat(detector.lockedFrameRate).isEqualTo(25f)
+
+        detector.reset()
+        assertThat(detector.lockedFrameRate).isEqualTo(0f)
+        feed(detector, intervalUs = 20_000, frames = 11)
+        assertThat(detector.lockedFrameRate).isEqualTo(50f)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #220 ("Show fps on play") and makes the bitrate in the diagnostics overlay useful for live IPTV streams.

Live MPEG-TS streams rarely declare a frame rate or a bitrate, so `Format.frameRate` / `Format.bitrate` are unset and the Stats overlay showed `0 kbps` and no fps. This PR measures both instead, while keeping the cost negligible for low-end TV boxes.

### Player module
- `FrameRateDetector`: fed from the existing `setVideoFrameMetadataListener` callback. Tracks the smallest presentation-timestamp gap over the first 60 rendered frames, snaps to the nearest standard rate (23.976 / 24 / 25 / 29.97 / 30 / 50 / 59.94 / 60), then locks and does no further work. Because it uses timestamp spacing rather than render throughput, it reports the stream's rate even when the device drops frames.
- `PlayerTransferByteCounter` (a `TransferListener`) attached in `PlayerDataSourceFactoryProvider` for non-preload data sources, plus `BitrateMeter`, an exponential running average sampled on the existing 1 s stats tick and rounded to 0.1 Mbps so the StateFlow only emits on visible changes.
- `PlayerStats` gains `frameRate` (declared), `measuredFrameRate` and `measuredBitrate`. `VideoFormat.frameRate` falls back to the detected rate when the stream declares none.

### App / domain
- Stats overlay: new "Frame Rate" and "Stream Bitrate" rows. The declared "Video Bitrate" and "Network Bandwidth" rows are shown only when non-zero instead of `0 kbps`.
- Resolution badge and channel-info resolution pill append the fps once known, e.g. `AUTO:1080p · 25fps` / `1080p · 25fps`.
- `VideoFormat.frameRateLabel` formats 25 -> `25`, 29.97 -> `29.97`.
- Two new strings (`player_diagnostics_frame_rate`, `player_diagnostics_stream_bitrate`); other locales fall back to English.

"Stream Bitrate" is the whole mux (audio + video + container), which is why it is labelled separately from the declared video-track bitrate.

## Test plan
- [x] `:domain:test` and `:player:testDebugUnitTest` pass, including new `FrameRateDetectorTest`, `BitrateMeterTest`, `VideoFormatTest`
- [x] `:app:assembleDebug` / `:app:assembleBeta` build, lint clean
- [x] Verified on an Android TV box (Amlogic, 2 GB RAM) with MPEG-TS live channels: Stats shows e.g. `25 fps` and `4.2 Mbps` within ~3 s; badge and channel-info pill show `1080p · 25fps`; main-thread CPU unchanged.
