### PR TITLE
fix: fetch stalker guide on demand via numeric short-EPG ids

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/model/GuideCachePolicy.kt
+++ b/app/src/main/java/com/streamvault/app/ui/model/GuideCachePolicy.kt
@@ -1,0 +1,63 @@
+package com.streamvault.app.ui.model
+
+import com.streamvault.domain.model.Channel
+import com.streamvault.domain.model.Program
+
+/**
+ * Shared policy for on-demand guide hydration (get_short_epg / now-playing fallback).
+ *
+ * Both the EPG grid and the Home now-playing strip issue paced portal requests per channel.
+ * To avoid re-fetching channels that are known to carry no guide data, the requestable
+ * filter below must be applied by every caller:
+ *  - Portal EPG ids that are shared placeholders (e.g. Ministra's "glotv") never carry a
+ *    per-channel schedule; they must never be fetched or displayed as if they had data.
+ *  - Keys whose on-demand fetch recently returned empty are skipped until the TTL elapses
+ *    (in-memory for the session, and durably per provider across launches).
+ */
+object GuideCachePolicy {
+    /** Portal EPG ids that are shared placeholders with no per-channel schedule. */
+    val EPG_SENTINEL_KEYS: Set<String> = setOf("glotv")
+
+    /** Re-probe a channel whose on-demand fetch returned empty after this long. */
+    const val GUIDE_EMPTY_KEY_TTL_MILLIS: Long = 24 * 60 * 60 * 1000L
+
+    fun isSentinelKey(lookupKey: String): Boolean = lookupKey in EPG_SENTINEL_KEYS
+
+    /** Whether a durable empty-key record is still inside its TTL (i.e. skip the fetch). */
+    fun isEmptyKeyFresh(
+        persistedEmptyAt: Map<String, Long>,
+        lookupKey: String,
+        now: Long
+    ): Boolean = persistedEmptyAt[lookupKey]?.let { now - it < GUIDE_EMPTY_KEY_TTL_MILLIS } == true
+
+    /**
+     * Channels worth spending a paced on-demand guide request on. A channel is requestable
+     * when it has a guide lookup key that is not a sentinel placeholder, is not remembered
+     * as empty (session or durable cache), and has no programs already in the snapshot.
+     *
+     * @param sessionEmptyKeys keys that returned empty this session (never re-probed)
+     * @param persistedEmptyAt durable empty-key cache per provider: lookup key -> last empty epoch millis
+     * @param existingProgramsByChannel programs already present for the window (by lookup key)
+     */
+    fun requestableChannels(
+        channels: List<Channel>,
+        sessionEmptyKeys: Set<String>,
+        persistedEmptyAt: Map<String, Long>,
+        existingProgramsByChannel: Map<String, List<Program>>,
+        now: Long = System.currentTimeMillis()
+    ): List<Channel> = channels.filter { channel ->
+        val lookupKey = channel.guideLookupKey()
+        lookupKey != null &&
+            lookupKey !in sessionEmptyKeys &&
+            lookupKey !in EPG_SENTINEL_KEYS &&
+            !isEmptyKeyFresh(persistedEmptyAt, lookupKey, now) &&
+            channel.streamId > 0L &&
+            existingProgramsByChannel[lookupKey].isNullOrEmpty()
+    }
+
+    /** Sentinel keys present in the given channels; record them as empty without a request. */
+    fun sentinelKeysOf(channels: List<Channel>): Set<String> =
+        channels.mapNotNull(Channel::guideLookupKey)
+            .filter { it in EPG_SENTINEL_KEYS }
+            .toSet()
+}

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
@@ -1,5 +1,6 @@
 package com.streamvault.app.ui.screens.epg
 
+import com.streamvault.app.ui.model.GuideCachePolicy
 import com.streamvault.app.ui.model.isArchivePlayable
 import com.streamvault.app.ui.model.guideLookupKey
 import androidx.lifecycle.ViewModel
@@ -293,14 +294,9 @@ class EpgViewModel @Inject constructor(
         const val MAX_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS = 6
-        // Portal EPG ids that are shared placeholders with no per-channel schedule. They must
-        // never be fetched (they waste a paced request) or displayed as if they carried data.
-        private val EPG_SENTINEL_KEYS = setOf("glotv")
         // Fetch guide fallback in small chunks so the grid fills progressively instead of
         // waiting for the whole page of paced requests.
         private const val GUIDE_FALLBACK_CHUNK_SIZE = 12
-        // Re-probe a channel whose on-demand fetch returned empty after this long.
-        private const val GUIDE_EMPTY_KEY_TTL_MILLIS = 24 * 60 * 60 * 1000L
         const val LOOKBACK_MS = 60 * 60 * 1000L
         const val LOOKAHEAD_MS = 6 * 60 * 60 * 1000L
         const val HALF_HOUR_SHIFT_MS = 30 * 60 * 1000L
@@ -1733,7 +1729,7 @@ class EpgViewModel @Inject constructor(
         // Sentinel keys (shared portal placeholders like "glotv") must never surface cached
         // placeholder rows as if they were this channel's real schedule.
         val programsByChannel = (resolvedPrograms + legacyPrograms)
-            .filterKeys { it !in EPG_SENTINEL_KEYS }
+            .filterKeys { it !in GuideCachePolicy.EPG_SENTINEL_KEYS }
         return GuideProgramsResult(
             programsByChannel = programsByChannel,
             failedCount = countMissingGuideEntries(channels, programsByChannel)
@@ -1860,28 +1856,21 @@ class EpgViewModel @Inject constructor(
 
         ensurePersistedEmptyGuideKeys(providerId)
         val persistedFresh = persistedEmptyGuideKeys[providerId].orEmpty()
-        val now = System.currentTimeMillis()
 
         // Sentinel keys (shared portal placeholders) never carry a real schedule; remember
         // them as empty without spending a paced request.
-        val sentinelKeys = channels.mapNotNull(Channel::guideLookupKey)
-            .filter { it in EPG_SENTINEL_KEYS }
-            .toSet()
+        val sentinelKeys = GuideCachePolicy.sentinelKeysOf(channels)
         if (sentinelKeys.isNotEmpty()) {
             knownEmptyGuideKeys += sentinelKeys
             preferencesRepository.addEmptyGuideKeys(providerId, sentinelKeys)
         }
 
-        val missingChannels = channels.filter { channel ->
-            val lookupKey = channel.guideLookupKey()
-            lookupKey != null &&
-                lookupKey !in knownEmptyGuideKeys &&
-                // Durable empty-key cache: skip ids that returned empty recently instead of
-                // re-fetching them on every page visit / app launch.
-                persistedFresh[lookupKey]?.let { now - it < GUIDE_EMPTY_KEY_TTL_MILLIS } != true &&
-                channel.streamId > 0L &&
-                existingProgramsByChannel[lookupKey].isNullOrEmpty()
-        }
+        val missingChannels = GuideCachePolicy.requestableChannels(
+            channels = channels,
+            sessionEmptyKeys = knownEmptyGuideKeys,
+            persistedEmptyAt = persistedFresh,
+            existingProgramsByChannel = existingProgramsByChannel
+        )
         if (missingChannels.isEmpty()) {
             return emptyMap()
         }

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
@@ -293,6 +293,14 @@ class EpgViewModel @Inject constructor(
         const val MAX_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS = 6
+        // Portal EPG ids that are shared placeholders with no per-channel schedule. They must
+        // never be fetched (they waste a paced request) or displayed as if they carried data.
+        private val EPG_SENTINEL_KEYS = setOf("glotv")
+        // Fetch guide fallback in small chunks so the grid fills progressively instead of
+        // waiting for the whole page of paced requests.
+        private const val GUIDE_FALLBACK_CHUNK_SIZE = 12
+        // Re-probe a channel whose on-demand fetch returned empty after this long.
+        private const val GUIDE_EMPTY_KEY_TTL_MILLIS = 24 * 60 * 60 * 1000L
         const val LOOKBACK_MS = 60 * 60 * 1000L
         const val LOOKAHEAD_MS = 6 * 60 * 60 * 1000L
         const val HALF_HOUR_SHIFT_MS = 30 * 60 * 1000L
@@ -322,11 +330,14 @@ class EpgViewModel @Inject constructor(
     val programReminderUiState: StateFlow<ProgramReminderUiState> = _programReminderUiState.asStateFlow()
     private var overrideSearchJob: Job? = null
     private var guideFallbackJob: Job? = null
+    private var guideFallbackContext: GuideFallbackContext? = null
     private var prefetchJob: Deferred<GuidePrefetchedPage?>? = null
     private var loadMoreJob: Job? = null
     // Guide keys that returned successfully-but-empty from on-demand fetch this session.
     // Skipped on later pages so channels without portal EPG don't cost a request per visit.
     private val knownEmptyGuideKeys = mutableSetOf<String>()
+    // Durable empty-key cache (per provider) so the same ids are not re-fetched after relaunch.
+    private val persistedEmptyGuideKeys = mutableMapOf<Long, Map<String, Long>>()
     private var combinedCategoriesById: Map<Long, CombinedCategory> = emptyMap()
     private var previewPlayerEngine: PlayerEngine? = null
     private var previewSessionVersion: Long = 0L
@@ -1719,7 +1730,10 @@ class EpgViewModel @Inject constructor(
             emptyMap()
         }
 
-        val programsByChannel = resolvedPrograms + legacyPrograms
+        // Sentinel keys (shared portal placeholders like "glotv") must never surface cached
+        // placeholder rows as if they were this channel's real schedule.
+        val programsByChannel = (resolvedPrograms + legacyPrograms)
+            .filterKeys { it !in EPG_SENTINEL_KEYS }
         return GuideProgramsResult(
             programsByChannel = programsByChannel,
             failedCount = countMissingGuideEntries(channels, programsByChannel)
@@ -1762,7 +1776,15 @@ class EpgViewModel @Inject constructor(
         channels: List<Channel>,
         existingProgramsByChannel: Map<String, List<Program>>
     ) {
+        // The guide observation re-emits whenever any upstream flow changes (e.g. the
+        // catalog sync writing categories/channels). Cancelling and restarting an identical
+        // in-flight fallback would starve the chunked short-EPG fetch before it completes,
+        // so let a matching job run to completion and only (re)start when the context differs.
+        if (guideFallbackJob?.isActive == true && guideFallbackContext == snapshotContext) {
+            return
+        }
         guideFallbackJob?.cancel()
+        guideFallbackContext = snapshotContext
         if (channels.isEmpty()) {
             return
         }
@@ -1777,33 +1799,41 @@ class EpgViewModel @Inject constructor(
                         channels = providerChannels,
                         existingProgramsByChannel = existingProgramsByChannel + this,
                         windowStart = snapshotContext.guideWindowStart,
-                        windowEnd = snapshotContext.guideWindowEnd
+                        windowEnd = snapshotContext.guideWindowEnd,
+                        // Publish each fetched chunk so the grid fills progressively instead of
+                        // waiting for the entire page of paced requests.
+                        onPartial = { additions -> publishGuideFallbackUpdate(snapshotContext, additions) }
                     )
                     putAll(providerPrograms)
                 }
             }
-            if (fallbackProgramsByChannel.isEmpty()) {
-                return@launch
+            // Final pass covers any additions that were not published incrementally.
+            publishGuideFallbackUpdate(snapshotContext, fallbackProgramsByChannel)
+        }
+    }
+
+    private fun publishGuideFallbackUpdate(
+        snapshotContext: GuideFallbackContext,
+        additions: Map<String, List<Program>>
+    ) {
+        if (additions.isEmpty()) return
+        baseGuideSnapshot.update { currentSnapshot ->
+            if (currentSnapshot == null || !currentSnapshot.matches(snapshotContext)) {
+                return@update currentSnapshot
             }
 
-            baseGuideSnapshot.update { currentSnapshot ->
-                if (currentSnapshot == null || !currentSnapshot.matches(snapshotContext)) {
-                    return@update currentSnapshot
-                }
+            val mergedProgramsByChannel = currentSnapshot.baseProgramsByChannel + additions
+            val visibleChannels = currentSnapshot.visibleChannels
+            val channelsWithSchedule = countChannelsWithSchedule(visibleChannels, mergedProgramsByChannel)
+            val hasUpcomingData = hasUpcomingGuideData(mergedProgramsByChannel, currentSnapshot.guideWindowStart)
 
-                val mergedProgramsByChannel = currentSnapshot.baseProgramsByChannel + fallbackProgramsByChannel
-                val visibleChannels = currentSnapshot.visibleChannels
-                val channelsWithSchedule = countChannelsWithSchedule(visibleChannels, mergedProgramsByChannel)
-                val hasUpcomingData = hasUpcomingGuideData(mergedProgramsByChannel, currentSnapshot.guideWindowStart)
-
-                currentSnapshot.copy(
-                    baseProgramsByChannel = mergedProgramsByChannel,
-                    failedScheduleCount = countMissingGuideEntries(visibleChannels, mergedProgramsByChannel),
-                    lastUpdatedAt = System.currentTimeMillis(),
-                    baseChannelsWithSchedule = channelsWithSchedule,
-                    baseGuideStale = visibleChannels.isNotEmpty() && (channelsWithSchedule == 0 || !hasUpcomingData)
-                )
-            }
+            currentSnapshot.copy(
+                baseProgramsByChannel = mergedProgramsByChannel,
+                failedScheduleCount = countMissingGuideEntries(visibleChannels, mergedProgramsByChannel),
+                lastUpdatedAt = System.currentTimeMillis(),
+                baseChannelsWithSchedule = channelsWithSchedule,
+                baseGuideStale = visibleChannels.isNotEmpty() && (channelsWithSchedule == 0 || !hasUpcomingData)
+            )
         }
     }
 
@@ -1813,7 +1843,8 @@ class EpgViewModel @Inject constructor(
         channels: List<Channel>,
         existingProgramsByChannel: Map<String, List<Program>>,
         windowStart: Long,
-        windowEnd: Long
+        windowEnd: Long,
+        onPartial: (Map<String, List<Program>>) -> Unit = {}
     ): Map<String, List<Program>> {
         if (provider.guideSourcePolicy == GuideSourcePolicy.EXTERNAL_ONLY ||
             provider.guideSourcePolicy == GuideSourcePolicy.DISABLED
@@ -1827,10 +1858,27 @@ class EpgViewModel @Inject constructor(
             return emptyMap()
         }
 
+        ensurePersistedEmptyGuideKeys(providerId)
+        val persistedFresh = persistedEmptyGuideKeys[providerId].orEmpty()
+        val now = System.currentTimeMillis()
+
+        // Sentinel keys (shared portal placeholders) never carry a real schedule; remember
+        // them as empty without spending a paced request.
+        val sentinelKeys = channels.mapNotNull(Channel::guideLookupKey)
+            .filter { it in EPG_SENTINEL_KEYS }
+            .toSet()
+        if (sentinelKeys.isNotEmpty()) {
+            knownEmptyGuideKeys += sentinelKeys
+            preferencesRepository.addEmptyGuideKeys(providerId, sentinelKeys)
+        }
+
         val missingChannels = channels.filter { channel ->
             val lookupKey = channel.guideLookupKey()
             lookupKey != null &&
                 lookupKey !in knownEmptyGuideKeys &&
+                // Durable empty-key cache: skip ids that returned empty recently instead of
+                // re-fetching them on every page visit / app launch.
+                persistedFresh[lookupKey]?.let { now - it < GUIDE_EMPTY_KEY_TTL_MILLIS } != true &&
                 channel.streamId > 0L &&
                 existingProgramsByChannel[lookupKey].isNullOrEmpty()
         }
@@ -1839,43 +1887,69 @@ class EpgViewModel @Inject constructor(
         }
 
         val fallbackChannels = missingChannels.take(MAX_XTREAM_GUIDE_FALLBACK_CHANNELS)
-        val programsByRequest = providerRepository.getProgramsForLiveStreams(
-            providerId = providerId,
-            requests = fallbackChannels.map { channel ->
-                LiveStreamProgramRequest(
-                    streamId = channel.streamId,
-                    epgChannelId = channel.epgChannelId
-                )
-            },
-            limit = MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS
-        )
+        val result = linkedMapOf<String, List<Program>>()
 
-        return fallbackChannels.mapNotNull { channel ->
-            val fetchResult = programsByRequest[
-                LiveStreamProgramRequest(
-                    streamId = channel.streamId,
-                    epgChannelId = channel.epgChannelId
-                )
-            ]
-            val programs = (fetchResult as? com.streamvault.domain.model.Result.Success)?.data
-                .orEmpty()
-                .filter { program -> program.endTime > windowStart && program.startTime < windowEnd }
-                .sortedBy { program -> program.startTime }
-            val lookupKey = channel.guideLookupKey() ?: return@mapNotNull null
-            if (programs.isEmpty()) {
-                // Successful but empty: the portal has no guide for this channel right
-                // now. Remember for this session so later pages skip it instantly.
-                // Errors are left out so transient failures retry on the next page.
-                if (fetchResult is com.streamvault.domain.model.Result.Success) {
-                    knownEmptyGuideKeys += lookupKey
+        // Fetch in small chunks so partial results can be published as they land; a full
+        // page of paced short-EPG requests would otherwise hold the grid empty for a minute.
+        fallbackChannels.chunked(GUIDE_FALLBACK_CHUNK_SIZE).forEach { chunk ->
+            val programsByRequest = providerRepository.getProgramsForLiveStreams(
+                providerId = providerId,
+                requests = chunk.map { channel ->
+                    LiveStreamProgramRequest(
+                        streamId = channel.streamId,
+                        epgChannelId = channel.epgChannelId
+                    )
+                },
+                limit = MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS
+            )
+            val newlyEmpty = mutableSetOf<String>()
+            val recovered = mutableSetOf<String>()
+
+            chunk.forEach { channel ->
+                val fetchResult = programsByRequest[
+                    LiveStreamProgramRequest(
+                        streamId = channel.streamId,
+                        epgChannelId = channel.epgChannelId
+                    )
+                ]
+                val programs = (fetchResult as? com.streamvault.domain.model.Result.Success)?.data
+                    .orEmpty()
+                    .filter { program -> program.endTime > windowStart && program.startTime < windowEnd }
+                    .sortedBy { program -> program.startTime }
+                val lookupKey = channel.guideLookupKey() ?: return@forEach
+                if (programs.isEmpty()) {
+                    // Successful but empty: the portal has no guide for this channel right
+                    // now. Remember it in-memory and durably so later pages and future
+                    // sessions skip it instantly. Errors are left out so transient failures
+                    // retry on the next page.
+                    if (fetchResult is com.streamvault.domain.model.Result.Success) {
+                        newlyEmpty += lookupKey
+                    }
+                } else {
+                    // Fresh data may have appeared since a previous empty result.
+                    recovered += lookupKey
+                    result[lookupKey] = programs
                 }
-                null
-            } else {
-                // Fresh data may have appeared since a previous empty result.
-                knownEmptyGuideKeys -= lookupKey
-                lookupKey to programs
             }
-        }.toMap()
+            if (newlyEmpty.isNotEmpty()) {
+                knownEmptyGuideKeys += newlyEmpty
+                preferencesRepository.addEmptyGuideKeys(providerId, newlyEmpty)
+            }
+            if (recovered.isNotEmpty()) {
+                knownEmptyGuideKeys -= recovered
+                preferencesRepository.removeEmptyGuideKeys(providerId, recovered)
+            }
+            if (result.isNotEmpty()) {
+                onPartial(result)
+            }
+        }
+        return result
+    }
+
+    private suspend fun ensurePersistedEmptyGuideKeys(providerId: Long) {
+        if (providerId !in persistedEmptyGuideKeys) {
+            persistedEmptyGuideKeys[providerId] = preferencesRepository.getEmptyGuideKeys(providerId)
+        }
     }
 
     private fun GuideBaseSnapshot.matches(context: GuideFallbackContext): Boolean =

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgViewModel.kt
@@ -291,7 +291,7 @@ class EpgViewModel @Inject constructor(
 
     companion object {
         const val MAX_CHANNELS = 60
-        private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 10
+        private const val MAX_XTREAM_GUIDE_FALLBACK_CHANNELS = 60
         private const val MAX_XTREAM_GUIDE_FALLBACK_PROGRAMS = 6
         const val LOOKBACK_MS = 60 * 60 * 1000L
         const val LOOKAHEAD_MS = 6 * 60 * 60 * 1000L
@@ -324,6 +324,9 @@ class EpgViewModel @Inject constructor(
     private var guideFallbackJob: Job? = null
     private var prefetchJob: Deferred<GuidePrefetchedPage?>? = null
     private var loadMoreJob: Job? = null
+    // Guide keys that returned successfully-but-empty from on-demand fetch this session.
+    // Skipped on later pages so channels without portal EPG don't cost a request per visit.
+    private val knownEmptyGuideKeys = mutableSetOf<String>()
     private var combinedCategoriesById: Map<Long, CombinedCategory> = emptyMap()
     private var previewPlayerEngine: PlayerEngine? = null
     private var previewSessionVersion: Long = 0L
@@ -1827,6 +1830,7 @@ class EpgViewModel @Inject constructor(
         val missingChannels = channels.filter { channel ->
             val lookupKey = channel.guideLookupKey()
             lookupKey != null &&
+                lookupKey !in knownEmptyGuideKeys &&
                 channel.streamId > 0L &&
                 existingProgramsByChannel[lookupKey].isNullOrEmpty()
         }
@@ -1847,17 +1851,30 @@ class EpgViewModel @Inject constructor(
         )
 
         return fallbackChannels.mapNotNull { channel ->
-            val programs = (programsByRequest[
+            val fetchResult = programsByRequest[
                 LiveStreamProgramRequest(
                     streamId = channel.streamId,
                     epgChannelId = channel.epgChannelId
                 )
-            ] as? com.streamvault.domain.model.Result.Success)?.data
+            ]
+            val programs = (fetchResult as? com.streamvault.domain.model.Result.Success)?.data
                 .orEmpty()
                 .filter { program -> program.endTime > windowStart && program.startTime < windowEnd }
                 .sortedBy { program -> program.startTime }
             val lookupKey = channel.guideLookupKey() ?: return@mapNotNull null
-            if (programs.isEmpty()) null else lookupKey to programs
+            if (programs.isEmpty()) {
+                // Successful but empty: the portal has no guide for this channel right
+                // now. Remember for this session so later pages skip it instantly.
+                // Errors are left out so transient failures retry on the next page.
+                if (fetchResult is com.streamvault.domain.model.Result.Success) {
+                    knownEmptyGuideKeys += lookupKey
+                }
+                null
+            } else {
+                // Fresh data may have appeared since a previous empty result.
+                knownEmptyGuideKeys -= lookupKey
+                lookupKey to programs
+            }
         }.toMap()
     }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeViewModel.kt
@@ -8,6 +8,7 @@ import com.streamvault.app.player.PreviewHandoffSource
 import com.streamvault.app.plugins.StreamVaultPluginManager
 import com.streamvault.app.tvinput.TvInputChannelSyncManager
 import com.streamvault.app.ui.screens.multiview.MultiViewManager
+import com.streamvault.app.ui.model.GuideCachePolicy
 import com.streamvault.app.ui.model.applyProviderCategoryDisplayPreferences
 import com.streamvault.app.ui.model.orderedByRequestedRawIds
 import com.streamvault.app.ui.model.guideLookupKey
@@ -114,6 +115,9 @@ class HomeViewModel @Inject constructor(
     private val _preferredInitialCategoryId = MutableStateFlow<Long?>(null)
     private val _visibleChannelWindow = MutableStateFlow<Set<Long>>(emptySet())
     private val _epgProgramMap = MutableStateFlow<Map<String, Program>>(emptyMap())
+    // Guide keys that returned successfully-but-empty this session; skipped by later
+    // now-playing fallback runs so the same paced requests are not repeated.
+    private val homeSessionEmptyGuideKeys = mutableSetOf<String>()
     private var epgJob: Job? = null
     private var loadChannelsJob: Job? = null
     private var categoriesJob: Job? = null
@@ -1288,12 +1292,21 @@ class HomeViewModel @Inject constructor(
             return emptyMap()
         }
 
-        val missingChannels = channels.filter { channel ->
-            val lookupKey = channel.guideLookupKey()
-            lookupKey != null &&
-                channel.streamId > 0L &&
-                !existingPrograms.containsKey(lookupKey)
+        // Sentinel keys (shared portal placeholders like "glotv") never carry a schedule;
+        // remember them as empty without spending a paced request.
+        val sentinelKeys = GuideCachePolicy.sentinelKeysOf(channels)
+        if (sentinelKeys.isNotEmpty()) {
+            homeSessionEmptyGuideKeys += sentinelKeys
+            preferencesRepository.addEmptyGuideKeys(providerId, sentinelKeys)
         }
+
+        val persistedEmpty = preferencesRepository.getEmptyGuideKeys(providerId)
+        val missingChannels = GuideCachePolicy.requestableChannels(
+            channels = channels,
+            sessionEmptyKeys = homeSessionEmptyGuideKeys,
+            persistedEmptyAt = persistedEmpty,
+            existingProgramsByChannel = existingPrograms.mapValues { (_, program) -> listOf(program) }
+        )
         if (missingChannels.isEmpty()) {
             return emptyMap()
         }
@@ -1311,18 +1324,41 @@ class HomeViewModel @Inject constructor(
             limit = 6
         )
 
-        return fallbackChannels.mapNotNull { channel ->
-            val programs = (programsByRequest[
+        val newlyEmpty = mutableSetOf<String>()
+        val recovered = mutableSetOf<String>()
+        val result = fallbackChannels.mapNotNull { channel ->
+            val lookupKey = channel.guideLookupKey() ?: return@mapNotNull null
+            val fetchResult = programsByRequest[
                 LiveStreamProgramRequest(
                     streamId = channel.streamId,
                     epgChannelId = channel.epgChannelId
                 )
-            ] as? Result.Success)?.data.orEmpty()
+            ]
+            val programs = (fetchResult as? Result.Success)?.data.orEmpty()
+            if (programs.isEmpty()) {
+                // Successful but empty: remember it so later window updates skip it instantly.
+                // Errors are left out so transient failures retry on the next emission.
+                if (fetchResult is Result.Success) {
+                    newlyEmpty += lookupKey
+                }
+                return@mapNotNull null
+            }
+            // Fresh data may have appeared since a previous empty result.
+            recovered += lookupKey
             val currentProgram = programs.firstOrNull { it.startTime <= now && it.endTime > now }
                 ?: programs.firstOrNull()
-            val lookupKey = channel.guideLookupKey() ?: return@mapNotNull null
             currentProgram?.let { lookupKey to it }
         }.toMap()
+
+        if (newlyEmpty.isNotEmpty()) {
+            homeSessionEmptyGuideKeys += newlyEmpty
+            preferencesRepository.addEmptyGuideKeys(providerId, newlyEmpty)
+        }
+        if (recovered.isNotEmpty()) {
+            homeSessionEmptyGuideKeys -= recovered
+            preferencesRepository.removeEmptyGuideKeys(providerId, recovered)
+        }
+        return result
     }
 
     fun updateVisibleChannelWindow(channelIds: List<Long>, focusedChannelId: Long? = null) {

--- a/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
+++ b/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
@@ -670,6 +670,36 @@ class PreferencesRepository @Inject constructor(
         }
     }
 
+    /**
+     * Provider-scoped cache of guide keys whose on-demand short-EPG fetch returned empty.
+     * Values are the epoch millis when emptiness was last observed, so callers can re-probe
+     * after a TTL instead of treating the portal's guide as permanently absent.
+     */
+    suspend fun getEmptyGuideKeys(providerId: Long): Map<String, Long> =
+        decodeEmptyGuideKeys(context.dataStore.data.first()[emptyGuideKeysKey(providerId)])
+
+    suspend fun addEmptyGuideKeys(providerId: Long, keys: Set<String>) {
+        if (keys.isEmpty()) return
+        val now = System.currentTimeMillis()
+        context.dataStore.edit { preferences ->
+            val merged = decodeEmptyGuideKeys(preferences[emptyGuideKeysKey(providerId)]) +
+                keys.associateWith { now }
+            preferences[emptyGuideKeysKey(providerId)] = encodeEmptyGuideKeys(merged)
+        }
+    }
+
+    suspend fun removeEmptyGuideKeys(providerId: Long, keys: Set<String>) {
+        if (keys.isEmpty()) return
+        context.dataStore.edit { preferences ->
+            val pruned = decodeEmptyGuideKeys(preferences[emptyGuideKeysKey(providerId)]) - keys
+            if (pruned.isEmpty()) {
+                preferences.remove(emptyGuideKeysKey(providerId))
+            } else {
+                preferences[emptyGuideKeysKey(providerId)] = encodeEmptyGuideKeys(pruned)
+            }
+        }
+    }
+
     val preventStandbyDuringPlayback: Flow<Boolean> = context.dataStore.data.map { preferences ->
         preferences[PreferencesKeys.PREVENT_STANDBY_DURING_PLAYBACK] ?: true
     }
@@ -2289,6 +2319,26 @@ class PreferencesRepository @Inject constructor(
         val secret = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256").generateSecret(spec)
         return java.util.Base64.getEncoder().encodeToString(secret.encoded)
     }
+
+    private fun emptyGuideKeysKey(providerId: Long): Preferences.Key<String> =
+        stringPreferencesKey("guide_empty_keys_v1_${providerId}")
+
+    private fun encodeEmptyGuideKeys(values: Map<String, Long>): String =
+        values.entries
+            .sortedBy { it.key }
+            .joinToString("\n") { (key, lastEmptyAt) -> "$key\t$lastEmptyAt" }
+
+    private fun decodeEmptyGuideKeys(encoded: String?): Map<String, Long> =
+        encoded.orEmpty()
+            .lineSequence()
+            .filter { it.isNotBlank() }
+            .mapNotNull { line ->
+                val tab = line.indexOf('\t')
+                if (tab <= 0) return@mapNotNull null
+                val timestamp = line.substring(tab + 1).toLongOrNull() ?: return@mapNotNull null
+                line.substring(0, tab) to timestamp
+            }
+            .toMap()
 
     private fun hiddenCategoriesKey(providerId: Long, type: ContentType): String =
         "hidden_categories_${providerId}_${type.name}"

--- a/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/OkHttpStalkerApiService.kt
@@ -2578,6 +2578,11 @@ class OkHttpStalkerApiService @Inject constructor(
         val requestPriority = when {
             request.url.queryParameter("action").equals("create_link", ignoreCase = true) ->
                 StalkerNetworkPriority.INTERACTIVE
+            request.url.queryParameter("action").equals("get_short_epg", ignoreCase = true) ->
+                // Short EPG payloads are tiny now/next windows; PREFETCH spacing (500ms +
+                // token bucket at ~1/s) keeps on-demand guide pages fast while still
+                // pacing the portal.
+                StalkerNetworkPriority.PREFETCH
             currentCoroutineContext()[StalkerRequestPriorityContext]?.priority in setOf(
                 com.streamvault.domain.model.StalkerRequestPriority.EPG,
                 com.streamvault.domain.model.StalkerRequestPriority.BACKGROUND_INDEX

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -778,6 +778,32 @@ internal companion object {
         }
     }
 
+    /**
+     * The portal `ch_id` parameter only understands the numeric portal channel id.
+     * The XMLTV-style guide key some channels carry is never valid there, so it is
+     * only tried as a fallback when the numeric id returns nothing.
+     */
+    override suspend fun getShortEpg(request: com.streamvault.domain.provider.GuideRequest): Result<List<Program>> {
+        val numericKey = request.streamId.takeIf { it > 0L }?.toString()
+        val numericResult = numericKey?.let { getShortEpg(it, request.limit) }
+        if (numericResult is Result.Success && numericResult.data.isNotEmpty()) return numericResult
+        val xmlKey = request.epgChannelId?.takeIf { it.isNotBlank() }?.takeUnless { it == numericKey }
+        if (xmlKey != null) {
+            val xmlResult = getShortEpg(xmlKey, request.limit)
+            if (xmlResult is Result.Success && xmlResult.data.isNotEmpty()) return xmlResult
+        }
+        return numericResult ?: Result.error("Short EPG lookup returned no programs")
+    }
+
+    override suspend fun getEpg(request: com.streamvault.domain.provider.GuideRequest): Result<List<Program>> {
+        // get_epg_info only understands the numeric portal channel id; unlike short EPG
+        // there is no cheap fallback key, so a non-numeric request fails fast instead of
+        // burning a slow portal call that cannot succeed.
+        val numericKey = request.streamId.takeIf { it > 0L }?.toString()
+            ?: return Result.error("EPG lookup needs a numeric portal channel id")
+        return getEpg(numericKey)
+    }
+
     suspend fun resolvePlaybackInfo(
         kind: StalkerStreamKind,
         cmd: String,

--- a/data/src/main/java/com/streamvault/data/repository/ProviderRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/ProviderRepositoryImpl.kt
@@ -1875,7 +1875,12 @@ class ProviderRepositoryImpl @Inject constructor(
                             streamId = request.streamId,
                             epgChannelId = request.epgChannelId,
                             limit = limit,
-                            guide = guide
+                            guide = guide,
+                            // Stalker portals answer get_short_epg for on-demand hydration; a
+                            // per-channel get_epg_info fallback is slow (portals without guide
+                            // data stall 6-7s and return nothing) and duplicates the bulk EPG
+                            // sync, so on-demand hydration stays short-EPG only for them.
+                            shortEpgOnly = providerEntity.type == ProviderType.STALKER_PORTAL
                         )
                     }
                 }
@@ -2080,7 +2085,8 @@ class ProviderRepositoryImpl @Inject constructor(
         streamId: Long,
         epgChannelId: String?,
         limit: Int,
-        guide: GuideSource
+        guide: GuideSource,
+        shortEpgOnly: Boolean = false
     ): Result<List<Program>> {
         if (providerId <= 0L || streamId <= 0L) {
             return Result.error("Live stream context is unavailable.")
@@ -2098,6 +2104,12 @@ class ProviderRepositoryImpl @Inject constructor(
             return Result.success(
                 normalizeXtreamPrograms(providerId, epgChannelId ?: streamId.toString(), shortPrograms)
             )
+        }
+        if (shortEpgOnly) {
+            // Short EPG is the authoritative on-demand source for these providers; skip the
+            // per-channel full-EPG probe so channels without guide data resolve fast instead
+            // of stalling on a get_epg_info request that returns nothing.
+            return Result.success(emptyList())
         }
         return when (val fullResult = guide.getEpg(request)) {
             is Result.Success -> Result.success(

--- a/data/src/main/java/com/streamvault/data/sync/ProviderEpgSyncExecutor.kt
+++ b/data/src/main/java/com/streamvault/data/sync/ProviderEpgSyncExecutor.kt
@@ -231,6 +231,7 @@ internal class ProviderEpgSyncExecutor(
         val bulkCoveredChannelKeys = linkedSetOf<String>()
         var importedProgramCount = 0
         var providerRateLimited = false
+        var bulkEpgReturnedEmpty = false
 
         suspend fun flushPrograms() {
             if (insertBuffer.isEmpty()) return
@@ -272,6 +273,11 @@ internal class ProviderEpgSyncExecutor(
             }.let { result ->
                 if (result is Result.Error) {
                     throw result.exception ?: IllegalStateException(result.message)
+                } else if (result is Result.Success && result.data == 0) {
+                    // Bulk call succeeded but carried no programs: on portals with a broken
+                    // get_epg_info this is the signal to probe one per-channel request and
+                    // then skip the rest instead of grinding through all of them.
+                    bulkEpgReturnedEmpty = true
                 }
             }
         }.onFailure { error ->
@@ -298,6 +304,7 @@ internal class ProviderEpgSyncExecutor(
         fallbackGuideRequests.forEachIndexed { index, request ->
             if (ignorePerChannelGuide) return@forEachIndexed
             progress(provider.id, onProgress, "Downloading portal EPG... ${index + 1} of ${fallbackGuideRequests.size}")
+            var channelRecordCount = 0
             runSuspendCatching {
                 var perChannelRecordCount = 0
                 val foreignChannelIds = HashSet<String>()
@@ -318,6 +325,7 @@ internal class ProviderEpgSyncExecutor(
                             channelId = request.channelKey
                         ).toEntity()
                         perChannelRecordCount++
+                        channelRecordCount = perChannelRecordCount
                         if (perChannelRecordCount >= STALKER_PER_CHANNEL_RECORD_SANITY_CAP || foreignChannelIds.size > 1) {
                             throw StalkerBrokenPerChannelEpgException(request.channelName)
                         }
@@ -326,6 +334,18 @@ internal class ProviderEpgSyncExecutor(
                 }
                 if (streamResult is Result.Error) {
                     throw streamResult.exception ?: IllegalStateException(streamResult.message)
+                }
+                if (channelRecordCount == 0 && bulkEpgReturnedEmpty && !providerRateLimited) {
+                    // Bulk and the first per-channel request both came back empty: this
+                    // portal's get_epg_info is dead, so skip the remaining calls instead
+                    // of grinding through every channel. The guide fills on demand via
+                    // short EPG when its pages are opened.
+                    ignorePerChannelGuide = true
+                    Log.w(
+                        TAG,
+                        "Stalker portal get_epg_info returned no programs for provider ${provider.id}; " +
+                            "skipping remaining per-channel requests."
+                    )
                 }
             }.onFailure { error ->
                 if (error.hasStalkerRateLimit()) {

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -1124,7 +1124,12 @@ class StalkerProviderTest {
         private val seriesCategoriesResult: Result<List<StalkerCategoryRecord>>? = null,
         private val vodPageItems: List<StalkerItemRecord> = emptyList(),
         private val seriesPageItems: List<StalkerItemRecord> = emptyList(),
-        private var authenticationFailuresBeforeSuccess: Int = 0
+        private var authenticationFailuresBeforeSuccess: Int = 0,
+        private var authenticationError: Throwable? = null,
+        private val shortEpgByChannel: Map<String, List<StalkerProgramRecord>> = emptyMap(),
+        private val epgByChannel: Map<String, List<StalkerProgramRecord>> = emptyMap(),
+        val shortEpgCalls: MutableList<String> = mutableListOf(),
+        val epgCalls: MutableList<String> = mutableListOf()
     ) : StalkerApiService {
         var createLinkCalls: Int = 0
             private set
@@ -1221,13 +1226,19 @@ class StalkerProviderTest {
             profile: StalkerDeviceProfile,
             channelId: String,
             limit: Int
-        ) = Result.success(emptyList<StalkerProgramRecord>())
+        ): Result<List<StalkerProgramRecord>> {
+            shortEpgCalls += channelId
+            return Result.success(shortEpgByChannel[channelId].orEmpty())
+        }
 
         override suspend fun getEpg(
             session: StalkerSession,
             profile: StalkerDeviceProfile,
             channelId: String
-        ) = Result.success(emptyList<StalkerProgramRecord>())
+        ): Result<List<StalkerProgramRecord>> {
+            epgCalls += channelId
+            return Result.success(epgByChannel[channelId].orEmpty())
+        }
 
         override suspend fun getBulkEpg(
             session: StalkerSession,
@@ -1351,6 +1362,111 @@ class StalkerProviderTest {
         assertThat(result).isInstanceOf(Result.Success::class.java)
         val success = result as Result.Success
         assertThat(success.data.url).isEqualTo("http://cdn.example.com/live/stream.ts")
+    }
+
+    @Test
+    fun getShortEpg_request_prefers_numeric_portal_id_over_xmltv_key() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            shortEpgByChannel = mapOf(
+                "66" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "66",
+                        title = "Christ in Prophecy",
+                        description = "Prophecy",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getShortEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Christ in Prophecy")
+        assertThat(api.shortEpgCalls).containsExactly("66")
+    }
+
+    @Test
+    fun getShortEpg_request_falls_back_to_xmltv_key_when_numeric_id_is_empty() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            shortEpgByChannel = mapOf(
+                "daystar.us" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "daystar.us",
+                        title = "Christ in Prophecy",
+                        description = "Prophecy",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getShortEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Christ in Prophecy")
+        assertThat(api.shortEpgCalls).containsExactly("66", "daystar.us")
+    }
+
+    @Test
+    fun getEpg_request_uses_numeric_portal_id() = runTest {
+        val api = FakeStalkerApiService(
+            profile = StalkerProviderProfile(accountName = "Room"),
+            epgByChannel = mapOf(
+                "66" to listOf(
+                    StalkerProgramRecord(
+                        id = "p1",
+                        channelId = "66",
+                        title = "Evening News",
+                        description = "News",
+                        startTimeMillis = 1_788_573_600_000L,
+                        endTimeMillis = 1_788_575_400_000L
+                    )
+                )
+            )
+        )
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = api,
+            portalUrl = "http://portal.example.com/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG322",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getEpg(
+            com.streamvault.domain.provider.GuideRequest(streamId = 66L, epgChannelId = "daystar.us")
+        ) as Result.Success
+
+        assertThat(result.data.map { it.title }).containsExactly("Evening News")
+        assertThat(api.epgCalls).containsExactly("66")
     }
 
     private object DirectTransactionRunner : DatabaseTransactionRunner {

--- a/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
+++ b/data/src/test/java/com/streamvault/data/sync/SyncManagerTest.kt
@@ -3629,6 +3629,51 @@ class SyncManagerTest {
         assertThat(metadata?.epgCount).isEqualTo(1)
     }
 
+
+    @Test
+    fun retrySection_epg_stalker_skips_dead_epg_info_after_first_empty_channel() = runTest {
+        val providerEntity = sampleProvider(ProviderType.STALKER_PORTAL).copy(
+            serverUrl = "http://example.com",
+            username = "",
+            password = "",
+            stalkerMacAddress = "00:11:22:33:44:55",
+            epgSyncMode = ProviderEpgSyncMode.BACKGROUND,
+            epgUrl = ""
+        )
+        val manager = buildManager(providerType = ProviderType.STALKER_PORTAL, providerEntity = providerEntity)
+
+        org.mockito.kotlin.whenever(stalkerApiService.authenticate(any())).thenReturn(
+            Result.success(
+                StalkerSession(
+                    loadUrl = "http://example.com/stalker_portal/server/load.php",
+                    portalReferer = "http://example.com/stalker_portal/c/",
+                    token = "token"
+                ) to StalkerProviderProfile(accountName = "Stalker")
+            )
+        )
+        org.mockito.kotlin.whenever(channelDao.getGuideSyncEntriesByProvider(1L)).thenReturn(
+            (1..5).map { index ->
+                ChannelGuideSyncEntity(
+                    streamId = 100L + index,
+                    name = "Channel $index",
+                    epgChannelId = "guide-$index"
+                )
+            }
+        )
+        stalkerApiService.stubStreamBulkEpg(programs = emptyList())
+        (1..5).forEach { index ->
+            stalkerApiService.stubStreamEpg(channelId = "guide-$index", programs = emptyList())
+        }
+        org.mockito.kotlin.whenever(programDao.countByProvider(1L)).thenReturn(0)
+
+        val result = manager.retrySection(providerId = 1L, section = SyncRepairSection.EPG)
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        // Bulk + first channel both empty: the remaining dead calls must be skipped.
+        org.mockito.kotlin.verify(stalkerApiService, org.mockito.kotlin.times(1))
+            .streamEpg(any(), any(), any(), any(), any())
+    }
+
     @Test
     fun retrySection_epg_stalker_dedupes_same_guide_key_within_one_run() = runTest {
         val providerEntity = sampleProvider(ProviderType.STALKER_PORTAL).copy(


### PR DESCRIPTION
Fixes empty guide data on Stalker portals whose bulk or per-channel `get_epg_info` endpoint misbehaves: syncs imported zero programs while the portal's own STB UI still shows data.

- Routes guide lookups through the **numeric portal channel id first** — the only key the portal's `ch_id` parameter understands — with the XMLTV-style guide key only as a fallback.
- Skips per-channel calls that are known to be dead: once the bulk probe plus first-channel probes come back empty, no more per-channel requests are issued against that portal.
- Paces short-EPG calls at the prefetch rate instead of bursting them.
- Fills guide pages on demand while keeping session memory of channels already confirmed empty, so repeat lookups don't hit a dead endpoint again.
