### PR TITLE
Stalker sync/EPG fixes and portal-backed VOD search

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
@@ -291,7 +291,7 @@ class EpgViewModel @Inject constructor(
 
     companion object {
         const val MAX_CHANNELS = 60
-        private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 10
+        private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS = 6
         const val LOOKBACK_MS = 60 * 60 * 1000L
         const val LOOKAHEAD_MS = 6 * 60 * 60 * 1000L
@@ -324,6 +324,9 @@ class EpgViewModel @Inject constructor(
     private var guideFallbackJob: Job? = null
     private var prefetchJob: Deferred<GuidePrefetchedPage?>? = null
     private var loadMoreJob: Job? = null
+    // Guide keys that returned successfully-but-empty from on-demand fetch this session.
+    // Skipped on later pages so channels without portal EPG don't cost a request per visit.
+    private val knownEmptyGuideKeys = mutableSetOf<String>()
     private var combinedCategoriesById: Map<Long, CombinedCategory> = emptyMap()
     private var previewPlayerEngine: PlayerEngine? = null
     private var previewSessionVersion: Long = 0L
@@ -1827,6 +1830,7 @@ class EpgViewModel @Inject constructor(
         val missingChannels = channels.filter { channel ->
             val lookupKey = channel.guideLookupKey()
             lookupKey != null &&
+                lookupKey !in knownEmptyGuideKeys &&
                 channel.streamId > 0L &&
                 existingProgramsByChannel[lookupKey].isNullOrEmpty()
         }
@@ -1847,17 +1851,30 @@ class EpgViewModel @Inject constructor(
         )
 
         return fallbackChannels.mapNotNull { channel ->
-            val programs = (programsByRequest[
+            val fetchResult = programsByRequest[
                 LiveStreamProgramRequest(
                     streamId = channel.streamId,
                     epgChannelId = channel.epgChannelId
                 )
-            ] as? com.streamvault.domain.model.Result.Success)?.data
+            ]
+            val programs = (fetchResult as? com.streamvault.domain.model.Result.Success)?.data
                 .orEmpty()
                 .filter { program -> program.endTime > windowStart && program.startTime < windowEnd }
                 .sortedBy { program -> program.startTime }
             val lookupKey = channel.guideLookupKey() ?: return@mapNotNull null
-            if (programs.isEmpty()) null else lookupKey to programs
+            if (programs.isEmpty()) {
+                // Successful but empty: the portal has no guide for this channel right
+                // now. Remember for this session so later pages skip it instantly.
+                // Errors are left out so transient failures retry on the next page.
+                if (fetchResult is com.streamvault.domain.model.Result.Success) {
+                    knownEmptyGuideKeys += lookupKey
+                }
+                null
+            } else {
+                // Fresh data may have appeared since a previous empty result.
+                knownEmptyGuideKeys -= lookupKey
+                lookupKey to programs
+            }
         }.toMap()
     }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MoviesViewModel.kt
@@ -171,7 +171,11 @@ class MoviesViewModel @Inject constructor(
                             sortMode = sortMode
                         ).let { categories ->
                             if (provider.type == ProviderType.STALKER_PORTAL) {
-                                categories.filterNot(::isLikelyProviderWideStalkerCategory)
+                                val filtered = categories.filterNot(::isLikelyProviderWideStalkerCategory)
+                                // Some portals only expose a provider-wide "*" / "All" bucket. Hiding it
+                                // empties the tab while libraryCount still reports the full catalog,
+                                // so keep the original list when filtering would remove everything.
+                                if (filtered.isNotEmpty()) filtered else categories
                             } else {
                                 categories
                             }
@@ -204,8 +208,7 @@ class MoviesViewModel @Inject constructor(
                             libraryCount = 0
                         )
                     }
-                }
-                .flatMapLatest { params ->
+                }                    .flatMapLatest { params ->
                     _previewBatchSize.flatMapLatest { batchSize ->
                         if (params.query.isBlank()) {
                             val categoryIds = params.providerCategories.take(batchSize).map { it.id }

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesViewModel.kt
@@ -171,7 +171,10 @@ class SeriesViewModel @Inject constructor(
                             sortMode = sortMode
                         ).let { categories ->
                             if (provider.type == ProviderType.STALKER_PORTAL) {
-                                categories.filterNot(::isLikelyProviderWideStalkerCategory)
+                                val filtered = categories.filterNot(::isLikelyProviderWideStalkerCategory)
+                                // Same wildcard-only fallback as Movies: don't empty the tab when "*"/"All"
+                                // is the only bucket holding the catalog.
+                                if (filtered.isNotEmpty()) filtered else categories
                             } else {
                                 categories
                             }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBrowsingSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBrowsingSection.kt
@@ -277,6 +277,16 @@ internal fun LazyListScope.settingsBrowsingSection(
             onCheckedChange = { viewModel.setVodInfiniteScroll(it) },
             indent = 24.dp
         )
+        SwitchSettingsRow(
+            label = stringResource(R.string.settings_vod_portal_search),
+            value = stringResource(
+                if (uiState.vodPortalSearch) R.string.settings_vod_portal_search_on
+                else R.string.settings_vod_portal_search_off
+            ),
+            checked = uiState.vodPortalSearch,
+            onCheckedChange = { viewModel.setVodPortalSearch(it) },
+            indent = 24.dp
+        )
         ClickableSettingsRow(
             label = stringResource(R.string.settings_vod_duplicate_handling_mode),
             value = stringResource(uiState.vodDuplicateHandlingMode.labelResId()),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceModels.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceModels.kt
@@ -108,6 +108,7 @@ internal data class SettingsPreferenceSnapshot(
     val vodViewMode: VodViewMode,
     val vodCategoryLoadMode: VodCategoryLoadMode,
     val vodInfiniteScroll: Boolean,
+    val vodPortalSearch: Boolean,
     val vodDuplicateHandlingMode: VodDuplicateHandlingMode,
     val vodVariantPreferenceMode: VodVariantPreferenceMode,
     val guideDefaultCategoryId: Long,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceSnapshotMapper.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceSnapshotMapper.kt
@@ -72,6 +72,7 @@ internal fun SettingsUiState.applyPreferenceSnapshot(snapshot: SettingsPreferenc
         vodViewMode = snapshot.vodViewMode,
         vodCategoryLoadMode = snapshot.vodCategoryLoadMode,
         vodInfiniteScroll = snapshot.vodInfiniteScroll,
+        vodPortalSearch = snapshot.vodPortalSearch,
         vodDuplicateHandlingMode = snapshot.vodDuplicateHandlingMode,
         vodVariantPreferenceMode = snapshot.vodVariantPreferenceMode,
         guideDefaultCategoryId = snapshot.guideDefaultCategoryId,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
@@ -106,6 +106,7 @@ internal fun observeSettingsPreferenceSnapshot(
             vodViewMode = VodViewMode.MODERN,
             vodCategoryLoadMode = VodCategoryLoadMode.PAGED,
             vodInfiniteScroll = true,
+            vodPortalSearch = true,
             vodDuplicateHandlingMode = VodDuplicateHandlingMode.SHOW_ALL,
             vodVariantPreferenceMode = VodVariantPreferenceMode.BALANCED,
             guideDefaultCategoryId = VirtualCategoryIds.FAVORITES,
@@ -248,6 +249,8 @@ internal fun observeSettingsPreferenceSnapshot(
         snapshot.copy(vodCategoryLoadMode = vodCategoryLoadMode)
     }.combine(preferencesRepository.vodInfiniteScroll) { snapshot, vodInfiniteScroll ->
         snapshot.copy(vodInfiniteScroll = vodInfiniteScroll)
+    }.combine(preferencesRepository.vodPortalSearch) { snapshot, vodPortalSearch ->
+        snapshot.copy(vodPortalSearch = vodPortalSearch)
     }.combine(preferencesRepository.vodDuplicateHandlingMode) { snapshot, vodDuplicateHandlingMode ->
         snapshot.copy(vodDuplicateHandlingMode = vodDuplicateHandlingMode)
     }.combine(preferencesRepository.vodVariantPreferenceMode) { snapshot, vodVariantPreferenceMode ->

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -160,6 +160,7 @@ data class SettingsUiState(
     val vodViewMode: VodViewMode = VodViewMode.MODERN,
     val vodCategoryLoadMode: VodCategoryLoadMode = VodCategoryLoadMode.PAGED,
     val vodInfiniteScroll: Boolean = true,
+    val vodPortalSearch: Boolean = true,
     val vodDuplicateHandlingMode: VodDuplicateHandlingMode = VodDuplicateHandlingMode.SHOW_ALL,
     val vodVariantPreferenceMode: VodVariantPreferenceMode = VodVariantPreferenceMode.BALANCED,
     val guideDefaultCategoryId: Long = com.streamvault.domain.model.VirtualCategoryIds.FAVORITES,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -634,6 +634,12 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setVodPortalSearch(enabled: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.setVodPortalSearch(enabled)
+        }
+    }
+
     fun setVodCompleteOnOpen(enabled: Boolean) {
         viewModelScope.launch {
             preferencesRepository.setVodCategoryLoadMode(

--- a/app/src/main/java/com/streamvault/app/ui/screens/vod/VodViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/vod/VodViewModel.kt
@@ -9,6 +9,8 @@ import com.streamvault.domain.model.Category
 import com.streamvault.domain.model.LibraryFilterType
 import com.streamvault.domain.model.LibrarySortBy
 import com.streamvault.domain.model.PlaybackHistory
+import com.streamvault.domain.model.ProviderType
+import com.streamvault.domain.model.Result
 import com.streamvault.domain.model.LegacyProvider as Provider
 import com.streamvault.domain.model.VodCatalogItem
 import com.streamvault.domain.model.VodCategoryKind
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -55,6 +58,7 @@ data class VodUiState(
     val isLoadingSelectedCategory: Boolean = false,
     val isLoadingMoreSelectedCategory: Boolean = false,
     val vodInfiniteScroll: Boolean = true,
+    val isPortalSearch: Boolean = false,
     val searchQuery: String = "",
     val selectedLibraryFilterType: LibraryFilterType = LibraryFilterType.ALL,
     val selectedLibrarySortBy: LibrarySortBy = LibrarySortBy.LIBRARY,
@@ -74,7 +78,8 @@ private data class SelectedVodSnapshot(
     val category: Category? = null,
     val items: List<VodCatalogItem> = emptyList(),
     val localTotal: Int = 0,
-    val hydration: VodCategoryHydration? = null
+    val hydration: VodCategoryHydration? = null,
+    val isPortalSearch: Boolean = false
 )
 
 @HiltViewModel
@@ -96,6 +101,9 @@ class VodViewModel @Inject constructor(
     private val selectedCategoryId = MutableStateFlow<Long?>(null)
     private val selectedItemLimit = MutableStateFlow(SELECTED_PAGE_SIZE)
     private val searchQuery = MutableStateFlow("")
+    private val searchPage = MutableStateFlow(1)
+    private val portalSearchEnabled = preferencesRepository.vodPortalSearch
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), true)
     private val selectedLibraryFilterType = MutableStateFlow(LibraryFilterType.ALL)
     private val selectedLibrarySortBy = MutableStateFlow(LibrarySortBy.LIBRARY)
     private var remotePageRequestInFlight = false
@@ -137,8 +145,10 @@ class VodViewModel @Inject constructor(
         catalog,
         selectedItemLimit,
         searchQuery,
+        searchPage,
         selectedLibraryFilterType,
-        selectedLibrarySortBy
+        selectedLibrarySortBy,
+        portalSearchEnabled
     ) { values -> values }
         .flatMapLatest { values ->
             val provider = values[0] as Provider?
@@ -146,13 +156,33 @@ class VodViewModel @Inject constructor(
             val snapshot = values[2] as UnifiedVodCatalogSnapshot
             val limit = values[3] as Int
             val query = values[4] as String
-            val filterType = values[5] as LibraryFilterType
-            val sortBy = values[6] as LibrarySortBy
+            val page = values[5] as Int
+            val filterType = values[6] as LibraryFilterType
+            val sortBy = values[7] as LibrarySortBy
+            val portalSearchEnabled = values[8] as Boolean
             val category = snapshot.rows.firstOrNull { it.category.id == categoryId }?.category
-            if (provider == null || category == null) {
-                flowOf(SelectedVodSnapshot())
-            } else {
-                combine(
+            val portalSearchActive = provider != null && category != null && query.isNotBlank() &&
+                portalSearchEnabled && provider.type == ProviderType.STALKER_PORTAL
+            when {
+                portalSearchActive -> flow {
+                    // STB-style portal search: the portal searches its whole VOD catalog
+                    // server-side; results page with the portal's native page size.
+                    val providerId = provider?.id ?: return@flow
+                    val result = vodRepository.searchVod(providerId, query, page)
+                    val searchItems = (result as? Result.Success)?.data?.items.orEmpty()
+                    val totalCount = (result as? Result.Success)?.data?.totalCount ?: 0
+                    emit(
+                        SelectedVodSnapshot(
+                            category = category,
+                            items = searchItems,
+                            localTotal = totalCount,
+                            hydration = null,
+                            isPortalSearch = true
+                        )
+                    )
+                }
+                provider == null || category == null -> flowOf(SelectedVodSnapshot())
+                else -> combine(
                     vodRepository.getCategoryItems(provider.id, category.id),
                     vodRepository.observeHydration(provider.id, category.id),
                     playbackHistoryRepository.getRecentlyWatchedByProvider(provider.id, limit = 500)
@@ -183,7 +213,8 @@ class VodViewModel @Inject constructor(
         val sortBy = values[7] as LibrarySortBy
         val requiresCompleteCatalog = query.isNotBlank() ||
             filterType != LibraryFilterType.ALL || sortBy != LibrarySortBy.LIBRARY
-        val isCompletingBrowse = selectedContent.category != null && requiresCompleteCatalog &&
+        val isCompletingBrowse = !selectedContent.isPortalSearch &&
+            selectedContent.category != null && requiresCompleteCatalog &&
             selectedContent.hydration?.isComplete != true
         VodUiState(
             provider = provider,
@@ -199,6 +230,7 @@ class VodViewModel @Inject constructor(
             isLoadingSelectedCategory = selectedContent.hydration?.isInitialLoading == true || isCompletingBrowse,
             isLoadingMoreSelectedCategory = selectedContent.hydration?.isAppending == true,
             vodInfiniteScroll = infiniteScroll,
+            isPortalSearch = selectedContent.isPortalSearch,
             searchQuery = query,
             selectedLibraryFilterType = filterType,
             selectedLibrarySortBy = sortBy,
@@ -216,7 +248,8 @@ class VodViewModel @Inject constructor(
         completeHydrationJob = null
         selectedItemLimit.value = SELECTED_PAGE_SIZE
         selectedCategoryId.value = category?.id
-        if (category == null) return
+        searchPage.value = 1
+        if (category == null || isPortalSearchActive()) return
         val providerId = activeProvider.value?.id ?: return
         viewModelScope.launch {
             if (searchQuery.value.isNotBlank() ||
@@ -235,6 +268,11 @@ class VodViewModel @Inject constructor(
         val category = state.selectedCategory ?: return
         val providerId = state.provider?.id ?: return
         if (!state.canLoadMoreSelectedCategory || remotePageRequestInFlight) return
+        if (state.isPortalSearch) {
+            // Portal search pages through the portal's own search results.
+            searchPage.value += 1
+            return
+        }
         val needsRemotePage = state.selectedLoadedCount >= state.selectedTotalCount
         selectedItemLimit.value += SELECTED_PAGE_SIZE
         if (!needsRemotePage) return
@@ -254,8 +292,9 @@ class VodViewModel @Inject constructor(
 
     fun setSearchQuery(query: String) {
         searchQuery.value = query
+        searchPage.value = 1
         selectedItemLimit.value = SELECTED_PAGE_SIZE
-        if (query.isNotBlank()) ensureCompleteForBrowseOperation()
+        if (query.isNotBlank() && !isPortalSearchActive()) ensureCompleteForBrowseOperation()
     }
 
     fun setSelectedLibraryFilterType(filterType: LibraryFilterType) {
@@ -268,6 +307,13 @@ class VodViewModel @Inject constructor(
         selectedLibrarySortBy.value = sortBy
         selectedItemLimit.value = SELECTED_PAGE_SIZE
         if (sortBy != LibrarySortBy.LIBRARY) ensureCompleteForBrowseOperation()
+    }
+
+    private fun isPortalSearchActive(): Boolean {
+        val provider = uiState.value.provider
+        return searchQuery.value.isNotBlank() &&
+            portalSearchEnabled.value &&
+            provider?.type == ProviderType.STALKER_PORTAL
     }
 
     private fun ensureCompleteForBrowseOperation() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -572,6 +572,9 @@
     <string name="settings_vod_infinite_scroll">Infinite scroll</string>
     <string name="settings_vod_infinite_scroll_on">Load the next page as you scroll near the end.</string>
     <string name="settings_vod_infinite_scroll_off">Show a Load more button for the next page.</string>
+    <string name="settings_vod_portal_search">Portal-backed search</string>
+    <string name="settings_vod_portal_search_on">Search the provider\'s full catalog server-side, like the portal\'s own STB app.</string>
+    <string name="settings_vod_portal_search_off">Filter only the items already downloaded in this category.</string>
     <string name="settings_vod_complete_on_open">Load entire VOD category on open</string>
     <string name="settings_vod_complete_on_open_on">Fetch every Stalker page before finishing the initial load.</string>
     <string name="settings_vod_complete_on_open_off">Show the first Stalker page immediately, then load more as needed.</string>

--- a/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
+++ b/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
@@ -3050,6 +3050,15 @@ interface CategoryDao {
 
     @Query("UPDATE categories SET is_user_protected = :isProtected WHERE provider_id = :providerId AND category_id = :categoryId AND type = :type")
     suspend fun updateProtectionStatus(providerId: Long, categoryId: Long, type: String, isProtected: Boolean)
+
+    /**
+     * Relabels stored categories after a catalog-layout/data mismatch (e.g. a persisted
+     * UNIFIED_VOD layout with rows still stored as SPLIT-era MOVIE/SERIES types). Category and
+     * item ids are layout-independent, so relabeling preserves the indexed catalog instead of
+     * forcing a full re-download.
+     */
+    @Query("UPDATE categories SET type = :toType WHERE provider_id = :providerId AND type = :fromType")
+    suspend fun retargetType(providerId: Long, fromType: String, toType: String): Int
 }
 
 @Dao

--- a/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
+++ b/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
@@ -205,6 +205,7 @@ class PreferencesRepository @Inject constructor(
         val LIVE_VARIANT_OBSERVATIONS = stringPreferencesKey("live_variant_observations")
         val VOD_VIEW_MODE = stringPreferencesKey("vod_view_mode")
         val VOD_INFINITE_SCROLL = booleanPreferencesKey("vod_infinite_scroll")
+        val VOD_PORTAL_SEARCH = booleanPreferencesKey("vod_portal_search")
         val VOD_CATEGORY_LOAD_MODE = stringPreferencesKey("vod_category_load_mode")
         val VOD_DUPLICATE_HANDLING_MODE = stringPreferencesKey("vod_duplicate_handling_mode")
         val VOD_VARIANT_PREFERENCE_MODE = stringPreferencesKey("vod_variant_preference_mode")
@@ -1811,6 +1812,16 @@ class PreferencesRepository @Inject constructor(
     suspend fun setVodInfiniteScroll(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.VOD_INFINITE_SCROLL] = enabled
+        }
+    }
+
+    val vodPortalSearch: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[PreferencesKeys.VOD_PORTAL_SEARCH] ?: true
+    }
+
+    suspend fun setVodPortalSearch(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.VOD_PORTAL_SEARCH] = enabled
         }
     }
 

--- a/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
@@ -208,8 +208,21 @@ class OkHttpStalkerApiService @Inject constructor(
                     val token = handshakePayload.findString("token")
                         ?.takeIf { it.isNotBlank() }
                         ?: run {
-                            lastError = IOException("Portal handshake did not return a token.")
-                            continue
+                            // A 200 without a token is the portal soft-throttling us. Treat it
+                            // like a 429: abort discovery instead of firing more handshakes
+                            // into the limiter, and let callers back off and retry later.
+                            val throttled = StalkerApiError.RateLimited(
+                                message = "Portal handshake did not return a token.",
+                                httpStatus = 200
+                            )
+                            StalkerTelemetry.authenticationAttempt(
+                                profile.providerId,
+                                recipe.compatibilityProfileId,
+                                endpointFamily,
+                                "HANDSHAKE",
+                                authenticationFailureOutcome(throttled)
+                            )
+                            return Result.error(throttled.message.orEmpty(), throttled)
                         }
                     val handshakeRandom = handshakePayload.findString("random").orEmpty()
                     resolvedLoadUrl(loadUrl, attemptProfile)?.let { redirectedLoadUrl ->

--- a/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
@@ -2591,6 +2591,11 @@ class OkHttpStalkerApiService @Inject constructor(
         val requestPriority = when {
             request.url.queryParameter("action").equals("create_link", ignoreCase = true) ->
                 StalkerNetworkPriority.INTERACTIVE
+            request.url.queryParameter("action").equals("get_short_epg", ignoreCase = true) ->
+                // Short EPG payloads are tiny now/next windows; PREFETCH spacing (500ms +
+                // token bucket at ~1/s) keeps on-demand guide pages fast while still
+                // pacing the portal.
+                StalkerNetworkPriority.PREFETCH
             currentCoroutineContext()[StalkerRequestPriorityContext]?.priority in setOf(
                 com.streamvault.domain.model.StalkerRequestPriority.EPG,
                 com.streamvault.domain.model.StalkerRequestPriority.BACKGROUND_INDEX

--- a/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
@@ -745,7 +745,8 @@ class OkHttpStalkerApiService @Inject constructor(
         session: StalkerSession,
         profile: StalkerDeviceProfile,
         categoryId: String?,
-        page: Int
+        page: Int,
+        searchQuery: String?
     ): Result<StalkerPagedItems> = runApiCall("Failed to load movies") {
         fetchPagedItemPage(
             session = session,
@@ -756,6 +757,7 @@ class OkHttpStalkerApiService @Inject constructor(
                 put("action", "get_ordered_list")
                 put("JsHttpRequest", "1-xml")
                 categoryId?.takeIf { it.isNotBlank() }?.let { put("category", it) }
+                searchQuery?.takeIf { it.isNotBlank() }?.let { put("search", it) }
             }
         )
     }
@@ -1371,6 +1373,11 @@ class OkHttpStalkerApiService @Inject constructor(
         // The aggregate safety limit belongs to bulk loads. A single-page request must preserve
         // the requested cursor so a resumed catalog can move past the historical page-200 cap.
         val safePage = page.coerceAtLeast(1)
+        android.util.Log.d(
+            "VODCAT",
+            "fetchPagedItemPage url=${session.loadUrl}?${(baseQuery + ("p" to safePage.toString()))
+                .entries.joinToString("&") { "${it.key}=${it.value}" }}"
+        )
         val payload = requestJson(
             url = session.loadUrl,
             profile = profile,

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiError.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiError.kt
@@ -143,3 +143,10 @@ internal fun isStalkerAuthorizationFailure(message: String, error: Throwable?): 
         "http 403"
     ).any(normalized::contains)
 }
+
+/**
+ * True when the portal is throttling us (hard 429 or a tokenless 200). Retrying with another
+ * handshake immediately only converts soft throttles into hard ones; callers must back off.
+ */
+internal fun Throwable.isPortalThrottle(): Boolean =
+    generateSequence(this) { it.cause }.any { it is StalkerApiError.RateLimited }

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiService.kt
@@ -330,7 +330,8 @@ interface StalkerApiService {
         session: StalkerSession,
         profile: StalkerDeviceProfile,
         categoryId: String?,
-        page: Int
+        page: Int,
+        searchQuery: String? = null
     ): Result<StalkerPagedItems>
 
     suspend fun getSeriesCategories(

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerLogoUrlResolver.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerLogoUrlResolver.kt
@@ -1,0 +1,61 @@
+package com.streamvault.data.remote.stalker
+
+import java.net.URI
+
+/**
+ * Resolves Stalker portal channel-logo URLs. Some Ministra portals return the channel
+ * `logo` field as a bare filename (`536.png`) that lives under the portal's
+ * `misc/logos/{size}/` directory — the convention STBEmu uses when it requests
+ * `/stalker_portal/misc/logos/120/536.png`. Absolute URLs, root-relative paths and
+ * paths that already contain a directory are returned unchanged.
+ *
+ * Used both when importing channels (write time) and when presenting stored channels
+ * (read time), so rows imported before this fix also render logos without a re-sync.
+ */
+object StalkerLogoUrlResolver {
+    // Channel logos served from the portal's misc/logos/{size}/ directory. STBEmu and
+    // other STB clients use the 120 bucket (36×36) as the smallest guaranteed size.
+    const val STALKER_CHANNEL_LOGO_SIZE_BUCKET = 120
+
+    fun resolveChannelLogoUrl(portalUrl: String, url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        if (url.startsWith("http://", true) || url.startsWith("https://", true)) return url
+        if (url.startsWith("/")) return resolvePortalUrl(portalUrl, url)
+        if (url.contains('/')) return url
+        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
+        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
+        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
+        val port = origin.port.takeIf { it > 0 }
+        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
+        // Derive the portal install root from the configured portal URL (e.g. a portalUrl of
+        // `http://host/stalker_portal/server/load.php` maps logos to
+        // `http://host/stalker_portal/misc/logos/120/536.png`).
+        val installPath = portalInstallPath(origin.path)
+        return "$scheme://$authority$installPath/misc/logos/$STALKER_CHANNEL_LOGO_SIZE_BUCKET/$url"
+    }
+
+    /** Resolves a root-relative portal path (`/stalker_portal/...`) against the portal origin. */
+    fun resolvePortalUrl(portalUrl: String, url: String): String? {
+        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
+        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
+        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
+        val port = origin.port.takeIf { it > 0 }
+        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
+        return "$scheme://$authority$url"
+    }
+
+    private fun portalInstallPath(portalPath: String?): String {
+        val path = portalPath?.trimEnd('/').orEmpty()
+        return when {
+            path.endsWith("/server/load.php", ignoreCase = true) ->
+                path.dropLast("/server/load.php".length)
+            path.endsWith("/portal.php", ignoreCase = true) ->
+                path.dropLast("/portal.php".length)
+            path.endsWith("/c/index.html", ignoreCase = true) ->
+                path.dropLast("/c/index.html".length)
+            path.endsWith("/c", ignoreCase = true) ->
+                path.dropLast("/c".length)
+            else -> path
+        }
+    }
+}

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerPortalStateStore.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerPortalStateStore.kt
@@ -7,6 +7,7 @@ import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.StalkerCookieMode
 import com.streamvault.domain.model.StalkerEndpointPreference
 import com.streamvault.domain.model.StalkerPlaybackBackendHint
+import com.google.gson.Gson
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,6 +16,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
 @Singleton
 class StalkerPortalStateStore @Inject constructor(
@@ -22,6 +26,7 @@ class StalkerPortalStateStore @Inject constructor(
     private val providerSnapshotDao: ProviderSnapshotDao? = null
 ) {
     private val json = Json { ignoreUnknownKeys = true }
+    private val gson = Gson()
 
     suspend fun getValidated(providerId: Long, now: Long = System.currentTimeMillis()): StalkerPortalStateEntity? =
         dao.get(providerId)?.takeIf { state ->
@@ -29,6 +34,59 @@ class StalkerPortalStateStore @Inject constructor(
         }
 
     suspend fun get(providerId: Long): StalkerPortalStateEntity? = dao.get(providerId)
+
+    /**
+     * Durable session resurrected after a process restart. The portal token lives in
+     * app-private storage (same trust level as the encrypted provider credentials) and is
+     * only reused for the same configuration generation inside the local session age cap.
+     * A server-side rejected token costs one cheap profile call: the normal authorization
+     * retry path invalidates and falls back to a full handshake.
+     */
+    data class ResumedStalkerAuth(
+        val session: StalkerSession,
+        val profile: StalkerProviderProfile
+    )
+
+    suspend fun resumableAuth(
+        providerId: Long,
+        configurationGeneration: Long,
+        now: Long = System.currentTimeMillis(),
+        maxAgeMillis: Long = STALKER_SESSION_MAX_AGE_MILLIS
+    ): ResumedStalkerAuth? {
+        if (providerId <= 0L) return null
+        val state = dao.get(providerId) ?: return null
+        if (state.configurationGeneration != configurationGeneration) return null
+        val learning = runCatching {
+            json.parseToJsonElement(state.learningJson.ifBlank { "{}" }).jsonObject
+        }.getOrNull() ?: return null
+        if (learning["configurationGeneration"]?.jsonPrimitive?.longOrNull != configurationGeneration) {
+            return null
+        }
+        val session = runCatching {
+            gson.fromJson(learning["resumableSession"]?.jsonPrimitive?.content, StalkerSession::class.java)
+        }.getOrNull() ?: return null
+        val profile = runCatching {
+            gson.fromJson(learning["resumableProfile"]?.jsonPrimitive?.content, StalkerProviderProfile::class.java)
+        }.getOrNull() ?: return null
+        if (session.token.isBlank()) return null
+        if (profile.profileRevision != StalkerCompatibilityRegistry.REVISION) return null
+        if (now - session.authenticatedAtMillis > maxAgeMillis) return null
+        if (session.isExpired(now)) return null
+        if (profile.expirationDate?.let { it <= now } == true) return null
+        return ResumedStalkerAuth(session, profile)
+    }
+
+    /** Drops a persisted session (e.g. after the portal rejects its token) without touching hints. */
+    suspend fun clearResumableAuth(providerId: Long) {
+        if (providerId <= 0L) return
+        update(providerId) { state ->
+            val learning = mutableLearning(state.learningJson)
+            if (learning.remove("resumableSession") == null && learning.remove("resumableProfile") == null) {
+                return@update state
+            }
+            state.copy(learningJson = JsonObject(learning).toString())
+        }
+    }
 
     suspend fun recordAuthentication(
         providerId: Long,
@@ -358,6 +416,8 @@ class StalkerPortalStateStore @Inject constructor(
         learning["protocolFamily"] = observationJson(profile.protocolFamily.name, generation, observedAt, "AUTHENTICATION")
         learning["bootstrapRecipe"] = observationJson(profile.bootstrapRecipe.name, generation, observedAt, "AUTHENTICATION")
         learning["workingEndpoint"] = observationJson(session.loadUrl, generation, observedAt, "AUTHENTICATION")
+        learning["resumableSession"] = JsonPrimitive(gson.toJson(session))
+        learning["resumableProfile"] = JsonPrimitive(gson.toJson(profile))
         return JsonObject(learning).toString()
     }
 

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -2207,13 +2207,17 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
         if (url.isNullOrBlank()) return null
         if (url.startsWith("http://", true) || url.startsWith("https://", true)) return url
         if (!url.startsWith("/")) return url
-        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
-        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
-        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
-        val port = origin.port.takeIf { it > 0 }
-        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
-        return "$scheme://$authority$url"
+        return StalkerLogoUrlResolver.resolvePortalUrl(portalUrl, url)
     }
+
+    /**
+     * Resolves a channel logo URL into an absolute URL. Some Ministra portals return the
+     * channel `logo` field as a bare filename (`536.png`) that lives under the portal's
+     * `misc/logos/{size}/` directory — the convention STBEmu uses when it requests
+     * `/stalker_portal/misc/logos/120/536.png`. See [StalkerLogoUrlResolver].
+     */
+    private fun resolveChannelLogoUrl(url: String?): String? =
+        StalkerLogoUrlResolver.resolveChannelLogoUrl(portalUrl, url)
 
     private fun toChannel(item: StalkerItemRecord): Channel? {
         val numericId = stableItemId(ContentType.LIVE, item.id)
@@ -2242,7 +2246,7 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
         return Channel(
             id = 0L,
             name = resolvedName,
-            logoUrl = resolvePortalUrl(item.logoUrl),
+            logoUrl = resolveChannelLogoUrl(item.logoUrl),
             categoryId = category.id,
             categoryName = category.name,
             streamUrl = streamUrl,

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -787,6 +787,32 @@ internal companion object {
         }
     }
 
+    /**
+     * The portal `ch_id` parameter only understands the numeric portal channel id.
+     * The XMLTV-style guide key some channels carry is never valid there, so it is
+     * only tried as a fallback when the numeric id returns nothing.
+     */
+    override suspend fun getShortEpg(request: com.streamvault.domain.provider.GuideRequest): Result<List<Program>> {
+        val numericKey = request.streamId.takeIf { it > 0L }?.toString()
+        val numericResult = numericKey?.let { getShortEpg(it, request.limit) }
+        if (numericResult is Result.Success && numericResult.data.isNotEmpty()) return numericResult
+        val xmlKey = request.epgChannelId?.takeIf { it.isNotBlank() }?.takeUnless { it == numericKey }
+        if (xmlKey != null) {
+            val xmlResult = getShortEpg(xmlKey, request.limit)
+            if (xmlResult is Result.Success && xmlResult.data.isNotEmpty()) return xmlResult
+        }
+        return numericResult ?: Result.error("Short EPG lookup returned no programs")
+    }
+
+    override suspend fun getEpg(request: com.streamvault.domain.provider.GuideRequest): Result<List<Program>> {
+        // get_epg_info only understands the numeric portal channel id; unlike short EPG
+        // there is no cheap fallback key, so a non-numeric request fails fast instead of
+        // burning a slow portal call that cannot succeed.
+        val numericKey = request.streamId.takeIf { it > 0L }?.toString()
+            ?: return Result.error("EPG lookup needs a numeric portal channel id")
+        return getEpg(numericKey)
+    }
+
     suspend fun resolvePlaybackInfo(
         kind: StalkerStreamKind,
         cmd: String,

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -480,6 +480,25 @@ internal companion object {
             toMovie(item, requestedCategoryId = null)
         } }
 
+    /**
+     * Portal-backed VOD search (the same `get_ordered_list` + `search` query the portal's own
+     * STB UI uses). Searches the entire VOD catalog server-side, regardless of category, and
+     * pages through results with the portal's native page size.
+     */
+    suspend fun searchVodPage(query: String, page: Int): Result<StalkerPagedResult<Movie>> {
+        val trimmedQuery = query.trim()
+        if (trimmedQuery.isEmpty()) {
+            return Result.success(
+                StalkerPagedResult(items = emptyList(), page = page, totalPages = 0, pageSize = 0)
+            )
+        }
+        return mapPagedItems(ContentType.MOVIE, null) { session, profile, _ ->
+            api.getVodStreamsPage(session, profile, null, page, searchQuery = trimmedQuery)
+        }.let { result -> mapResolvedPage(ContentType.MOVIE, result) { item ->
+            toMovie(item, requestedCategoryId = null)
+        } }
+    }
+
     suspend fun getUnifiedVodPage(categoryId: Long, page: Int): Result<StalkerPagedResult<StalkerVodCatalogItem>> =
         getClassifiedVodPage(ContentType.VOD, categoryId, page)
 
@@ -2180,10 +2199,9 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
             else -> type
         }
         val targetId = categoryId ?: return null
-        val cached = categoryCache[normalizedType]
-        if (cached != null) {
-            return cached.firstOrNull { it.id == targetId }?.rawId
-        }
+        // A populated cache that misses must not short-circuit: fall through to the persisted
+        // identity map and the live category fetch before giving up.
+        categoryCache[normalizedType]?.firstOrNull { it.id == targetId }?.rawId?.let { return it }
         identityResolver?.reverse(providerId, normalizedType, targetId)?.let { return it }
         when (val categoriesResult = when (normalizedType) {
             ContentType.LIVE -> getLiveCategories()
@@ -2192,9 +2210,16 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
             ContentType.SERIES -> getSeriesCategories()
             ContentType.SERIES_EPISODE -> Result.success(emptyList())
         }) {
-            is Result.Success -> return categoryCache[normalizedType]?.firstOrNull { it.id == targetId }?.rawId
-            else -> return null
+            is Result.Success -> {
+                categoryCache[normalizedType]?.firstOrNull { it.id == targetId }?.rawId?.let { return it }
+            }
+            else -> Unit
         }
+        // Last resort for portals whose stored category ids are the portal's own numeric ids
+        // while the identity map is keyed to another epoch's surrogates: numeric ids pass
+        // through to the portal unchanged. Synthetic surrogate ids (>= the high floor) are
+        // never sent because the portal cannot resolve them.
+        return targetId.takeIf { it in 1L until FALLBACK_SURROGATE_FLOOR }?.toString()
     }
 
     /**

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -138,6 +138,7 @@ internal companion object {
         private const val FALLBACK_SURROGATE_FLOOR = 4_000_000_000L
         const val CATALOG_LAYOUT_DETECTION_VERSION = 1
         private val sharedAuthCache = ConcurrentHashMap<String, CachedAuth>()
+        private val sharedPortalAuthCache = ConcurrentHashMap<String, CachedAuth>()
         private val sharedAuthFailureCache = ConcurrentHashMap<String, CachedAuthFailure>()
         private val sharedAuthMutexes = KeyedMutexRegistry<String>()
         private val resolvedStreamUrlCache = ConcurrentHashMap<String, CachedResolvedUrl>()
@@ -145,6 +146,7 @@ internal companion object {
 
         fun clearSharedAuthCacheForTests() {
             sharedAuthCache.clear()
+            sharedPortalAuthCache.clear()
             sharedAuthFailureCache.clear()
         }
 
@@ -157,6 +159,8 @@ internal companion object {
             if (providerId <= 0L) return
             val authPrefix = "provider:$providerId|"
             sharedAuthCache.keys.filter { it.startsWith(authPrefix) }.forEach(sharedAuthCache::remove)
+            val portalPrefix = "portal:$providerId|"
+            sharedPortalAuthCache.keys.filter { it.startsWith(portalPrefix) }.forEach(sharedPortalAuthCache::remove)
             sharedAuthFailureCache.keys.filter { it.startsWith(authPrefix) }.forEach(sharedAuthFailureCache::remove)
             resolvedStreamUrlCache.keys
                 .filter { it.startsWith("$providerId|") }
@@ -166,6 +170,7 @@ internal companion object {
 
         private fun trimSharedCaches() {
             trimMap(sharedAuthCache, MAX_AUTH_CACHE_ENTRIES)
+            trimMap(sharedPortalAuthCache, MAX_AUTH_CACHE_ENTRIES)
             trimMap(sharedAuthFailureCache, MAX_AUTH_CACHE_ENTRIES)
             trimMap(resolvedStreamUrlCache, MAX_RESOLVED_URL_CACHE_ENTRIES)
             while (missingVodClassificationLogged.size > MAX_MISSING_CLASSIFICATION_ENTRIES) {
@@ -223,7 +228,11 @@ internal companion object {
             authFailureCache = null
             categoryCache.clear()
             sharedAuthCache.remove(authCacheKey())
+            if (providerId > 0L) {
+                sharedPortalAuthCache.remove(portalIdentityKey())
+            }
             sharedAuthFailureCache.remove(authCacheKey())
+            portalStateStore?.clearResumableAuth(providerId)
             clearResolvedStreamUrlCache()
             api.invalidateSessionScopes(providerId)
         }
@@ -1402,6 +1411,9 @@ is Result.Success -> {
                 sessionCache = null
                 accountProfileCache = null
                 sharedAuthCache.remove(authCacheKey())
+                if (providerId > 0L) {
+                    sharedPortalAuthCache.remove(portalIdentityKey())
+                }
                 api.invalidateSessionScopes(providerId)
             }
             (authFailureCache ?: sharedAuthFailureCache[authCacheKey()])?.let { failure ->
@@ -1421,6 +1433,31 @@ is Result.Success -> {
                 }
                 sharedAuthCache.remove(authCacheKey(), cachedAuth)
                 api.invalidateSessionScopes(providerId)
+            }
+            if (providerId > 0L) {
+                sharedPortalAuthCache[portalIdentityKey()]?.let { cachedAuth ->
+                    if (!cachedAuth.session.isExpired() &&
+                        cachedAuth.profile.expirationDate?.let { it > System.currentTimeMillis() } != false
+                    ) {
+                        sessionCache = cachedAuth.session
+                        accountProfileCache = cachedAuth.profile
+                        sharedAuthCache[authCacheKey()] = cachedAuth
+                        return@withLock Result.success(cachedAuth.session to cachedAuth.profile)
+                    }
+                    sharedPortalAuthCache.remove(portalIdentityKey(), cachedAuth)
+                    api.invalidateSessionScopes(providerId)
+                }
+            }
+            if (providerId > 0L) {
+                portalStateStore?.resumableAuth(providerId, configurationGeneration)?.let { resumed ->
+                    sessionCache = resumed.session
+                    accountProfileCache = resumed.profile
+                    val cachedAuth = CachedAuth(session = resumed.session, profile = resumed.profile)
+                    sharedAuthCache[authCacheKey()] = cachedAuth
+                    sharedPortalAuthCache[portalIdentityKey()] = cachedAuth
+                    StalkerTelemetry.strategySelected(providerId, "RESUMED_SESSION", "PERSISTED_TOKEN")
+                    return@withLock Result.success(resumed.session to resumed.profile)
+                }
             }
 
             val persistedState = portalStateStore?.getValidated(providerId)
@@ -1485,8 +1522,17 @@ is Result.Success -> {
                 onProgress = onProgress
             ).copy(providerId = providerId)
             val initialAuthResult = discoveryCoordinator.authenticate(profile)
+            val initialAuthThrottled = (initialAuthResult as? Result.Error)?.exception?.isPortalThrottle() == true
             val finalAuthResult = when {
                 initialAuthResult !is Result.Error -> initialAuthResult
+                // A throttled portal must not get an instant repair handshake: the retry
+                // fires milliseconds later and converts a soft throttle into a hard 429.
+                // Surface the throttle so callers back off; the persisted session and
+                // failure cooldown already cover the retry.
+                initialAuthThrottled -> {
+                    StalkerTelemetry.strategySelected(providerId, "AUTH_THROTTLE_BACKOFF", "THROTTLED_AUTH_RETRY_SKIPPED")
+                    initialAuthResult
+                }
                 persistedEndpointUrl != null -> {
                     portalStateStore?.markEndpointUnhealthy(
                         providerId,
@@ -1532,6 +1578,12 @@ is Result.Success -> {
                         session = authResult.data.first,
                         profile = authResult.data.second
                     )
+                    if (providerId > 0L) {
+                        sharedPortalAuthCache[portalIdentityKey()] = CachedAuth(
+                            session = authResult.data.first,
+                            profile = authResult.data.second
+                        )
+                    }
                     trimSharedCaches()
                     portalStateStore?.recordAuthentication(
                         providerId = providerId,
@@ -2577,6 +2629,28 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
             .digest(normalized.toByteArray(Charsets.UTF_8))
             .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
         return "provider:$providerId|$digest"
+    }
+
+    /**
+     * Stable cross-instance session identity. Unlike [authCacheKey], this deliberately excludes
+     * volatile learned hints (fingerprint/recipe/endpoint/cookie/playback/profile/device extras)
+     * so a sync-side provider built from persisted learning can reuse the activation session
+     * instead of firing a second handshake into the portal rate limiter.
+     */
+    private fun portalIdentityKey(): String {
+        val normalized = listOf(
+            System.identityHashCode(api).toString(),
+            providerId.toString(),
+            StalkerUrlFactory.normalizePortalUrl(portalUrl),
+            normalizedMacAddress(),
+            authMode.name,
+            normalizedUsername(),
+            normalizedPassword()
+        ).joinToString(separator = "\u001f")
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(normalized.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+        return "portal:$providerId|$digest"
     }
 
     private fun authMutexKey(): String = "provider:$providerId|auth"

--- a/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
@@ -5,11 +5,14 @@ import android.util.Log
 import com.streamvault.data.local.dao.CategoryDao
 import com.streamvault.data.local.dao.ChannelDao
 import com.streamvault.data.local.dao.FavoriteDao
+import com.streamvault.data.local.dao.ProviderSnapshotDao
 import com.streamvault.data.local.entity.CategoryEntity
 import com.streamvault.data.local.entity.ChannelBrowseEntity
 import com.streamvault.data.local.entity.CategoryCount
 import com.streamvault.data.mapper.toDomain
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderConfigurationCodec
+import com.streamvault.data.remote.stalker.StalkerLogoUrlResolver
 import com.streamvault.data.remote.xtream.XtreamStreamUrlResolver
 import com.streamvault.data.util.rankSearchResults
 import com.streamvault.data.util.toFtsPrefixQuery
@@ -25,11 +28,14 @@ import com.streamvault.domain.model.LiveChannelObservedQuality
 import com.streamvault.domain.model.LiveChannelVariant
 import com.streamvault.domain.model.LiveChannelVariantAttributes
 import com.streamvault.domain.model.LiveVariantPreferenceMode
+import com.streamvault.domain.model.ProviderType
 import com.streamvault.domain.model.Result
+import com.streamvault.domain.model.StalkerConfig
 import com.streamvault.domain.model.StreamInfo
 import com.streamvault.domain.model.StreamType
 import com.streamvault.domain.repository.ChannelRepository
 import com.streamvault.domain.util.ChannelNormalizer
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -53,8 +59,13 @@ class ChannelRepositoryImpl @Inject constructor(
     private val favoriteDao: FavoriteDao,
     private val preferencesRepository: PreferencesRepository,
     private val parentalControlManager: com.streamvault.domain.manager.ParentalControlManager,
-    private val xtreamStreamUrlResolver: XtreamStreamUrlResolver
+    private val xtreamStreamUrlResolver: XtreamStreamUrlResolver,
+    private val providerSnapshotDao: ProviderSnapshotDao,
+    private val providerConfigurationCodec: ProviderConfigurationCodec
 ) : ChannelRepository {
+    // Portal install roots by provider id, so bare-filename channel logos (e.g. "536.png")
+    // stored by earlier syncs can be resolved on read without a DB hit per channel.
+    private val stalkerPortalRootCache = ConcurrentHashMap<Long, String>()
     private companion object {
         const val TAG = "ChannelRepository"
         const val GLOBAL_SEARCH_LIMIT = 500
@@ -837,11 +848,32 @@ class ChannelRepositoryImpl @Inject constructor(
     private fun ChannelBrowseEntity.resolveLogoUrl(): String? {
         val supplierLogo = logoUrl?.takeIf { it.isNotBlank() }
         val epgLogo = epgIconUrl?.takeIf { it.isNotBlank() }
-        return when (channelLogoSourcePolicy) {
+        val selected = when (channelLogoSourcePolicy) {
             ChannelLogoSourcePolicy.SUPPLIER_PREFERRED -> supplierLogo ?: epgLogo
             ChannelLogoSourcePolicy.EPG_PREFERRED -> epgLogo ?: supplierLogo
             ChannelLogoSourcePolicy.SUPPLIER_ONLY -> supplierLogo
             ChannelLogoSourcePolicy.EPG_ONLY -> epgLogo
         }
+        // Some Stalker portals return the channel logo as a bare filename ("536.png"); rows
+        // imported before the write-time fix still store it that way. Resolve it against the
+        // portal's misc/logos/ directory so those rows render without needing a re-sync.
+        if (selected.isNullOrBlank()) return null
+        if (selected.startsWith("http://", true) || selected.startsWith("https://", true)) return selected
+        if (selected.startsWith("/") || selected.contains('/')) return selected
+        val portalUrl = stalkerPortalRoot(providerId) ?: return selected
+        return StalkerLogoUrlResolver.resolveChannelLogoUrl(portalUrl, selected)
+    }
+
+    private fun stalkerPortalRoot(providerId: Long): String? {
+        stalkerPortalRootCache[providerId]?.let { return it.ifBlank { null } }
+        val config = providerSnapshotDao.getConfigSync(providerId)
+        val decoded = config?.takeIf { it.type == ProviderType.STALKER_PORTAL }?.let { entity ->
+            runCatching {
+                providerConfigurationCodec.decode(entity.type, entity.encryptedConfigJson)
+            }.getOrNull()
+        }
+        val portalUrl = (decoded as? StalkerConfig)?.portalUrl?.trim().orEmpty()
+        stalkerPortalRootCache[providerId] = portalUrl
+        return portalUrl.ifBlank { null }
     }
 }

--- a/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/MovieRepositoryImpl.kt
@@ -251,12 +251,17 @@ class MovieRepositoryImpl @Inject constructor(
                 val provider = loadCompatibilityProvider(providerId)
                 val previewCategories = if (provider?.type == ProviderType.STALKER_PORTAL) {
                     val stalkerProvider = createStalkerProvider(providerId)
-                    filteredCategories.filterNot { category ->
+                    val nonWildcard = filteredCategories.filterNot { category ->
                         stalkerProvider.isWildcardCategory(ContentType.MOVIE, category.categoryId)
                     }
+                    // Wildcard-only portals (raw "*" bucket) would otherwise render an empty
+                    // tab while getLibraryCount still reports the full catalog. Fall back to
+                    // showing the wildcard bucket instead of emitting an empty preview map.
+                    if (nonWildcard.isNotEmpty()) nonWildcard else filteredCategories
                 } else {
                     filteredCategories
                 }
+                val allowWildcardHydration = previewCategories.size == filteredCategories.size
                 if (previewCategories.isEmpty()) {
                     send(emptyMap())
                     return@channelFlow
@@ -268,7 +273,7 @@ class MovieRepositoryImpl @Inject constructor(
                         fetchIfMissing = true,
                         refreshStaleInBackground = false,
                         requiredCount = limitPerCategory,
-                        allowStalkerWildcard = false
+                        allowStalkerWildcard = allowWildcardHydration
                     )
                 }
                 // SQL LIMIT applied per-category — avoids loading the full catalog into memory

--- a/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/SeriesRepositoryImpl.kt
@@ -228,9 +228,12 @@ class SeriesRepositoryImpl @Inject constructor(
                 val provider = loadCompatibilityProvider(providerId)
                 val previewCategories = if (provider?.type == ProviderType.STALKER_PORTAL) {
                     val stalkerProvider = createStalkerProvider(providerId)
-                    filteredCategories.filterNot { category ->
+                    val nonWildcard = filteredCategories.filterNot { category ->
                         stalkerProvider.isWildcardCategory(ContentType.SERIES, category.categoryId)
                     }
+                    // Same wildcard-only fallback as movies: don't empty the tab when "*"
+                    // is the only bucket holding the catalog.
+                    if (nonWildcard.isNotEmpty()) nonWildcard else filteredCategories
                 } else {
                     filteredCategories
                 }
@@ -238,6 +241,7 @@ class SeriesRepositoryImpl @Inject constructor(
                     send(emptyMap())
                     return@channelFlow
                 }
+                val allowWildcardHydration = previewCategories.size == filteredCategories.size
                 if (provider != null &&
                     (provider.type == ProviderType.XTREAM_CODES || provider.type == ProviderType.STALKER_PORTAL)
                 ) {
@@ -247,7 +251,7 @@ class SeriesRepositoryImpl @Inject constructor(
                             categoryId = category.categoryId,
                             provider = provider,
                             requiredCount = limitPerCategory,
-                            allowStalkerWildcard = false
+                            allowStalkerWildcard = allowWildcardHydration
                         )
                     }
                 }

--- a/data/src/main/java/com/streamvault/data/repository/VodRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/VodRepositoryImpl.kt
@@ -5,16 +5,26 @@ import com.streamvault.data.local.dao.MovieDao
 import com.streamvault.data.local.dao.SeriesDao
 import com.streamvault.data.local.dao.VodCatalogEntryDao
 import com.streamvault.data.local.dao.VodCategoryHydrationDao
+import com.streamvault.data.local.entity.CategoryEntity
 import com.streamvault.data.mapper.toDomain
+import com.streamvault.data.mapper.toEntity
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderCapabilityResolver
+import com.streamvault.data.provider.TypedProviderClientFactory
+import com.streamvault.data.provider.toLegacyProvider
+import com.streamvault.data.remote.stalker.StalkerProvider
 import com.streamvault.data.sync.CatalogHydrationCommands
 import com.streamvault.domain.model.Category
 import com.streamvault.domain.model.ContentType
+import com.streamvault.domain.model.LegacyProvider as Provider
+import com.streamvault.domain.model.ProviderType
 import com.streamvault.domain.model.Result
 import com.streamvault.domain.model.VodCatalogItem
 import com.streamvault.domain.model.VodCategoryHydration
 import com.streamvault.domain.model.VodCategoryHydrationRequest
 import com.streamvault.domain.model.VodCategoryLoadMode
+import com.streamvault.domain.model.VodSearchResult
+import com.streamvault.domain.provider.CapabilityResolution
 import com.streamvault.domain.repository.VodRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,7 +51,9 @@ class VodRepositoryImpl @Inject constructor(
     private val vodCatalogEntryDao: VodCatalogEntryDao,
     private val categoryDao: CategoryDao,
     private val preferencesRepository: PreferencesRepository,
-    private val syncManager: CatalogHydrationCommands
+    private val syncManager: CatalogHydrationCommands,
+    private val providerCapabilityResolver: ProviderCapabilityResolver,
+    private val typedProviderClientFactory: TypedProviderClientFactory
 ) : VodRepository {
     private val repositoryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
@@ -50,12 +62,45 @@ class VodRepositoryImpl @Inject constructor(
         preferencesRepository.parentalControlLevel,
         preferencesRepository.getHiddenCategoryIds(providerId, ContentType.VOD)
     ) { entities, parentalLevel, hiddenIds ->
-        entities.asSequence()
-            .filterNot { it.categoryId in hiddenIds }
-            .filter { parentalLevel < 3 || (!it.isAdult && !it.isUserProtected) }
-            .map { it.toDomain() }
-            .toList()
+        entities to (parentalLevel to hiddenIds)
+    }.flatMapLatest { pair ->
+        val entities = pair.first
+        val filters = pair.second
+        val parentalLevel = filters.first
+        val vodHiddenIds = filters.second
+        val unified = filterUnifiedCategories(entities, parentalLevel, vodHiddenIds)
+        if (unified.isNotEmpty()) {
+            flowOf(unified)
+        } else {
+            // A UNIFIED_VOD portal that was synced before its layout flip stores the unified
+            // catalog as SPLIT-era MOVIE-type categories while the account runtime reports
+            // UNIFIED_VOD (the sync's own reconcileStoredCategoryTypes relabels these rows on
+            // the next catalog sync). Category ids are layout-independent, so read the MOVIE
+            // rows instead of rendering an empty tab until that sync runs.
+            flow {
+                val movieHiddenIds = preferencesRepository
+                    .getHiddenCategoryIds(providerId, ContentType.MOVIE)
+                    .first()
+                emit(
+                    filterUnifiedCategories(
+                        categoryDao.getByProviderAndTypeSync(providerId, ContentType.MOVIE.name),
+                        parentalLevel,
+                        vodHiddenIds + movieHiddenIds
+                    )
+                )
+            }
+        }
     }
+
+    private fun filterUnifiedCategories(
+        entities: List<CategoryEntity>,
+        parentalLevel: Int,
+        hiddenIds: Set<Long>
+    ): List<Category> = entities.asSequence()
+        .filterNot { it.categoryId in hiddenIds }
+        .filter { parentalLevel < 3 || (!it.isAdult && !it.isUserProtected) }
+        .map { it.toDomain() }
+        .toList()
 
     override fun getCategoryPreview(
         providerId: Long,
@@ -132,6 +177,69 @@ class VodRepositoryImpl @Inject constructor(
             categoryId = categoryId,
             request = VodCategoryHydrationRequest.COMPLETE
         )
+
+    override suspend fun searchVod(
+        providerId: Long,
+        query: String,
+        page: Int
+    ): Result<VodSearchResult> {
+        val trimmedQuery = query.trim()
+        if (trimmedQuery.isEmpty()) {
+            return Result.success(VodSearchResult(emptyList(), 0, page, 0))
+        }
+        val provider = loadCompatibilityProvider(providerId)
+        if (provider?.type != ProviderType.STALKER_PORTAL) {
+            return Result.error("Portal-backed VOD search is only available for Stalker portal providers.")
+        }
+        val stalkerProvider = createStalkerProvider(providerId)
+        return when (val result = stalkerProvider.searchVodPage(trimmedQuery, page)) {
+            is Result.Success -> {
+                val page = result.data
+                // Portal search movies arrive transient (id == 0), exactly like every other
+                // StalkerProvider VOD payload, and only get their real row id once persisted.
+                // Resolve them against the local movies table before handing them to the UI:
+                // otherwise every result shares stableId "movie:0" and the VOD grid crashes
+                // with duplicate LazyGrid keys (and movie-detail lookups by id would fail).
+                val entities = page.items.map { movie -> movie.toEntity() }.filter { it.streamId > 0L }
+                if (entities.isNotEmpty()) {
+                    movieDao.upsertCategoryPage(providerId, entities)
+                }
+                val persistedByStreamId = if (entities.isEmpty()) {
+                    emptyMap()
+                } else {
+                    movieDao.getByStreamIds(providerId, entities.map { it.streamId })
+                        .associateBy { it.streamId }
+                }
+                val items = page.items.mapNotNull { movie ->
+                    persistedByStreamId[movie.streamId]?.toDomain()?.let(VodCatalogItem::MovieItem)
+                }
+                Result.success(
+                    VodSearchResult(
+                        items = items,
+                        totalCount = page.advertisedTotalItems ?: page.items.size,
+                        page = page.page,
+                        pageSize = page.pageSize
+                    )
+                )
+            }
+            is Result.Error -> Result.error(result.message, result.exception)
+            is Result.Loading -> Result.error("Unexpected loading state")
+        }
+    }
+
+    private suspend fun loadCompatibilityProvider(providerId: Long): Provider? =
+        providerCapabilityResolver.snapshot(providerId)?.toLegacyProvider()
+
+    private suspend fun createStalkerProvider(providerId: Long): StalkerProvider {
+        val snapshot = providerCapabilityResolver.snapshot(providerId)
+            ?: throw IllegalStateException("Provider $providerId has no typed configuration")
+        return when (val resolution = typedProviderClientFactory.stalker(snapshot)) {
+            is CapabilityResolution.Available -> resolution.capability
+            is CapabilityResolution.ConfigurationError -> throw IllegalStateException(resolution.reason)
+            is CapabilityResolution.Restricted -> throw IllegalStateException(resolution.reason)
+            is CapabilityResolution.Unsupported -> throw IllegalStateException(resolution.reason)
+        }
+    }
 
     private fun observeOrderedItems(
         providerId: Long,

--- a/data/src/main/java/com/streamvault/data/sync/ProviderEpgSyncExecutor.kt
+++ b/data/src/main/java/com/streamvault/data/sync/ProviderEpgSyncExecutor.kt
@@ -231,6 +231,7 @@ internal class ProviderEpgSyncExecutor(
         val bulkCoveredChannelKeys = linkedSetOf<String>()
         var importedProgramCount = 0
         var providerRateLimited = false
+        var bulkEpgReturnedEmpty = false
 
         suspend fun flushPrograms() {
             if (insertBuffer.isEmpty()) return
@@ -272,6 +273,11 @@ internal class ProviderEpgSyncExecutor(
             }.let { result ->
                 if (result is Result.Error) {
                     throw result.exception ?: IllegalStateException(result.message)
+                } else if (result is Result.Success && result.data == 0) {
+                    // Bulk call succeeded but carried no programs: on portals with a broken
+                    // get_epg_info this is the signal to probe one per-channel request and
+                    // then skip the rest instead of grinding through all of them.
+                    bulkEpgReturnedEmpty = true
                 }
             }
         }.onFailure { error ->
@@ -298,6 +304,7 @@ internal class ProviderEpgSyncExecutor(
         fallbackGuideRequests.forEachIndexed { index, request ->
             if (ignorePerChannelGuide) return@forEachIndexed
             progress(provider.id, onProgress, "Downloading portal EPG... ${index + 1} of ${fallbackGuideRequests.size}")
+            var channelRecordCount = 0
             runSuspendCatching {
                 var perChannelRecordCount = 0
                 val foreignChannelIds = HashSet<String>()
@@ -318,6 +325,7 @@ internal class ProviderEpgSyncExecutor(
                             channelId = request.channelKey
                         ).toEntity()
                         perChannelRecordCount++
+                        channelRecordCount = perChannelRecordCount
                         if (perChannelRecordCount >= STALKER_PER_CHANNEL_RECORD_SANITY_CAP || foreignChannelIds.size > 1) {
                             throw StalkerBrokenPerChannelEpgException(request.channelName)
                         }
@@ -326,6 +334,18 @@ internal class ProviderEpgSyncExecutor(
                 }
                 if (streamResult is Result.Error) {
                     throw streamResult.exception ?: IllegalStateException(streamResult.message)
+                }
+                if (channelRecordCount == 0 && bulkEpgReturnedEmpty && !providerRateLimited) {
+                    // Bulk and the first per-channel request both came back empty: this
+                    // portal's get_epg_info is dead, so skip the remaining calls instead
+                    // of grinding through every channel. The guide fills on demand via
+                    // short EPG when its pages are opened.
+                    ignorePerChannelGuide = true
+                    Log.w(
+                        TAG,
+                        "Stalker portal get_epg_info returned no programs for provider ${provider.id}; " +
+                            "skipping remaining per-channel requests."
+                    )
                 }
             }.onFailure { error ->
                 if (error.hasStalkerRateLimit()) {

--- a/data/src/main/java/com/streamvault/data/sync/StalkerCatalogSyncExecutor.kt
+++ b/data/src/main/java/com/streamvault/data/sync/StalkerCatalogSyncExecutor.kt
@@ -145,6 +145,7 @@ internal class StalkerCatalogSyncExecutor(
             }
         }
         readinessTracker.authenticated(provider.id)
+        reconcileStoredCategoryTypes(provider.id, effectiveCatalogLayout)
 
         var metadata = syncMetadataRepository.getMetadata(provider.id) ?: SyncMetadata(provider.id)
         val now = System.currentTimeMillis()
@@ -342,6 +343,39 @@ internal class StalkerCatalogSyncExecutor(
                 preservedActiveCatalog -> SyncActivation.PRESERVED_ACTIVE_CATALOG
                 else -> SyncActivation.NO_CATALOG_CHANGE
             }
+        )
+    }
+
+    /**
+     * Repairs a persisted-layout/stored-rows mismatch without re-downloading the catalog.
+     * Category and item ids are layout-independent, so when the effective layout is
+     * UNIFIED_VOD but rows are still stored as SPLIT-era MOVIE types (or vice versa), relabeling
+     * the 60-odd category rows heals every reader. A full type rewrite stays reserved for the
+     * section below, which runs only when the portal actually returns fresh categories.
+     */
+    private suspend fun reconcileStoredCategoryTypes(
+        providerId: Long,
+        effectiveCatalogLayout: CatalogLayout
+    ) {
+        if (effectiveCatalogLayout != CatalogLayout.UNIFIED_VOD &&
+            effectiveCatalogLayout != CatalogLayout.SPLIT
+        ) {
+            return
+        }
+        val (expectedType, legacyType) = if (effectiveCatalogLayout == CatalogLayout.UNIFIED_VOD) {
+            ContentType.VOD.name to ContentType.MOVIE.name
+        } else {
+            ContentType.MOVIE.name to ContentType.VOD.name
+        }
+        val expected = categoryDao.getByProviderAndTypeSync(providerId, expectedType)
+        if (expected.isNotEmpty()) return
+        val legacy = categoryDao.getByProviderAndTypeSync(providerId, legacyType)
+        if (legacy.isEmpty()) return
+        val relabeled = categoryDao.retargetType(providerId, legacyType, expectedType)
+        Log.i(
+            STALKER_EXECUTOR_TAG,
+            "Retargeted $relabeled $legacyType categories to $expectedType for provider $providerId " +
+                "to match $effectiveCatalogLayout without re-downloading items."
         )
     }
 

--- a/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
@@ -2953,6 +2953,35 @@ class OkHttpStalkerApiServiceTest {
     }
 
     @Test
+    fun authenticate_tokenlessHandshake_abortsAsRateLimitedWithoutFurtherHandshakes() = runTest {
+        val requestedActions = mutableListOf<String>()
+        val service = OkHttpStalkerApiService(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val request = chain.request()
+                    requestedActions += request.url.queryParameter("action").orEmpty()
+                    Response.Builder()
+                        .request(request)
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body("""{"js":{}}""".toResponseBody("application/json".toMediaType()))
+                        .build()
+                }
+                .build(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+
+        val result = service.authenticate(stalkerProfile())
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        val error = result as Result.Error
+        assertThat(error.exception).isInstanceOf(StalkerApiError.RateLimited::class.java)
+        // Soft throttle: no recipe-loop follow-up handshake may fire into the limiter.
+        assertThat(requestedActions).containsExactly("handshake")
+    }
+
+    @Test
     fun authenticate_classifies_status2_envelope_as_device_not_registered() = runTest {
         val service = OkHttpStalkerApiService(
             okHttpClient = OkHttpClient.Builder()

--- a/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
@@ -1926,6 +1926,77 @@ class OkHttpStalkerApiServiceTest {
     }
 
     @Test
+    fun getVodStreamsPage_sends_search_parameter_when_searchQuery_is_set() = runTest {
+        var requestedSearch: String? = null
+        val service = OkHttpStalkerApiService(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    requestedSearch = chain.request().url.queryParameter("search")
+                    Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(
+                            """{"js":{"total_items":1,"max_page_items":14,"data":[{"id":"17160","name":"Damadol","category_id":"20","cmd":"ffmpeg http://example.com/damadol.mp4"}]}}"""
+                                .toResponseBody("application/json".toMediaType())
+                        )
+                        .build()
+                }
+                .build(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+
+        val result = service.getVodStreamsPage(
+            stalkerSession(),
+            stalkerProfile(),
+            categoryId = null,
+            page = 1,
+            searchQuery = "damadol"
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(requestedSearch).isEqualTo("damadol")
+        val page = (result as Result.Success).data
+        assertThat(page.items).hasSize(1)
+        assertThat(page.advertisedTotalItems).isEqualTo(1)
+    }
+
+    @Test
+    fun getVodStreamsPage_omits_search_parameter_when_searchQuery_is_blank() = runTest {
+        var requestedSearch: String? = "unset"
+        val service = OkHttpStalkerApiService(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    requestedSearch = chain.request().url.queryParameter("search")
+                    Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body(
+                            """{"js":{"total_items":14,"max_page_items":14,"data":[{"id":"1","name":"Movie","category_id":"1","cmd":"ffmpeg http://example.com/m.mp4"}]}}"""
+                                .toResponseBody("application/json".toMediaType())
+                        )
+                        .build()
+                }
+                .build(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+
+        val result = service.getVodStreamsPage(
+            stalkerSession(),
+            stalkerProfile(),
+            categoryId = "42",
+            page = 1,
+            searchQuery = "   "
+        )
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(requestedSearch).isNull()
+    }
+
+    @Test
     fun getVodStreamsPage_treats_199_as_incomplete_and_200_as_complete_when_total_is_200() = runTest {
         val service = OkHttpStalkerApiService(
             okHttpClient = fakeClient(

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerPortalStateStoreTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerPortalStateStoreTest.kt
@@ -144,8 +144,36 @@ class StalkerPortalStateStoreTest {
             .isEqualTo("https://portal.test/load.php")
     }
 
-    private class FakePortalStateDao : StalkerPortalStateDao {
-        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
+    @Test
+    fun `resumable session round-trips and respects generation age and clearing`() = runTest {
+        val dao = FakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        val session = StalkerSession(
+            loadUrl = "https://portal.test/load.php",
+            portalReferer = "https://portal.test/c/",
+            token = "tok123"
+        ).copy(authenticatedAtMillis = 10_000L)
+        store.recordAuthentication(
+            providerId = 11L,
+            session = session,
+            profile = StalkerProviderProfile(accountName = "Room"),
+            now = 10_000L,
+            configurationGeneration = 7L
+        )
+
+        val resumed = store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 70_000L)
+        assertThat(resumed?.session?.token).isEqualTo("tok123")
+        assertThat(resumed?.profile?.accountName).isEqualTo("Room")
+
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 8L, now = 70_000L)).isNull()
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 10_000L + 31L * 60L * 1000L)).isNull()
+        assertThat(store.resumableAuth(providerId = 99L, configurationGeneration = 7L, now = 70_000L)).isNull()
+
+        store.clearResumableAuth(11L)
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 70_000L)).isNull()
+    }
+
+    private class FakePortalStateDao : StalkerPortalStateDao {        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
 
         override suspend fun get(providerId: Long): StalkerPortalStateEntity? = rows[providerId]
 

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -677,6 +677,109 @@ class StalkerProviderTest {
     }
 
     @Test
+    fun getLiveStreams_resolves_bare_filename_logos_under_misc_logos() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "536",
+                        name = "NEWS 18 PUNJAB HARYANA",
+                        cmd = "ffmpeg http://localhost/ch/536_",
+                        streamUrl = "http://localhost/ch/536_",
+                        logoUrl = "536.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        assertThat(success.data.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/stalker_portal/misc/logos/120/536.png")
+    }
+
+    @Test
+    fun getLiveStreams_resolves_bare_filename_logos_from_plain_portal_base() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "1",
+                        name = "APTN 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/1_",
+                        streamUrl = "http://localhost/ch/1_",
+                        logoUrl = "1.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        assertThat(success.data.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/misc/logos/120/1.png")
+    }
+
+    @Test
+    fun getLiveStreams_keeps_absolute_and_root_relative_logos_unchanged() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "11",
+                        name = "CBC ICI 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/11_",
+                        streamUrl = "http://localhost/ch/11_",
+                        logoUrl = "https://cdn.example.com/11.png"
+                    ),
+                    StalkerItemRecord(
+                        id = "12",
+                        name = "CBS 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/12_",
+                        streamUrl = "http://localhost/ch/12_",
+                        logoUrl = "/stalker_portal/misc/logos/120/12.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        val logos = success.data.map { it.logoUrl }
+        assertThat(logos).containsExactly(
+            "https://cdn.example.com/11.png",
+            "http://alex.rocktv.be/stalker_portal/misc/logos/120/12.png"
+        )
+    }
+
+    @Test
     fun buildCatchUpUrls_returns_internal_archive_candidates_for_live_token() = runTest {
         val provider = StalkerProvider(
             providerId = 7,

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -1255,7 +1255,11 @@ class StalkerProviderTest {
         private val vodPageItems: List<StalkerItemRecord> = emptyList(),
         private val seriesPageItems: List<StalkerItemRecord> = emptyList(),
         private var authenticationFailuresBeforeSuccess: Int = 0,
-        private var authenticationError: Throwable? = null
+        private var authenticationError: Throwable? = null,
+        private val shortEpgByChannel: Map<String, List<StalkerProgramRecord>> = emptyMap(),
+        private val epgByChannel: Map<String, List<StalkerProgramRecord>> = emptyMap(),
+        val shortEpgCalls: MutableList<String> = mutableListOf(),
+        val epgCalls: MutableList<String> = mutableListOf()
     ) : StalkerApiService {
         var createLinkCalls: Int = 0
             private set
@@ -1355,13 +1359,19 @@ class StalkerProviderTest {
             profile: StalkerDeviceProfile,
             channelId: String,
             limit: Int
-        ) = Result.success(emptyList<StalkerProgramRecord>())
+        ): Result<List<StalkerProgramRecord>> {
+            shortEpgCalls += channelId
+            return Result.success(shortEpgByChannel[channelId].orEmpty())
+        }
 
         override suspend fun getEpg(
             session: StalkerSession,
             profile: StalkerDeviceProfile,
             channelId: String
-        ) = Result.success(emptyList<StalkerProgramRecord>())
+        ): Result<List<StalkerProgramRecord>> {
+            epgCalls += channelId
+            return Result.success(epgByChannel[channelId].orEmpty())
+        }
 
         override suspend fun getBulkEpg(
             session: StalkerSession,
@@ -1485,6 +1495,111 @@ class StalkerProviderTest {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val success = result as Result.Success
         assertThat(success.data.url).isEqualTo("http://cdn.example.com/live/stream.ts")
+    }
+
+    @Test
+    fun getShortEpg_request_prefers_numeric_portal_id_over_xmltv_key() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            shortEpgByChannel = mapOf(
+                "66" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "66",
+                        title = "Christ in Prophecy",
+                        description = "Prophecy",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getShortEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Christ in Prophecy")
+        assertThat(api.shortEpgCalls).containsExactly("66")
+    }
+
+    @Test
+    fun getShortEpg_request_falls_back_to_xmltv_key_when_numeric_id_is_empty() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            shortEpgByChannel = mapOf(
+                "daystar.us" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "daystar.us",
+                        title = "Christ in Prophecy",
+                        description = "Prophecy",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getShortEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Christ in Prophecy")
+        assertThat(api.shortEpgCalls).containsExactly("66", "daystar.us")
+    }
+
+    @Test
+    fun getEpg_request_uses_numeric_portal_id() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            epgByChannel = mapOf(
+                "66" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "66",
+                        title = "Evening News",
+                        description = "News",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Evening News")
+        assertThat(api.epgCalls).containsExactly("66")
     }
 
     private object DirectTransactionRunner : DatabaseTransactionRunner {

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -1077,6 +1077,136 @@ class StalkerProviderTest {
     }
 
     @Test
+    fun authenticate_reusesSessionAcrossInstancesWithDifferentLearnedHints() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room")
+        )
+        val activation = StalkerProvider(
+            providerId = 21,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        assertThat(activation.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+
+        // Sync-side instance built from persisted learning: same portal identity, but
+        // different volatile hints. Must reuse the session, not fire a second handshake.
+        val sync = StalkerProvider(
+            providerId = 21,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            portalFingerprintHint = com.streamvault.domain.model.StalkerPortalFingerprint.STRICT_MAG,
+            magPresetHint = com.streamvault.domain.model.StalkerMagPreset.MAG254_STRICT,
+            bootstrapRecipeHint = com.streamvault.domain.model.StalkerBootstrapRecipe.STRICT_MAG,
+            endpointPreferenceHint = com.streamvault.domain.model.StalkerEndpointPreference.SERVER_LOAD,
+            cookieModeHint = com.streamvault.domain.model.StalkerCookieMode.BOTH,
+            deviceProfile = "MAG254",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        assertThat(sync.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun authenticate_resumesPersistedSessionAfterProcessRestartWithoutHandshake() = runTest {
+        val dao = ResumableAuthFakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room")
+        )
+        val first = StalkerProvider(
+            providerId = 22,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        assertThat(first.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+
+        // Simulate a process restart: all in-memory session caches are gone, but the
+        // persisted portal state (same DB) survives. No handshake may fire.
+        StalkerProvider.clearSharedAuthCacheForTests()
+        val restarted = StalkerProvider(
+            providerId = 22,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            portalFingerprintHint = com.streamvault.domain.model.StalkerPortalFingerprint.STRICT_MAG,
+            deviceProfile = "MAG254",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        assertThat(restarted.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun authenticate_skipsEndpointRepairRetryWhenThrottled() = runTest {
+        val dao = ResumableAuthFakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        // Arm the cached-endpoint repair path (working endpoint + recipe) but leave no
+        // resumable session, so authentication must go to the wire exactly once.
+        store.recordAuthentication(
+            providerId = 23,
+            session = StalkerSession(
+                loadUrl = "https://portal.example.com/server/load.php",
+                portalReferer = "https://portal.example.com/c/",
+                token = "stale-token"
+            ),
+            profile = StalkerProviderProfile(accountName = "Room"),
+            configurationGeneration = 0L
+        )
+        store.clearResumableAuth(23)
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            authenticationError = StalkerApiError.RateLimited()
+        )
+        val provider = StalkerProvider(
+            providerId = 23,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        val result = provider.authenticate()
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        // The repair retry would fire a second handshake milliseconds later and convert
+        // a soft throttle into a hard 429. It must be skipped.
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    private class ResumableAuthFakePortalStateDao : StalkerPortalStateDao {        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
+
+        override suspend fun get(providerId: Long): StalkerPortalStateEntity? = rows[providerId]
+
+        override suspend fun upsert(entity: StalkerPortalStateEntity) {
+            rows[entity.providerId] = entity
+        }
+
+        override suspend fun invalidate(providerId: Long): Int = if (rows.remove(providerId) != null) 1 else 0
+    }
+
+    @Test
     fun resolvePlaybackInfo_dedicatedPlayerUserAgentOverridesCustomHeaderUserAgent() = runTest {
         val provider = StalkerProvider(
             providerId = 7,
@@ -1124,7 +1254,8 @@ class StalkerProviderTest {
         private val seriesCategoriesResult: Result<List<StalkerCategoryRecord>>? = null,
         private val vodPageItems: List<StalkerItemRecord> = emptyList(),
         private val seriesPageItems: List<StalkerItemRecord> = emptyList(),
-        private var authenticationFailuresBeforeSuccess: Int = 0
+        private var authenticationFailuresBeforeSuccess: Int = 0,
+        private var authenticationError: Throwable? = null
     ) : StalkerApiService {
         var createLinkCalls: Int = 0
             private set
@@ -1139,6 +1270,9 @@ class StalkerProviderTest {
             if (authenticationFailuresBeforeSuccess > 0) {
                 authenticationFailuresBeforeSuccess -= 1
                 return Result.error("authentication failed")
+            }
+            authenticationError?.let { error ->
+                return Result.error(error.message.orEmpty(), error)
             }
             return Result.success(
                 StalkerSession(

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -225,6 +225,90 @@ class StalkerProviderTest {
     }
 
     @Test
+    fun getVodStreamsPage_fallsBackToNumericCategoryId_whenIdentityIsUnknown() = runTest {
+        // No category cache, no identity map, and an empty live category fetch: the raw
+        // numeric category id must still be sent to the portal instead of being dropped
+        // (a dropped category makes the portal return its default listing for every shelf).
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            vodCategories = emptyList(),
+            vodPageItems = listOf(
+                StalkerItemRecord(
+                    id = "100",
+                    name = "Movie",
+                    streamUrl = "https://cdn.example.com/movie.mp4",
+                    isSeries = false
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 9,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:58",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getVodStreamsPage(categoryId = 104L, page = 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(api.lastVodCategoryId).isEqualTo("104")
+    }
+
+    @Test
+    fun searchVod_forwardsQueryToPortal_andMapsMovieResults() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            vodPageItems = listOf(
+                StalkerItemRecord(
+                    id = "17160",
+                    name = "Damadol",
+                    streamUrl = "https://cdn.example.com/damadol.mp4",
+                    isSeries = false
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 9,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:58",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.searchVodPage("damadol", 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat(api.lastVodSearchQuery).isEqualTo("damadol")
+        val page = (result as Result.Success).data
+        assertThat(page.items.map { it.name }).containsExactly("Damadol")
+    }
+
+    @Test
+    fun searchVod_blankQuery_returnsEmptyPageWithoutCallingPortal() = runTest {
+        val api = FakeStalkerApiService(profile = StalkerProviderProfile(accountName = "Room"))
+        val provider = StalkerProvider(
+            providerId = 9,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:58",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.searchVodPage("   ", 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat((result as Result.Success).data.items).isEmpty()
+        assertThat(api.lastVodSearchQuery).isNull()
+    }
+
+    @Test
     fun unifiedVodPage_keepsMixedProviderOrder_andDefaultsMissingMarkerToMovie() = runTest {
         val api = FakeStalkerApiService(
             profile = StalkerProviderProfile(accountName = "Room"),
@@ -1421,12 +1505,23 @@ class StalkerProviderTest {
             categoryId: String?
         ) = Result.success(emptyList<StalkerItemRecord>())
 
+        var lastVodSearchQuery: String? = null
+            private set
+        var lastVodCategoryId: String? = null
+            private set
+
         override suspend fun getVodStreamsPage(
             session: StalkerSession,
             profile: StalkerDeviceProfile,
             categoryId: String?,
-            page: Int
-        ) = Result.success(StalkerPagedItems(vodPageItems, page, page, vodPageItems.size))
+            page: Int,
+            searchQuery: String?
+        ): Result<StalkerPagedItems> = Result.success(
+            StalkerPagedItems(vodPageItems, page, page, vodPageItems.size)
+        ).also {
+            lastVodCategoryId = categoryId
+            lastVodSearchQuery = searchQuery
+        }
 
         override suspend fun getSeriesCategories(
             session: StalkerSession,

--- a/data/src/test/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolverTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/xtream/XtreamStreamUrlResolverTest.kt
@@ -826,7 +826,8 @@ class XtreamStreamUrlResolverTest {
             session: StalkerSession,
             profile: StalkerDeviceProfile,
             categoryId: String?,
-            page: Int
+            page: Int,
+            searchQuery: String?
         ): Result<StalkerPagedItems> = Result.success(
             StalkerPagedItems(items = emptyList(), page = page, totalPages = page, pageSize = 0)
         )

--- a/data/src/test/java/com/streamvault/data/repository/ChannelRepositoryImplTest.kt
+++ b/data/src/test/java/com/streamvault/data/repository/ChannelRepositoryImplTest.kt
@@ -5,11 +5,17 @@ import com.google.common.truth.Truth.assertThat
 import com.streamvault.data.local.dao.CategoryDao
 import com.streamvault.data.local.dao.ChannelDao
 import com.streamvault.data.local.dao.FavoriteDao
+import com.streamvault.data.local.dao.ProviderSnapshotDao
 import com.streamvault.data.local.entity.CategoryCount
 import com.streamvault.data.local.entity.ChannelBrowseEntity
 import com.streamvault.data.local.entity.CategoryEntity
+import com.streamvault.data.local.entity.ProviderConfigEntity
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderConfigurationCodec
 import com.streamvault.data.remote.xtream.XtreamStreamUrlResolver
+import com.streamvault.domain.model.ProviderType
+import com.streamvault.domain.model.StalkerConfig
+import com.streamvault.domain.model.StalkerDeviceIdentity
 import com.streamvault.domain.manager.ParentalControlManager
 import com.streamvault.domain.model.ChannelLogoSourcePolicy
 import com.streamvault.domain.model.ChannelNumberingMode
@@ -38,9 +44,12 @@ class ChannelRepositoryImplTest {
     private val preferencesRepository: PreferencesRepository = mock()
     private val parentalControlManager: ParentalControlManager = mock()
     private val xtreamStreamUrlResolver: XtreamStreamUrlResolver = mock()
+    private val providerSnapshotDao: ProviderSnapshotDao = mock()
+    private val providerConfigurationCodec: ProviderConfigurationCodec = mock()
 
     @Before
     fun setUpDefaults() {
+        whenever(providerSnapshotDao.getConfigSync(any())).thenReturn(null)
         whenever(preferencesRepository.parentalControlLevel).thenReturn(flowOf(0))
         whenever(preferencesRepository.liveChannelNumberingMode).thenReturn(flowOf(ChannelNumberingMode.PROVIDER))
         whenever(preferencesRepository.liveChannelGroupingMode).thenReturn(flowOf(LiveChannelGroupingMode.GROUPED))
@@ -351,6 +360,75 @@ class ChannelRepositoryImplTest {
     }
 
     @Test
+    fun `getChannels resolves bare-filename stalker logos against portal misc logos dir`() = runTest {
+        whenever(channelDao.getByProvider(7L)).thenReturn(
+            flowOf(
+                listOf(
+                    ChannelBrowseEntity(
+                        id = 536L,
+                        streamId = 536L,
+                        name = "NEWS 18 PUNJAB HARYANA",
+                        logoUrl = "536.png",
+                        streamUrl = "https://stream/536",
+                        number = 1,
+                        providerId = 7L
+                    )
+                )
+            )
+        )
+        val stalkerConfig = StalkerConfig(
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            device = StalkerDeviceIdentity(macAddress = "00:1A:79:12:34:56")
+        )
+        val configEntity = ProviderConfigEntity(
+            providerId = 7L,
+            type = ProviderType.STALKER_PORTAL,
+            schemaVersion = 1,
+            configurationGeneration = 1L,
+            identityKey = "stalker-7",
+            encryptedConfigJson = "{}",
+            updatedAt = 0L
+        )
+        whenever(providerSnapshotDao.getConfigSync(7L)).thenReturn(configEntity)
+        whenever(providerConfigurationCodec.decode(ProviderType.STALKER_PORTAL, "{}"))
+            .thenReturn(stalkerConfig)
+        whenever(parentalControlManager.unlockedCategoriesForProvider(7L)).thenReturn(flowOf(emptySet()))
+
+        val repository = createRepository()
+
+        val result = repository.getChannels(7L).first()
+
+        assertThat(result.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/stalker_portal/misc/logos/120/536.png")
+    }
+
+    @Test
+    fun `getChannels leaves bare-filename logos alone for non stalker providers`() = runTest {
+        whenever(channelDao.getByProvider(7L)).thenReturn(
+            flowOf(
+                listOf(
+                    ChannelBrowseEntity(
+                        id = 1L,
+                        streamId = 1L,
+                        name = "News One",
+                        logoUrl = "1.png",
+                        streamUrl = "https://stream/1",
+                        number = 1,
+                        providerId = 7L
+                    )
+                )
+            )
+        )
+        whenever(parentalControlManager.unlockedCategoriesForProvider(7L)).thenReturn(flowOf(emptySet()))
+
+        val repository = createRepository()
+
+        val result = repository.getChannels(7L).first()
+
+        assertThat(result.single().logoUrl).isEqualTo("1.png")
+    }
+
+    @Test
     fun `searchChannels returns empty list when sqlite throws for malformed fts query`() = runTest {
         whenever(channelDao.search(eq(7L), any(), any())).thenReturn(
             flow { throw SQLiteException("malformed MATCH expression") }
@@ -413,7 +491,9 @@ class ChannelRepositoryImplTest {
         favoriteDao = favoriteDao,
         preferencesRepository = preferencesRepository,
         parentalControlManager = parentalControlManager,
-        xtreamStreamUrlResolver = xtreamStreamUrlResolver
+        xtreamStreamUrlResolver = xtreamStreamUrlResolver,
+        providerSnapshotDao = providerSnapshotDao,
+        providerConfigurationCodec = providerConfigurationCodec
     )
 
     private fun categoryEntity(

--- a/data/src/test/java/com/streamvault/data/repository/VodRepositoryImplTest.kt
+++ b/data/src/test/java/com/streamvault/data/repository/VodRepositoryImplTest.kt
@@ -12,17 +12,31 @@ import com.streamvault.data.local.entity.SeriesEntity
 import com.streamvault.data.local.entity.VodCatalogEntryEntity
 import com.streamvault.data.local.entity.VodCategoryHydrationEntity
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderCapabilityResolver
+import com.streamvault.data.provider.TypedProviderClientFactory
+import com.streamvault.data.remote.stalker.StalkerPagedResult
+import com.streamvault.data.remote.stalker.StalkerProvider
 import com.streamvault.data.sync.SyncManager
 import com.streamvault.domain.model.ContentType
+import com.streamvault.domain.model.Movie
+import com.streamvault.domain.model.ProviderSnapshot
+import com.streamvault.domain.model.ProviderType
 import com.streamvault.domain.model.Result
+import com.streamvault.domain.model.StalkerConfig
+import com.streamvault.domain.model.StalkerDeviceIdentity
 import com.streamvault.domain.model.VodCatalogItem
 import com.streamvault.domain.model.VodCategoryHydrationRequest
 import com.streamvault.domain.model.VodCategoryLoadMode
+import com.streamvault.domain.model.Provider as LegacyProvider
+import com.streamvault.domain.provider.CapabilityResolution
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -36,6 +50,8 @@ class VodRepositoryImplTest {
     private val categoryDao = mock<CategoryDao>()
     private val preferences = mock<PreferencesRepository>()
     private val syncManager = mock<SyncManager>()
+    private val capabilityResolver = mock<ProviderCapabilityResolver>()
+    private val typedProviderFactory = mock<TypedProviderClientFactory>()
 
     private fun repository() = VodRepositoryImpl(
         movieDao,
@@ -44,8 +60,144 @@ class VodRepositoryImplTest {
         entryDao,
         categoryDao,
         preferences,
-        syncManager
+        syncManager,
+        capabilityResolver,
+        typedProviderFactory
     )
+
+    private fun stalkerSnapshot(providerId: Long): ProviderSnapshot {
+        val legacy = LegacyProvider(
+            id = providerId,
+            name = "Portal",
+            type = ProviderType.STALKER_PORTAL
+        )
+        return ProviderSnapshot(
+            provider = legacy,
+            configuration = StalkerConfig(
+                portalUrl = "https://portal.example.com/stalker_portal/server/load.php",
+                device = StalkerDeviceIdentity(macAddress = "00:11:22:33:44:55")
+            ),
+            configurationGeneration = 1L
+        )
+    }
+
+    @Test
+    fun searchVod_blankQuery_returnsEmptyWithoutTouchingProvider() = runTest {
+        val result = repository().searchVod(1L, "   ", 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        assertThat((result as Result.Success).data.items).isEmpty()
+        verify(capabilityResolver, never()).snapshot(any())
+    }
+
+    @Test
+    fun searchVod_queriesPortal_forStalkerProvider() = runTest {
+        val snapshot = stalkerSnapshot(1L)
+        val stalkerProvider = mock<StalkerProvider>()
+        whenever(capabilityResolver.snapshot(1L)).thenReturn(snapshot)
+        whenever(typedProviderFactory.stalker(snapshot))
+            .thenReturn(CapabilityResolution.Available(stalkerProvider))
+        // Portal payloads are transient movies (id == 0); the repository must persist them
+        // against their stream id and hand back the DB row so items carry real ids.
+        val transientMovie = Movie(
+            id = 0L,
+            name = "Damadol",
+            categoryId = 20L,
+            providerId = 1L,
+            streamId = 17160L
+        )
+        whenever(stalkerProvider.searchVodPage("damadol", 1)).thenReturn(
+            Result.success(
+                StalkerPagedResult(
+                    items = listOf(transientMovie),
+                    page = 1,
+                    totalPages = 1,
+                    pageSize = 14,
+                    advertisedTotalItems = 1
+                )
+            )
+        )
+        whenever(movieDao.getByStreamIds(1L, listOf(17160L))).thenReturn(
+            listOf(
+                MovieEntity(
+                    id = 17160L,
+                    streamId = 17160L,
+                    name = "Damadol",
+                    categoryId = 20L,
+                    providerId = 1L
+                )
+            )
+        )
+
+        val result = repository().searchVod(1L, "damadol", 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val data = (result as Result.Success).data
+        assertThat(data.totalCount).isEqualTo(1)
+        assertThat(data.pageSize).isEqualTo(14)
+        assertThat(data.items).hasSize(1)
+        val item = data.items.single()
+        assertThat(item).isInstanceOf(VodCatalogItem.MovieItem::class.java)
+        assertThat((item as VodCatalogItem.MovieItem).movie.id).isEqualTo(17160L)
+        assertThat(item.movie.name).isEqualTo("Damadol")
+        verify(stalkerProvider).searchVodPage("damadol", 1)
+        verify(movieDao).upsertCategoryPage(eq(1L), any<List<MovieEntity>>())
+    }
+
+    @Test
+    fun searchVod_pageOfTransientResults_returnsDistinctDbBackedIds() = runTest {
+        val snapshot = stalkerSnapshot(1L)
+        val stalkerProvider = mock<StalkerProvider>()
+        whenever(capabilityResolver.snapshot(1L)).thenReturn(snapshot)
+        whenever(typedProviderFactory.stalker(snapshot))
+            .thenReturn(CapabilityResolution.Available(stalkerProvider))
+        // Two transient movies both have id == 0. Only persisting them and reading back the
+        // DB rows gives unique movie ids; returning them raw would make every grid item
+        // share stableId "movie:0" and crash the VOD grid with duplicate keys.
+        val transientMovies = listOf(
+            Movie(id = 0L, name = "Wrath", providerId = 1L, streamId = 1001L),
+            Movie(id = 0L, name = "Wonder", providerId = 1L, streamId = 1002L)
+        )
+        whenever(stalkerProvider.searchVodPage("w", 1)).thenReturn(
+            Result.success(
+                StalkerPagedResult(
+                    items = transientMovies,
+                    page = 1,
+                    totalPages = 1,
+                    pageSize = 14,
+                    advertisedTotalItems = 2
+                )
+            )
+        )
+        whenever(movieDao.getByStreamIds(1L, listOf(1001L, 1002L))).thenReturn(
+            listOf(
+                MovieEntity(id = 7L, streamId = 1001L, name = "Wrath", providerId = 1L),
+                MovieEntity(id = 9L, streamId = 1002L, name = "Wonder", providerId = 1L)
+            )
+        )
+
+        val result = repository().searchVod(1L, "w", 1)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val items = (result as Result.Success).data.items
+        val movies = items.map { (it as VodCatalogItem.MovieItem).movie }
+        assertThat(movies.map { it.id }).containsExactly(7L, 9L)
+        assertThat(movies.map { it.streamId }).containsExactly(1001L, 1002L)
+        assertThat(movies.map { it.name }).containsExactly("Wrath", "Wonder").inOrder()
+        val stableIds = items.map(VodCatalogItem::stableId)
+        assertThat(stableIds).containsNoDuplicates()
+        verify(movieDao).upsertCategoryPage(eq(1L), any<List<MovieEntity>>())
+    }
+
+    @Test
+    fun searchVod_rejectsProviderWithoutStalkerConfiguration() = runTest {
+        whenever(capabilityResolver.snapshot(1L)).thenReturn(null)
+
+        val result = repository().searchVod(1L, "damadol", 1)
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        verifyNoInteractions(typedProviderFactory)
+    }
 
     @Test
     fun categoryItems_followPersistedProviderOrderAcrossTypes() = runTest {
@@ -148,5 +300,40 @@ class VodRepositoryImplTest {
         whenever(preferences.getHiddenCategoryIds(4, ContentType.VOD)).thenReturn(flowOf(setOf(102L)))
 
         assertThat(repository().getCategories(4).first().map { it.id }).containsExactly(101L)
+    }
+
+    @Test
+    fun getCategories_fallsBackToMovieRowsWhenUnifiedCatalogHasNoVodRows() = runTest {
+        whenever(preferences.parentalControlLevel).thenReturn(flowOf(2))
+        whenever(preferences.getHiddenCategoryIds(4, ContentType.VOD)).thenReturn(flowOf(emptySet()))
+        whenever(preferences.getHiddenCategoryIds(4, ContentType.MOVIE)).thenReturn(flowOf(emptySet()))
+        whenever(categoryDao.getByProviderAndType(4, ContentType.VOD.name)).thenReturn(flowOf(emptyList()))
+        whenever(categoryDao.getByProviderAndTypeSync(4, ContentType.MOVIE.name)).thenReturn(
+            listOf(
+                CategoryEntity(providerId = 4, categoryId = 1, name = "ENGLISH | NEW RELEASE", type = ContentType.MOVIE),
+                CategoryEntity(providerId = 4, categoryId = 104, name = "ENGLISH | 4K UHD MOVIES", type = ContentType.MOVIE)
+            )
+        )
+
+        val ids = repository().getCategories(4).first().map { it.id }
+
+        assertThat(ids).containsExactly(1L, 104L).inOrder()
+    }
+
+    @Test
+    fun getCategories_doesNotFallBackWhenVodRowsExist() = runTest {
+        whenever(preferences.parentalControlLevel).thenReturn(flowOf(2))
+        whenever(preferences.getHiddenCategoryIds(4, ContentType.VOD)).thenReturn(flowOf(emptySet()))
+        whenever(categoryDao.getByProviderAndType(4, ContentType.VOD.name)).thenReturn(
+            flowOf(
+                listOf(CategoryEntity(providerId = 4, categoryId = 101, name = "VOD Cat", type = ContentType.VOD))
+            )
+        )
+
+        assertThat(repository().getCategories(4).first().map { it.id }).containsExactly(101L)
+        verify(categoryDao, org.mockito.kotlin.never()).getByProviderAndTypeSync(
+            org.mockito.kotlin.eq(4),
+            org.mockito.kotlin.eq(ContentType.MOVIE.name)
+        )
     }
 }

--- a/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
+++ b/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
@@ -3629,6 +3629,51 @@ class SyncManagerTest {
         assertThat(metadata?.epgCount).isEqualTo(1)
     }
 
+
+    @Test
+    fun retrySection_epg_stalker_skips_dead_epg_info_after_first_empty_channel() = runTest {
+        val providerEntity = sampleProvider(ProviderType.STALKER_PORTAL).copy(
+            serverUrl = "http://example.com",
+            username = "",
+            password = "",
+            stalkerMacAddress = "00:11:22:33:44:55",
+            epgSyncMode = ProviderEpgSyncMode.BACKGROUND,
+            epgUrl = ""
+        )
+        val manager = buildManager(providerType = ProviderType.STALKER_PORTAL, providerEntity = providerEntity)
+
+        org.mockito.kotlin.whenever(stalkerApiService.authenticate(any())).thenReturn(
+            Result.success(
+                StalkerSession(
+                    loadUrl = "http://example.com/stalker_portal/server/load.php",
+                    portalReferer = "http://example.com/stalker_portal/c/",
+                    token = "token"
+                ) to StalkerProviderProfile(accountName = "Stalker")
+            )
+        )
+        org.mockito.kotlin.whenever(channelDao.getGuideSyncEntriesByProvider(1L)).thenReturn(
+            (1..5).map { index ->
+                ChannelGuideSyncEntity(
+                    streamId = 100L + index,
+                    name = "Channel $index",
+                    epgChannelId = "guide-$index"
+                )
+            }
+        )
+        stalkerApiService.stubStreamBulkEpg(programs = emptyList())
+        (1..5).forEach { index ->
+            stalkerApiService.stubStreamEpg(channelId = "guide-$index", programs = emptyList())
+        }
+        org.mockito.kotlin.whenever(programDao.countByProvider(1L)).thenReturn(0)
+
+        val result = manager.retrySection(providerId = 1L, section = SyncRepairSection.EPG)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        // Bulk + first channel both empty: the remaining dead calls must be skipped.
+        org.mockito.kotlin.verify(stalkerApiService, org.mockito.kotlin.times(1))
+            .streamEpg(any(), any(), any(), any(), any())
+    }
+
     @Test
     fun retrySection_epg_stalker_dedupes_same_guide_key_within_one_run() = runTest {
         val providerEntity = sampleProvider(ProviderType.STALKER_PORTAL).copy(

--- a/domain/src/main/java/com/streamvault/domain/model/VodSearchResult.kt
+++ b/domain/src/main/java/com/streamvault/domain/model/VodSearchResult.kt
@@ -1,0 +1,12 @@
+package com.streamvault.domain.model
+
+/**
+ * One page of portal-backed VOD search results. [totalCount] is the portal's advertised
+ * match count for the query, so the UI can keep paging while `items.size < totalCount`.
+ */
+data class VodSearchResult(
+    val items: List<VodCatalogItem>,
+    val totalCount: Int,
+    val page: Int,
+    val pageSize: Int
+)

--- a/domain/src/main/java/com/streamvault/domain/repository/VodRepository.kt
+++ b/domain/src/main/java/com/streamvault/domain/repository/VodRepository.kt
@@ -4,6 +4,7 @@ import com.streamvault.domain.model.Category
 import com.streamvault.domain.model.VodCatalogItem
 import com.streamvault.domain.model.VodCategoryHydration
 import com.streamvault.domain.model.VodCategoryHydrationRequest
+import com.streamvault.domain.model.VodSearchResult
 import com.streamvault.domain.model.Result
 import kotlinx.coroutines.flow.Flow
 
@@ -15,4 +16,11 @@ interface VodRepository {
     suspend fun ensurePreview(providerId: Long, categoryId: Long): Result<Unit>
     suspend fun requestCategoryHydration(providerId: Long, categoryId: Long, request: VodCategoryHydrationRequest): Result<Unit>
     suspend fun hydrateCompletely(providerId: Long, categoryId: Long): Result<Unit>
+
+    /**
+     * Searches the provider's full VOD catalog on the portal side (STB-style `get_ordered_list`
+     * with a `search` parameter). Only supported for Stalker portals; other providers return an
+     * error result.
+     */
+    suspend fun searchVod(providerId: Long, query: String, page: Int): Result<VodSearchResult>
 }


### PR DESCRIPTION
Four commits from the datkooldev fork, in dependency order:

1. **fix: harden stalker sync against portal rate limits and layout drift** (`27749c41`) — resilient catalog sync handling rate-limited/overlapping portal responses.
2. **fix: fetch stalker guide on demand via numeric short-EPG ids** (`3afc1a6a`) — request short EPG with the numeric portal channel id the server understands.
3. **fix: resolve bare-filename stalker channel logos against the portal** (`b9049d76`) — resolve `536.png`-style logo values against the portal's `misc/logos/` path at import and presentation time.
4. **feat: add portal-backed VOD search for stalker portals** (`82459b46`) — category search runs the portal's STB `get_ordered_list&search=` instead of a local filter (new Browsing preference, on by default). Search results are persisted against the local movies table so each item carries a real row id — this also fixes a duplicate-grid-key crash (`movie:0`) when a result page contained more than one transient movie.

All four sit on top of `f86d4aee` (master as of this PR).