### PR TITLE
fix: harden stalker sync against portal rate limits and layout drift

### DIFF
--- a/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
+++ b/data/src/main/java/com/streamvault/data/local/dao/Daos.kt
@@ -3050,6 +3050,15 @@ interface CategoryDao {
 
     @Query("UPDATE categories SET is_user_protected = :isProtected WHERE provider_id = :providerId AND category_id = :categoryId AND type = :type")
     suspend fun updateProtectionStatus(providerId: Long, categoryId: Long, type: String, isProtected: Boolean)
+
+    /**
+     * Relabels stored categories after a catalog-layout/data mismatch (e.g. a persisted
+     * UNIFIED_VOD layout with rows still stored as SPLIT-era MOVIE/SERIES types). Category and
+     * item ids are layout-independent, so relabeling preserves the indexed catalog instead of
+     * forcing a full re-download.
+     */
+    @Query("UPDATE categories SET type = :toType WHERE provider_id = :providerId AND type = :fromType")
+    suspend fun retargetType(providerId: Long, fromType: String, toType: String): Int
 }
 
 @Dao

--- a/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
@@ -208,8 +208,21 @@ class OkHttpStalkerApiService @Inject constructor(
                     val token = handshakePayload.findString("token")
                         ?.takeIf { it.isNotBlank() }
                         ?: run {
-                            lastError = IOException("Portal handshake did not return a token.")
-                            continue
+                            // A 200 without a token is the portal soft-throttling us. Treat it
+                            // like a 429: abort discovery instead of firing more handshakes
+                            // into the limiter, and let callers back off and retry later.
+                            val throttled = StalkerApiError.RateLimited(
+                                message = "Portal handshake did not return a token.",
+                                httpStatus = 200
+                            )
+                            StalkerTelemetry.authenticationAttempt(
+                                profile.providerId,
+                                recipe.compatibilityProfileId,
+                                endpointFamily,
+                                "HANDSHAKE",
+                                authenticationFailureOutcome(throttled)
+                            )
+                            return Result.error(throttled.message.orEmpty(), throttled)
                         }
                     val handshakeRandom = handshakePayload.findString("random").orEmpty()
                     resolvedLoadUrl(loadUrl, attemptProfile)?.let { redirectedLoadUrl ->

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiError.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerApiError.kt
@@ -143,3 +143,10 @@ internal fun isStalkerAuthorizationFailure(message: String, error: Throwable?): 
         "http 403"
     ).any(normalized::contains)
 }
+
+/**
+ * True when the portal is throttling us (hard 429 or a tokenless 200). Retrying with another
+ * handshake immediately only converts soft throttles into hard ones; callers must back off.
+ */
+internal fun Throwable.isPortalThrottle(): Boolean =
+    generateSequence(this) { it.cause }.any { it is StalkerApiError.RateLimited }

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerPortalStateStore.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerPortalStateStore.kt
@@ -7,6 +7,7 @@ import com.streamvault.domain.model.ContentType
 import com.streamvault.domain.model.StalkerCookieMode
 import com.streamvault.domain.model.StalkerEndpointPreference
 import com.streamvault.domain.model.StalkerPlaybackBackendHint
+import com.google.gson.Gson
 import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -15,6 +16,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
 @Singleton
 class StalkerPortalStateStore @Inject constructor(
@@ -22,6 +26,7 @@ class StalkerPortalStateStore @Inject constructor(
     private val providerSnapshotDao: ProviderSnapshotDao? = null
 ) {
     private val json = Json { ignoreUnknownKeys = true }
+    private val gson = Gson()
 
     suspend fun getValidated(providerId: Long, now: Long = System.currentTimeMillis()): StalkerPortalStateEntity? =
         dao.get(providerId)?.takeIf { state ->
@@ -29,6 +34,59 @@ class StalkerPortalStateStore @Inject constructor(
         }
 
     suspend fun get(providerId: Long): StalkerPortalStateEntity? = dao.get(providerId)
+
+    /**
+     * Durable session resurrected after a process restart. The portal token lives in
+     * app-private storage (same trust level as the encrypted provider credentials) and is
+     * only reused for the same configuration generation inside the local session age cap.
+     * A server-side rejected token costs one cheap profile call: the normal authorization
+     * retry path invalidates and falls back to a full handshake.
+     */
+    data class ResumedStalkerAuth(
+        val session: StalkerSession,
+        val profile: StalkerProviderProfile
+    )
+
+    suspend fun resumableAuth(
+        providerId: Long,
+        configurationGeneration: Long,
+        now: Long = System.currentTimeMillis(),
+        maxAgeMillis: Long = STALKER_SESSION_MAX_AGE_MILLIS
+    ): ResumedStalkerAuth? {
+        if (providerId <= 0L) return null
+        val state = dao.get(providerId) ?: return null
+        if (state.configurationGeneration != configurationGeneration) return null
+        val learning = runCatching {
+            json.parseToJsonElement(state.learningJson.ifBlank { "{}" }).jsonObject
+        }.getOrNull() ?: return null
+        if (learning["configurationGeneration"]?.jsonPrimitive?.longOrNull != configurationGeneration) {
+            return null
+        }
+        val session = runCatching {
+            gson.fromJson(learning["resumableSession"]?.jsonPrimitive?.content, StalkerSession::class.java)
+        }.getOrNull() ?: return null
+        val profile = runCatching {
+            gson.fromJson(learning["resumableProfile"]?.jsonPrimitive?.content, StalkerProviderProfile::class.java)
+        }.getOrNull() ?: return null
+        if (session.token.isBlank()) return null
+        if (profile.profileRevision != StalkerCompatibilityRegistry.REVISION) return null
+        if (now - session.authenticatedAtMillis > maxAgeMillis) return null
+        if (session.isExpired(now)) return null
+        if (profile.expirationDate?.let { it <= now } == true) return null
+        return ResumedStalkerAuth(session, profile)
+    }
+
+    /** Drops a persisted session (e.g. after the portal rejects its token) without touching hints. */
+    suspend fun clearResumableAuth(providerId: Long) {
+        if (providerId <= 0L) return
+        update(providerId) { state ->
+            val learning = mutableLearning(state.learningJson)
+            if (learning.remove("resumableSession") == null && learning.remove("resumableProfile") == null) {
+                return@update state
+            }
+            state.copy(learningJson = JsonObject(learning).toString())
+        }
+    }
 
     suspend fun recordAuthentication(
         providerId: Long,
@@ -358,6 +416,8 @@ class StalkerPortalStateStore @Inject constructor(
         learning["protocolFamily"] = observationJson(profile.protocolFamily.name, generation, observedAt, "AUTHENTICATION")
         learning["bootstrapRecipe"] = observationJson(profile.bootstrapRecipe.name, generation, observedAt, "AUTHENTICATION")
         learning["workingEndpoint"] = observationJson(session.loadUrl, generation, observedAt, "AUTHENTICATION")
+        learning["resumableSession"] = JsonPrimitive(gson.toJson(session))
+        learning["resumableProfile"] = JsonPrimitive(gson.toJson(profile))
         return JsonObject(learning).toString()
     }
 

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -138,6 +138,7 @@ internal companion object {
         private const val FALLBACK_SURROGATE_FLOOR = 4_000_000_000L
         const val CATALOG_LAYOUT_DETECTION_VERSION = 1
         private val sharedAuthCache = ConcurrentHashMap<String, CachedAuth>()
+        private val sharedPortalAuthCache = ConcurrentHashMap<String, CachedAuth>()
         private val sharedAuthFailureCache = ConcurrentHashMap<String, CachedAuthFailure>()
         private val sharedAuthMutexes = KeyedMutexRegistry<String>()
         private val resolvedStreamUrlCache = ConcurrentHashMap<String, CachedResolvedUrl>()
@@ -145,6 +146,7 @@ internal companion object {
 
         fun clearSharedAuthCacheForTests() {
             sharedAuthCache.clear()
+            sharedPortalAuthCache.clear()
             sharedAuthFailureCache.clear()
         }
 
@@ -157,6 +159,8 @@ internal companion object {
             if (providerId <= 0L) return
             val authPrefix = "provider:$providerId|"
             sharedAuthCache.keys.filter { it.startsWith(authPrefix) }.forEach(sharedAuthCache::remove)
+            val portalPrefix = "portal:$providerId|"
+            sharedPortalAuthCache.keys.filter { it.startsWith(portalPrefix) }.forEach(sharedPortalAuthCache::remove)
             sharedAuthFailureCache.keys.filter { it.startsWith(authPrefix) }.forEach(sharedAuthFailureCache::remove)
             resolvedStreamUrlCache.keys
                 .filter { it.startsWith("$providerId|") }
@@ -166,6 +170,7 @@ internal companion object {
 
         private fun trimSharedCaches() {
             trimMap(sharedAuthCache, MAX_AUTH_CACHE_ENTRIES)
+            trimMap(sharedPortalAuthCache, MAX_AUTH_CACHE_ENTRIES)
             trimMap(sharedAuthFailureCache, MAX_AUTH_CACHE_ENTRIES)
             trimMap(resolvedStreamUrlCache, MAX_RESOLVED_URL_CACHE_ENTRIES)
             while (missingVodClassificationLogged.size > MAX_MISSING_CLASSIFICATION_ENTRIES) {
@@ -223,7 +228,11 @@ internal companion object {
             authFailureCache = null
             categoryCache.clear()
             sharedAuthCache.remove(authCacheKey())
+            if (providerId > 0L) {
+                sharedPortalAuthCache.remove(portalIdentityKey())
+            }
             sharedAuthFailureCache.remove(authCacheKey())
+            portalStateStore?.clearResumableAuth(providerId)
             clearResolvedStreamUrlCache()
             api.invalidateSessionScopes(providerId)
         }
@@ -1402,6 +1411,9 @@ is Result.Success -> {
                 sessionCache = null
                 accountProfileCache = null
                 sharedAuthCache.remove(authCacheKey())
+                if (providerId > 0L) {
+                    sharedPortalAuthCache.remove(portalIdentityKey())
+                }
                 api.invalidateSessionScopes(providerId)
             }
             (authFailureCache ?: sharedAuthFailureCache[authCacheKey()])?.let { failure ->
@@ -1421,6 +1433,31 @@ is Result.Success -> {
                 }
                 sharedAuthCache.remove(authCacheKey(), cachedAuth)
                 api.invalidateSessionScopes(providerId)
+            }
+            if (providerId > 0L) {
+                sharedPortalAuthCache[portalIdentityKey()]?.let { cachedAuth ->
+                    if (!cachedAuth.session.isExpired() &&
+                        cachedAuth.profile.expirationDate?.let { it > System.currentTimeMillis() } != false
+                    ) {
+                        sessionCache = cachedAuth.session
+                        accountProfileCache = cachedAuth.profile
+                        sharedAuthCache[authCacheKey()] = cachedAuth
+                        return@withLock Result.success(cachedAuth.session to cachedAuth.profile)
+                    }
+                    sharedPortalAuthCache.remove(portalIdentityKey(), cachedAuth)
+                    api.invalidateSessionScopes(providerId)
+                }
+            }
+            if (providerId > 0L) {
+                portalStateStore?.resumableAuth(providerId, configurationGeneration)?.let { resumed ->
+                    sessionCache = resumed.session
+                    accountProfileCache = resumed.profile
+                    val cachedAuth = CachedAuth(session = resumed.session, profile = resumed.profile)
+                    sharedAuthCache[authCacheKey()] = cachedAuth
+                    sharedPortalAuthCache[portalIdentityKey()] = cachedAuth
+                    StalkerTelemetry.strategySelected(providerId, "RESUMED_SESSION", "PERSISTED_TOKEN")
+                    return@withLock Result.success(resumed.session to resumed.profile)
+                }
             }
 
             val persistedState = portalStateStore?.getValidated(providerId)
@@ -1485,8 +1522,17 @@ is Result.Success -> {
                 onProgress = onProgress
             ).copy(providerId = providerId)
             val initialAuthResult = discoveryCoordinator.authenticate(profile)
+            val initialAuthThrottled = (initialAuthResult as? Result.Error)?.exception?.isPortalThrottle() == true
             val finalAuthResult = when {
                 initialAuthResult !is Result.Error -> initialAuthResult
+                // A throttled portal must not get an instant repair handshake: the retry
+                // fires milliseconds later and converts a soft throttle into a hard 429.
+                // Surface the throttle so callers back off; the persisted session and
+                // failure cooldown already cover the retry.
+                initialAuthThrottled -> {
+                    StalkerTelemetry.strategySelected(providerId, "AUTH_THROTTLE_BACKOFF", "THROTTLED_AUTH_RETRY_SKIPPED")
+                    initialAuthResult
+                }
                 persistedEndpointUrl != null -> {
                     portalStateStore?.markEndpointUnhealthy(
                         providerId,
@@ -1532,6 +1578,12 @@ is Result.Success -> {
                         session = authResult.data.first,
                         profile = authResult.data.second
                     )
+                    if (providerId > 0L) {
+                        sharedPortalAuthCache[portalIdentityKey()] = CachedAuth(
+                            session = authResult.data.first,
+                            profile = authResult.data.second
+                        )
+                    }
                     trimSharedCaches()
                     portalStateStore?.recordAuthentication(
                         providerId = providerId,
@@ -2577,6 +2629,28 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
             .digest(normalized.toByteArray(Charsets.UTF_8))
             .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
         return "provider:$providerId|$digest"
+    }
+
+    /**
+     * Stable cross-instance session identity. Unlike [authCacheKey], this deliberately excludes
+     * volatile learned hints (fingerprint/recipe/endpoint/cookie/playback/profile/device extras)
+     * so a sync-side provider built from persisted learning can reuse the activation session
+     * instead of firing a second handshake into the portal rate limiter.
+     */
+    private fun portalIdentityKey(): String {
+        val normalized = listOf(
+            System.identityHashCode(api).toString(),
+            providerId.toString(),
+            StalkerUrlFactory.normalizePortalUrl(portalUrl),
+            normalizedMacAddress(),
+            authMode.name,
+            normalizedUsername(),
+            normalizedPassword()
+        ).joinToString(separator = "\u001f")
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(normalized.toByteArray(Charsets.UTF_8))
+            .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+        return "portal:$providerId|$digest"
     }
 
     private fun authMutexKey(): String = "provider:$providerId|auth"

--- a/data/src/main/java/com/streamvault/data/sync/StalkerCatalogSyncExecutor.kt
+++ b/data/src/main/java/com/streamvault/data/sync/StalkerCatalogSyncExecutor.kt
@@ -145,6 +145,7 @@ internal class StalkerCatalogSyncExecutor(
             }
         }
         readinessTracker.authenticated(provider.id)
+        reconcileStoredCategoryTypes(provider.id, effectiveCatalogLayout)
 
         var metadata = syncMetadataRepository.getMetadata(provider.id) ?: SyncMetadata(provider.id)
         val now = System.currentTimeMillis()
@@ -342,6 +343,39 @@ internal class StalkerCatalogSyncExecutor(
                 preservedActiveCatalog -> SyncActivation.PRESERVED_ACTIVE_CATALOG
                 else -> SyncActivation.NO_CATALOG_CHANGE
             }
+        )
+    }
+
+    /**
+     * Repairs a persisted-layout/stored-rows mismatch without re-downloading the catalog.
+     * Category and item ids are layout-independent, so when the effective layout is
+     * UNIFIED_VOD but rows are still stored as SPLIT-era MOVIE types (or vice versa), relabeling
+     * the 60-odd category rows heals every reader. A full type rewrite stays reserved for the
+     * section below, which runs only when the portal actually returns fresh categories.
+     */
+    private suspend fun reconcileStoredCategoryTypes(
+        providerId: Long,
+        effectiveCatalogLayout: CatalogLayout
+    ) {
+        if (effectiveCatalogLayout != CatalogLayout.UNIFIED_VOD &&
+            effectiveCatalogLayout != CatalogLayout.SPLIT
+        ) {
+            return
+        }
+        val (expectedType, legacyType) = if (effectiveCatalogLayout == CatalogLayout.UNIFIED_VOD) {
+            ContentType.VOD.name to ContentType.MOVIE.name
+        } else {
+            ContentType.MOVIE.name to ContentType.VOD.name
+        }
+        val expected = categoryDao.getByProviderAndTypeSync(providerId, expectedType)
+        if (expected.isNotEmpty()) return
+        val legacy = categoryDao.getByProviderAndTypeSync(providerId, legacyType)
+        if (legacy.isEmpty()) return
+        val relabeled = categoryDao.retargetType(providerId, legacyType, expectedType)
+        Log.i(
+            STALKER_EXECUTOR_TAG,
+            "Retargeted $relabeled $legacyType categories to $expectedType for provider $providerId " +
+                "to match $effectiveCatalogLayout without re-downloading items."
         )
     }
 

--- a/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiServiceTest.kt
@@ -2953,6 +2953,35 @@ class OkHttpStalkerApiServiceTest {
     }
 
     @Test
+    fun authenticate_tokenlessHandshake_abortsAsRateLimitedWithoutFurtherHandshakes() = runTest {
+        val requestedActions = mutableListOf<String>()
+        val service = OkHttpStalkerApiService(
+            okHttpClient = OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val request = chain.request()
+                    requestedActions += request.url.queryParameter("action").orEmpty()
+                    Response.Builder()
+                        .request(request)
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body("""{"js":{}}""".toResponseBody("application/json".toMediaType()))
+                        .build()
+                }
+                .build(),
+            json = Json { ignoreUnknownKeys = true }
+        )
+
+        val result = service.authenticate(stalkerProfile())
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        val error = result as Result.Error
+        assertThat(error.exception).isInstanceOf(StalkerApiError.RateLimited::class.java)
+        // Soft throttle: no recipe-loop follow-up handshake may fire into the limiter.
+        assertThat(requestedActions).containsExactly("handshake")
+    }
+
+    @Test
     fun authenticate_classifies_status2_envelope_as_device_not_registered() = runTest {
         val service = OkHttpStalkerApiService(
             okHttpClient = OkHttpClient.Builder()

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerPortalStateStoreTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerPortalStateStoreTest.kt
@@ -144,8 +144,36 @@ class StalkerPortalStateStoreTest {
             .isEqualTo("https://portal.test/load.php")
     }
 
-    private class FakePortalStateDao : StalkerPortalStateDao {
-        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
+    @Test
+    fun `resumable session round-trips and respects generation age and clearing`() = runTest {
+        val dao = FakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        val session = StalkerSession(
+            loadUrl = "https://portal.test/load.php",
+            portalReferer = "https://portal.test/c/",
+            token = "tok123"
+        ).copy(authenticatedAtMillis = 10_000L)
+        store.recordAuthentication(
+            providerId = 11L,
+            session = session,
+            profile = StalkerProviderProfile(accountName = "Room"),
+            now = 10_000L,
+            configurationGeneration = 7L
+        )
+
+        val resumed = store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 70_000L)
+        assertThat(resumed?.session?.token).isEqualTo("tok123")
+        assertThat(resumed?.profile?.accountName).isEqualTo("Room")
+
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 8L, now = 70_000L)).isNull()
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 10_000L + 31L * 60L * 1000L)).isNull()
+        assertThat(store.resumableAuth(providerId = 99L, configurationGeneration = 7L, now = 70_000L)).isNull()
+
+        store.clearResumableAuth(11L)
+        assertThat(store.resumableAuth(providerId = 11L, configurationGeneration = 7L, now = 70_000L)).isNull()
+    }
+
+    private class FakePortalStateDao : StalkerPortalStateDao {        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
 
         override suspend fun get(providerId: Long): StalkerPortalStateEntity? = rows[providerId]
 

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -1077,6 +1077,136 @@ class StalkerProviderTest {
     }
 
     @Test
+    fun authenticate_reusesSessionAcrossInstancesWithDifferentLearnedHints() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room")
+        )
+        val activation = StalkerProvider(
+            providerId = 21,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        assertThat(activation.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+
+        // Sync-side instance built from persisted learning: same portal identity, but
+        // different volatile hints. Must reuse the session, not fire a second handshake.
+        val sync = StalkerProvider(
+            providerId = 21,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            portalFingerprintHint = com.streamvault.domain.model.StalkerPortalFingerprint.STRICT_MAG,
+            magPresetHint = com.streamvault.domain.model.StalkerMagPreset.MAG254_STRICT,
+            bootstrapRecipeHint = com.streamvault.domain.model.StalkerBootstrapRecipe.STRICT_MAG,
+            endpointPreferenceHint = com.streamvault.domain.model.StalkerEndpointPreference.SERVER_LOAD,
+            cookieModeHint = com.streamvault.domain.model.StalkerCookieMode.BOTH,
+            deviceProfile = "MAG254",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        assertThat(sync.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun authenticate_resumesPersistedSessionAfterProcessRestartWithoutHandshake() = runTest {
+        val dao = ResumableAuthFakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room")
+        )
+        val first = StalkerProvider(
+            providerId = 22,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        assertThat(first.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+
+        // Simulate a process restart: all in-memory session caches are gone, but the
+        // persisted portal state (same DB) survives. No handshake may fire.
+        StalkerProvider.clearSharedAuthCacheForTests()
+        val restarted = StalkerProvider(
+            providerId = 22,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            portalFingerprintHint = com.streamvault.domain.model.StalkerPortalFingerprint.STRICT_MAG,
+            deviceProfile = "MAG254",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        assertThat(restarted.authenticate()).isInstanceOf(Result.Success::class.java)
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun authenticate_skipsEndpointRepairRetryWhenThrottled() = runTest {
+        val dao = ResumableAuthFakePortalStateDao()
+        val store = StalkerPortalStateStore(dao)
+        // Arm the cached-endpoint repair path (working endpoint + recipe) but leave no
+        // resumable session, so authentication must go to the wire exactly once.
+        store.recordAuthentication(
+            providerId = 23,
+            session = StalkerSession(
+                loadUrl = "https://portal.example.com/server/load.php",
+                portalReferer = "https://portal.example.com/c/",
+                token = "stale-token"
+            ),
+            profile = StalkerProviderProfile(accountName = "Room"),
+            configurationGeneration = 0L
+        )
+        store.clearResumableAuth(23)
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            authenticationError = StalkerApiError.RateLimited()
+        )
+        val provider = StalkerProvider(
+            providerId = 23,
+            api = api,
+            portalUrl = "https://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en",
+            portalStateStore = store
+        )
+
+        val result = provider.authenticate()
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
+        // The repair retry would fire a second handshake milliseconds later and convert
+        // a soft throttle into a hard 429. It must be skipped.
+        assertThat(api.authenticateCalls).isEqualTo(1)
+    }
+
+    private class ResumableAuthFakePortalStateDao : StalkerPortalStateDao {        private val rows = mutableMapOf<Long, StalkerPortalStateEntity>()
+
+        override suspend fun get(providerId: Long): StalkerPortalStateEntity? = rows[providerId]
+
+        override suspend fun upsert(entity: StalkerPortalStateEntity) {
+            rows[entity.providerId] = entity
+        }
+
+        override suspend fun invalidate(providerId: Long): Int = if (rows.remove(providerId) != null) 1 else 0
+    }
+
+    @Test
     fun resolvePlaybackInfo_dedicatedPlayerUserAgentOverridesCustomHeaderUserAgent() = runTest {
         val provider = StalkerProvider(
             providerId = 7,
@@ -1124,7 +1254,8 @@ class StalkerProviderTest {
         private val seriesCategoriesResult: Result<List<StalkerCategoryRecord>>? = null,
         private val vodPageItems: List<StalkerItemRecord> = emptyList(),
         private val seriesPageItems: List<StalkerItemRecord> = emptyList(),
-        private var authenticationFailuresBeforeSuccess: Int = 0
+        private var authenticationFailuresBeforeSuccess: Int = 0,
+        private var authenticationError: Throwable? = null
     ) : StalkerApiService {
         var createLinkCalls: Int = 0
             private set
@@ -1139,6 +1270,9 @@ class StalkerProviderTest {
             if (authenticationFailuresBeforeSuccess > 0) {
                 authenticationFailuresBeforeSuccess -= 1
                 return Result.error("authentication failed")
+            }
+            authenticationError?.let { error ->
+                return Result.error(error.message.orEmpty(), error)
             }
             return Result.success(
                 StalkerSession(


### PR DESCRIPTION
Hardens Stalker sync against portals that throttle requests or whose stored catalog layout drifts from the effective layout.

**Rate-limit handling**
- A token-less 200 handshake is now treated as a soft throttle (equivalent to a 429) instead of firing another handshake, which only escalates soft throttles into hard ones. Discovery stops and callers back off and retry later.
- Adds `StalkerApiError.RateLimited` and a helper that detects throttling anywhere in an error's cause chain.

**Session resilience**
- Persists a resumable portal session (token + profile) in app-private storage after successful authentication so a process restart can skip the full handshake. Sessions are only reused for the same configuration generation within a bounded age; a server-rejected token falls back to the normal authorization retry path and clears the stored session.

**Layout drift repair**
- `reconcileStoredCategoryTypes()` relabels category rows in place when the effective catalog layout no longer matches how rows are stored (e.g. a UNIFIED_VOD portal still storing SPLIT-era MOVIE categories). Category ids are layout-independent, so every reader heals without a full catalog re-download.
