### PR TITLE
fix: resolve bare-filename stalker channel logos against the portal

### DIFF
--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerLogoUrlResolver.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerLogoUrlResolver.kt
@@ -1,0 +1,61 @@
+package com.streamvault.data.remote.stalker
+
+import java.net.URI
+
+/**
+ * Resolves Stalker portal channel-logo URLs. Some Ministra portals return the channel
+ * `logo` field as a bare filename (`536.png`) that lives under the portal's
+ * `misc/logos/{size}/` directory — the convention STBEmu uses when it requests
+ * `/stalker_portal/misc/logos/120/536.png`. Absolute URLs, root-relative paths and
+ * paths that already contain a directory are returned unchanged.
+ *
+ * Used both when importing channels (write time) and when presenting stored channels
+ * (read time), so rows imported before this fix also render logos without a re-sync.
+ */
+object StalkerLogoUrlResolver {
+    // Channel logos served from the portal's misc/logos/{size}/ directory. STBEmu and
+    // other STB clients use the 120 bucket (36×36) as the smallest guaranteed size.
+    const val STALKER_CHANNEL_LOGO_SIZE_BUCKET = 120
+
+    fun resolveChannelLogoUrl(portalUrl: String, url: String?): String? {
+        if (url.isNullOrBlank()) return null
+        if (url.startsWith("http://", true) || url.startsWith("https://", true)) return url
+        if (url.startsWith("/")) return resolvePortalUrl(portalUrl, url)
+        if (url.contains('/')) return url
+        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
+        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
+        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
+        val port = origin.port.takeIf { it > 0 }
+        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
+        // Derive the portal install root from the configured portal URL (e.g. a portalUrl of
+        // `http://host/stalker_portal/server/load.php` maps logos to
+        // `http://host/stalker_portal/misc/logos/120/536.png`).
+        val installPath = portalInstallPath(origin.path)
+        return "$scheme://$authority$installPath/misc/logos/$STALKER_CHANNEL_LOGO_SIZE_BUCKET/$url"
+    }
+
+    /** Resolves a root-relative portal path (`/stalker_portal/...`) against the portal origin. */
+    fun resolvePortalUrl(portalUrl: String, url: String): String? {
+        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
+        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
+        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
+        val port = origin.port.takeIf { it > 0 }
+        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
+        return "$scheme://$authority$url"
+    }
+
+    private fun portalInstallPath(portalPath: String?): String {
+        val path = portalPath?.trimEnd('/').orEmpty()
+        return when {
+            path.endsWith("/server/load.php", ignoreCase = true) ->
+                path.dropLast("/server/load.php".length)
+            path.endsWith("/portal.php", ignoreCase = true) ->
+                path.dropLast("/portal.php".length)
+            path.endsWith("/c/index.html", ignoreCase = true) ->
+                path.dropLast("/c/index.html".length)
+            path.endsWith("/c", ignoreCase = true) ->
+                path.dropLast("/c".length)
+            else -> path
+        }
+    }
+}

--- a/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
+++ b/data/src/main/java/com/streamvault/data/remote/stalker/StalkerProvider.kt
@@ -2129,13 +2129,17 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
         if (url.isNullOrBlank()) return null
         if (url.startsWith("http://", true) || url.startsWith("https://", true)) return url
         if (!url.startsWith("/")) return url
-        val origin = runCatching { URI(portalUrl) }.getOrNull() ?: return url
-        val scheme = origin.scheme?.takeIf { it == "http" || it == "https" } ?: "https"
-        val host = origin.host?.takeIf(String::isNotBlank) ?: return url
-        val port = origin.port.takeIf { it > 0 }
-        val authority = if (port != null && port != (if (scheme == "https") 443 else 80)) "$host:$port" else host
-        return "$scheme://$authority$url"
+        return StalkerLogoUrlResolver.resolvePortalUrl(portalUrl, url)
     }
+
+    /**
+     * Resolves a channel logo URL into an absolute URL. Some Ministra portals return the
+     * channel `logo` field as a bare filename (`536.png`) that lives under the portal's
+     * `misc/logos/{size}/` directory — the convention STBEmu uses when it requests
+     * `/stalker_portal/misc/logos/120/536.png`. See [StalkerLogoUrlResolver].
+     */
+    private fun resolveChannelLogoUrl(url: String?): String? =
+        StalkerLogoUrlResolver.resolveChannelLogoUrl(portalUrl, url)
 
     private fun toChannel(item: StalkerItemRecord): Channel? {
         val numericId = stableItemId(ContentType.LIVE, item.id)
@@ -2164,7 +2168,7 @@ private fun playbackTransportChallengeFor(url: String): StalkerTransportChalleng
         return Channel(
             id = 0L,
             name = resolvedName,
-            logoUrl = resolvePortalUrl(item.logoUrl),
+            logoUrl = resolveChannelLogoUrl(item.logoUrl),
             categoryId = category.id,
             categoryName = category.name,
             streamUrl = streamUrl,

--- a/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
+++ b/data/src/main/java/com/streamvault/data/repository/ChannelRepositoryImpl.kt
@@ -5,11 +5,14 @@ import android.util.Log
 import com.streamvault.data.local.dao.CategoryDao
 import com.streamvault.data.local.dao.ChannelDao
 import com.streamvault.data.local.dao.FavoriteDao
+import com.streamvault.data.local.dao.ProviderSnapshotDao
 import com.streamvault.data.local.entity.CategoryEntity
 import com.streamvault.data.local.entity.ChannelBrowseEntity
 import com.streamvault.data.local.entity.CategoryCount
 import com.streamvault.data.mapper.toDomain
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderConfigurationCodec
+import com.streamvault.data.remote.stalker.StalkerLogoUrlResolver
 import com.streamvault.data.remote.xtream.XtreamStreamUrlResolver
 import com.streamvault.data.util.rankSearchResults
 import com.streamvault.data.util.toFtsPrefixQuery
@@ -25,11 +28,14 @@ import com.streamvault.domain.model.LiveChannelObservedQuality
 import com.streamvault.domain.model.LiveChannelVariant
 import com.streamvault.domain.model.LiveChannelVariantAttributes
 import com.streamvault.domain.model.LiveVariantPreferenceMode
+import com.streamvault.domain.model.ProviderType
 import com.streamvault.domain.model.Result
+import com.streamvault.domain.model.StalkerConfig
 import com.streamvault.domain.model.StreamInfo
 import com.streamvault.domain.model.StreamType
 import com.streamvault.domain.repository.ChannelRepository
 import com.streamvault.domain.util.ChannelNormalizer
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.withContext
@@ -53,8 +59,13 @@ class ChannelRepositoryImpl @Inject constructor(
     private val favoriteDao: FavoriteDao,
     private val preferencesRepository: PreferencesRepository,
     private val parentalControlManager: com.streamvault.domain.manager.ParentalControlManager,
-    private val xtreamStreamUrlResolver: XtreamStreamUrlResolver
+    private val xtreamStreamUrlResolver: XtreamStreamUrlResolver,
+    private val providerSnapshotDao: ProviderSnapshotDao,
+    private val providerConfigurationCodec: ProviderConfigurationCodec
 ) : ChannelRepository {
+    // Portal install roots by provider id, so bare-filename channel logos (e.g. "536.png")
+    // stored by earlier syncs can be resolved on read without a DB hit per channel.
+    private val stalkerPortalRootCache = ConcurrentHashMap<Long, String>()
     private companion object {
         const val TAG = "ChannelRepository"
         const val GLOBAL_SEARCH_LIMIT = 500
@@ -837,11 +848,32 @@ class ChannelRepositoryImpl @Inject constructor(
     private fun ChannelBrowseEntity.resolveLogoUrl(): String? {
         val supplierLogo = logoUrl?.takeIf { it.isNotBlank() }
         val epgLogo = epgIconUrl?.takeIf { it.isNotBlank() }
-        return when (channelLogoSourcePolicy) {
+        val selected = when (channelLogoSourcePolicy) {
             ChannelLogoSourcePolicy.SUPPLIER_PREFERRED -> supplierLogo ?: epgLogo
             ChannelLogoSourcePolicy.EPG_PREFERRED -> epgLogo ?: supplierLogo
             ChannelLogoSourcePolicy.SUPPLIER_ONLY -> supplierLogo
             ChannelLogoSourcePolicy.EPG_ONLY -> epgLogo
         }
+        // Some Stalker portals return the channel logo as a bare filename ("536.png"); rows
+        // imported before the write-time fix still store it that way. Resolve it against the
+        // portal's misc/logos/ directory so those rows render without needing a re-sync.
+        if (selected.isNullOrBlank()) return null
+        if (selected.startsWith("http://", true) || selected.startsWith("https://", true)) return selected
+        if (selected.startsWith("/") || selected.contains('/')) return selected
+        val portalUrl = stalkerPortalRoot(providerId) ?: return selected
+        return StalkerLogoUrlResolver.resolveChannelLogoUrl(portalUrl, selected)
+    }
+
+    private fun stalkerPortalRoot(providerId: Long): String? {
+        stalkerPortalRootCache[providerId]?.let { return it.ifBlank { null } }
+        val config = providerSnapshotDao.getConfigSync(providerId)
+        val decoded = config?.takeIf { it.type == ProviderType.STALKER_PORTAL }?.let { entity ->
+            runCatching {
+                providerConfigurationCodec.decode(entity.type, entity.encryptedConfigJson)
+            }.getOrNull()
+        }
+        val portalUrl = (decoded as? StalkerConfig)?.portalUrl?.trim().orEmpty()
+        stalkerPortalRootCache[providerId] = portalUrl
+        return portalUrl.ifBlank { null }
     }
 }

--- a/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
+++ b/data/src/test/java/com/streamvault/data/remote/stalker/StalkerProviderTest.kt
@@ -677,6 +677,109 @@ class StalkerProviderTest {
     }
 
     @Test
+    fun getLiveStreams_resolves_bare_filename_logos_under_misc_logos() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "536",
+                        name = "NEWS 18 PUNJAB HARYANA",
+                        cmd = "ffmpeg http://localhost/ch/536_",
+                        streamUrl = "http://localhost/ch/536_",
+                        logoUrl = "536.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        assertThat(success.data.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/stalker_portal/misc/logos/120/536.png")
+    }
+
+    @Test
+    fun getLiveStreams_resolves_bare_filename_logos_from_plain_portal_base() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "1",
+                        name = "APTN 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/1_",
+                        streamUrl = "http://localhost/ch/1_",
+                        logoUrl = "1.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/c/",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        assertThat(success.data.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/misc/logos/120/1.png")
+    }
+
+    @Test
+    fun getLiveStreams_keeps_absolute_and_root_relative_logos_unchanged() = runTest {
+        val provider = StalkerProvider(
+            providerId = 7,
+            api = FakeStalkerApiService(
+                profile = StalkerProviderProfile(accountName = "Room"),
+                liveStreams = listOf(
+                    StalkerItemRecord(
+                        id = "11",
+                        name = "CBC ICI 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/11_",
+                        streamUrl = "http://localhost/ch/11_",
+                        logoUrl = "https://cdn.example.com/11.png"
+                    ),
+                    StalkerItemRecord(
+                        id = "12",
+                        name = "CBS 4K cc",
+                        cmd = "ffmpeg http://localhost/ch/12_",
+                        streamUrl = "http://localhost/ch/12_",
+                        logoUrl = "/stalker_portal/misc/logos/120/12.png"
+                    )
+                )
+            ),
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            macAddress = "00:1A:79:12:34:56",
+            deviceProfile = "MAG250",
+            timezone = "UTC",
+            locale = "en"
+        )
+
+        val result = provider.getLiveStreams()
+
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        val success = result as Result.Success
+        val logos = success.data.map { it.logoUrl }
+        assertThat(logos).containsExactly(
+            "https://cdn.example.com/11.png",
+            "http://alex.rocktv.be/stalker_portal/misc/logos/120/12.png"
+        )
+    }
+
+    @Test
     fun buildCatchUpUrls_returns_internal_archive_candidates_for_live_token() = runTest {
         val provider = StalkerProvider(
             providerId = 7,

--- a/data/src/test/java/com/streamvault/data/repository/ChannelRepositoryImplTest.kt
+++ b/data/src/test/java/com/streamvault/data/repository/ChannelRepositoryImplTest.kt
@@ -5,11 +5,17 @@ import com.google.common.truth.Truth.assertThat
 import com.streamvault.data.local.dao.CategoryDao
 import com.streamvault.data.local.dao.ChannelDao
 import com.streamvault.data.local.dao.FavoriteDao
+import com.streamvault.data.local.dao.ProviderSnapshotDao
 import com.streamvault.data.local.entity.CategoryCount
 import com.streamvault.data.local.entity.ChannelBrowseEntity
 import com.streamvault.data.local.entity.CategoryEntity
+import com.streamvault.data.local.entity.ProviderConfigEntity
 import com.streamvault.data.preferences.PreferencesRepository
+import com.streamvault.data.provider.ProviderConfigurationCodec
 import com.streamvault.data.remote.xtream.XtreamStreamUrlResolver
+import com.streamvault.domain.model.ProviderType
+import com.streamvault.domain.model.StalkerConfig
+import com.streamvault.domain.model.StalkerDeviceIdentity
 import com.streamvault.domain.manager.ParentalControlManager
 import com.streamvault.domain.model.ChannelLogoSourcePolicy
 import com.streamvault.domain.model.ChannelNumberingMode
@@ -38,9 +44,12 @@ class ChannelRepositoryImplTest {
     private val preferencesRepository: PreferencesRepository = mock()
     private val parentalControlManager: ParentalControlManager = mock()
     private val xtreamStreamUrlResolver: XtreamStreamUrlResolver = mock()
+    private val providerSnapshotDao: ProviderSnapshotDao = mock()
+    private val providerConfigurationCodec: ProviderConfigurationCodec = mock()
 
     @Before
     fun setUpDefaults() {
+        whenever(providerSnapshotDao.getConfigSync(any())).thenReturn(null)
         whenever(preferencesRepository.parentalControlLevel).thenReturn(flowOf(0))
         whenever(preferencesRepository.liveChannelNumberingMode).thenReturn(flowOf(ChannelNumberingMode.PROVIDER))
         whenever(preferencesRepository.liveChannelGroupingMode).thenReturn(flowOf(LiveChannelGroupingMode.GROUPED))
@@ -351,6 +360,75 @@ class ChannelRepositoryImplTest {
     }
 
     @Test
+    fun `getChannels resolves bare-filename stalker logos against portal misc logos dir`() = runTest {
+        whenever(channelDao.getByProvider(7L)).thenReturn(
+            flowOf(
+                listOf(
+                    ChannelBrowseEntity(
+                        id = 536L,
+                        streamId = 536L,
+                        name = "NEWS 18 PUNJAB HARYANA",
+                        logoUrl = "536.png",
+                        streamUrl = "https://stream/536",
+                        number = 1,
+                        providerId = 7L
+                    )
+                )
+            )
+        )
+        val stalkerConfig = StalkerConfig(
+            portalUrl = "http://alex.rocktv.be/stalker_portal/server/load.php",
+            device = StalkerDeviceIdentity(macAddress = "00:1A:79:12:34:56")
+        )
+        val configEntity = ProviderConfigEntity(
+            providerId = 7L,
+            type = ProviderType.STALKER_PORTAL,
+            schemaVersion = 1,
+            configurationGeneration = 1L,
+            identityKey = "stalker-7",
+            encryptedConfigJson = "{}",
+            updatedAt = 0L
+        )
+        whenever(providerSnapshotDao.getConfigSync(7L)).thenReturn(configEntity)
+        whenever(providerConfigurationCodec.decode(ProviderType.STALKER_PORTAL, "{}"))
+            .thenReturn(stalkerConfig)
+        whenever(parentalControlManager.unlockedCategoriesForProvider(7L)).thenReturn(flowOf(emptySet()))
+
+        val repository = createRepository()
+
+        val result = repository.getChannels(7L).first()
+
+        assertThat(result.single().logoUrl)
+            .isEqualTo("http://alex.rocktv.be/stalker_portal/misc/logos/120/536.png")
+    }
+
+    @Test
+    fun `getChannels leaves bare-filename logos alone for non stalker providers`() = runTest {
+        whenever(channelDao.getByProvider(7L)).thenReturn(
+            flowOf(
+                listOf(
+                    ChannelBrowseEntity(
+                        id = 1L,
+                        streamId = 1L,
+                        name = "News One",
+                        logoUrl = "1.png",
+                        streamUrl = "https://stream/1",
+                        number = 1,
+                        providerId = 7L
+                    )
+                )
+            )
+        )
+        whenever(parentalControlManager.unlockedCategoriesForProvider(7L)).thenReturn(flowOf(emptySet()))
+
+        val repository = createRepository()
+
+        val result = repository.getChannels(7L).first()
+
+        assertThat(result.single().logoUrl).isEqualTo("1.png")
+    }
+
+    @Test
     fun `searchChannels returns empty list when sqlite throws for malformed fts query`() = runTest {
         whenever(channelDao.search(eq(7L), any(), any())).thenReturn(
             flow { throw SQLiteException("malformed MATCH expression") }
@@ -413,7 +491,9 @@ class ChannelRepositoryImplTest {
         favoriteDao = favoriteDao,
         preferencesRepository = preferencesRepository,
         parentalControlManager = parentalControlManager,
-        xtreamStreamUrlResolver = xtreamStreamUrlResolver
+        xtreamStreamUrlResolver = xtreamStreamUrlResolver,
+        providerSnapshotDao = providerSnapshotDao,
+        providerConfigurationCodec = providerConfigurationCodec
     )
 
     private fun categoryEntity(


### PR DESCRIPTION
Some Ministra portals return the channel logo field as a bare filename (`536.png`) that actually lives under the portal's `misc/logos/{size}/` directory — the convention STBEmu uses when it requests `/stalker_portal/misc/logos/120/536.png`. Such channels previously rendered without a logo.

- Adds a resolver that turns bare logo filenames into absolute portal URLs.
- Applies it at import time **and** again when presenting stored channels, so rows imported before this fix also render logos without requiring a re-sync.
