### PR TITLE
Add togglable dark theme

### DIFF
--- a/app/src/main/java/com/streamvault/app/MainActivity.kt
+++ b/app/src/main/java/com/streamvault/app/MainActivity.kt
@@ -154,6 +154,7 @@ class MainActivity : ComponentActivity() {
         setContent {
             val appLanguage by preferencesRepository.appLanguage.collectAsState(initial = "system")
             val appTimeFormat by preferencesRepository.appTimeFormat.collectAsState(initial = com.streamvault.domain.model.AppTimeFormat.SYSTEM)
+            val darkTheme by preferencesRepository.darkTheme.collectAsState(initial = false)
             val databaseStartupState by databaseStartupCoordinator.state.collectAsState()
             val currentContext = LocalContext.current
             
@@ -196,7 +197,7 @@ class MainActivity : ComponentActivity() {
                 LocalLayoutDirection provides layoutDirection,
                 LocalAppTimeFormat provides appTimeFormat
             ) {
-                StreamVaultTheme {
+                StreamVaultTheme(useDarkTheme = darkTheme) {
                     when (val state = databaseStartupState) {
                         DatabaseStartupState.Opening -> DatabaseStartupScreen(state = state)
                         is DatabaseStartupState.Failed -> DatabaseStartupScreen(

--- a/app/src/main/java/com/streamvault/app/tvinput/TvInputSetupActivity.kt
+++ b/app/src/main/java/com/streamvault/app/tvinput/TvInputSetupActivity.kt
@@ -44,12 +44,14 @@ import com.streamvault.app.ui.theme.OnBackground
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
 import com.streamvault.app.ui.theme.StreamVaultTheme
+import com.streamvault.data.preferences.PreferencesRepository
 import com.streamvault.app.ui.theme.SurfaceElevated
 import com.streamvault.domain.model.LegacyProvider as Provider
 import com.streamvault.domain.repository.ProviderRepository
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import androidx.compose.runtime.collectAsState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -61,13 +63,17 @@ import kotlinx.coroutines.launch
 class TvInputSetupActivity : ComponentActivity() {
     private val viewModel: TvInputSetupViewModel by viewModels()
 
+    @Inject
+    lateinit var preferencesRepository: PreferencesRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val inputId = intent.getStringExtra(TvInputInfo.EXTRA_INPUT_ID)
             ?: ComponentName(this, StreamVaultTvInputService::class.java).flattenToShortString()
         viewModel.startSetup(inputId)
         setContent {
-            StreamVaultTheme {
+            val darkTheme by preferencesRepository.darkTheme.collectAsState(initial = false)
+            StreamVaultTheme(useDarkTheme = darkTheme) {
                 TvInputSetupRoute(
                     onOpenProviderSetup = {
                         startActivity(

--- a/app/src/main/java/com/streamvault/app/ui/components/Cards.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/Cards.kt
@@ -318,7 +318,7 @@ fun ChannelCard(
                     StatusPill(label = stringResource(R.string.badge_error), containerColor = AccentRed, cornerRadius = 4.dp, horizontalPadding = 6.dp, verticalPadding = 2.dp)
                 }
                 if (hasUsableArchive) {
-                    StatusPill(label = stringResource(R.string.badge_catch_up), containerColor = Primary, cornerRadius = 4.dp, horizontalPadding = 6.dp, verticalPadding = 2.dp)
+                    StatusPill(label = stringResource(R.string.badge_catch_up), containerColor = Primary, contentColor = Color.Black, cornerRadius = 4.dp, horizontalPadding = 6.dp, verticalPadding = 2.dp)
                 }
                 if (isRecording) {
                     StatusPill(label = stringResource(R.string.badge_recording), containerColor = AccentRed, cornerRadius = 4.dp, horizontalPadding = 6.dp, verticalPadding = 2.dp)

--- a/app/src/main/java/com/streamvault/app/ui/components/dialogs/PremiumDialog.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/dialogs/PremiumDialog.kt
@@ -329,7 +329,7 @@ fun PremiumDialogActionButton(
             containerColor = containerColor,
             contentColor = contentColor,
             focusedContainerColor = if (destructive) AppColors.Live else AppColors.SurfaceEmphasis,
-            focusedContentColor = AppColors.Focus,
+            focusedContentColor = AppColors.TextPrimary,
             disabledContainerColor = AppColors.Surface.copy(alpha = 0.85f),
             disabledContentColor = AppColors.TextDisabled
         ),
@@ -372,7 +372,7 @@ fun PremiumDialogFooterButton(
             containerColor = containerColor,
             contentColor = contentColor,
             focusedContainerColor = if (destructive) AppColors.Live else AppColors.SurfaceEmphasis,
-            focusedContentColor = AppColors.Focus,
+            focusedContentColor = AppColors.TextPrimary,
             disabledContainerColor = AppColors.Surface.copy(alpha = 0.85f),
             disabledContentColor = AppColors.TextDisabled
         ),

--- a/app/src/main/java/com/streamvault/app/ui/components/dialogs/RenameGroupDialog.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/dialogs/RenameGroupDialog.kt
@@ -186,9 +186,9 @@ fun RenameGroupDialog(
                         ),
                         colors = ButtonDefaults.colors(
                             containerColor = Primary,
-                            contentColor = Color.White,
+                            contentColor = Color.Black,
                             focusedContainerColor = Primary.copy(alpha = 0.84f),
-                            focusedContentColor = Color.White
+                            focusedContentColor = Color.Black
                         ),
                         border = ButtonDefaults.border(
                             focusedBorder = Border(

--- a/app/src/main/java/com/streamvault/app/ui/components/shell/AppMediaCards.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/shell/AppMediaCards.kt
@@ -157,7 +157,7 @@ fun LiveChannelRowCard(
                             StatusPill(label = stringResource(R.string.badge_saved), containerColor = AppColors.Warning, contentColor = Color.Black)
                         }
                         if (hasUsableArchive) {
-                            StatusPill(label = stringResource(R.string.badge_catch_up), containerColor = AppColors.Brand)
+                            StatusPill(label = stringResource(R.string.badge_catch_up), containerColor = AppColors.Brand, contentColor = Color.Black)
                         }
                     }
                 }

--- a/app/src/main/java/com/streamvault/app/ui/design/AppColors.kt
+++ b/app/src/main/java/com/streamvault/app/ui/design/AppColors.kt
@@ -1,33 +1,142 @@
 package com.streamvault.app.ui.design
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.Color
 
+/**
+ * The full app palette for one theme.
+ *
+ * - [light]: the ORIGINAL StreamVault look — blue-navy surfaces, blue brand,
+ *   near-white focus ring (colors restored from git history, pre-M3 commit).
+ * - [dark]: the M3 purple look — neutral black surfaces, lavender primary
+ *   (#D0BCFF), subtle gray focus ring (colors restored from the M3 commit).
+ */
+data class AppPalette(
+    val canvas: Color,
+    val canvasElevated: Color,
+    val surface: Color,
+    val surfaceElevated: Color,
+    val surfaceEmphasis: Color,
+    val surfaceAccent: Color,
+    val brand: Color,
+    val brandMuted: Color,
+    val brandStrong: Color,
+    val onPrimary: Color,
+    val focus: Color,
+    val textPrimary: Color,
+    val textSecondary: Color,
+    val textTertiary: Color,
+    val textDisabled: Color,
+    val live: Color,
+    val success: Color,
+    val warning: Color,
+    val info: Color,
+    val divider: Color,
+    val outline: Color,
+    val heroTop: Color,
+    val heroBottom: Color,
+    val isDark: Boolean
+) {
+    companion object {
+        /** The original blue theme (was the app's only theme before the M3 commit). */
+        fun light(): AppPalette = AppPalette(
+            canvas = Color(0xFF07111B),
+            canvasElevated = Color(0xFF0B1622),
+            surface = Color(0xFF0F1B29),
+            surfaceElevated = Color(0xFF162338),
+            surfaceEmphasis = Color(0xFF1D2E46),
+            surfaceAccent = Color(0xFF223754),
+            brand = Color(0xFF69A8FF),
+            brandMuted = Color(0x335FA4FF),
+            brandStrong = Color(0xFF8BBCFF),
+            onPrimary = Color.White,
+            focus = Color(0xFFF4F8FF),
+            textPrimary = Color(0xFFF5F7FB),
+            textSecondary = Color(0xFFBBC6D8),
+            textTertiary = Color(0xFF7F8DA5),
+            textDisabled = Color(0xFF566173),
+            live = Color(0xFFFF5C61),
+            success = Color(0xFF4FD39A),
+            warning = Color(0xFFFFC766),
+            info = Color(0xFF57C9FF),
+            divider = Color(0x1AF4F8FF),
+            outline = Color(0x264C6D95),
+            heroTop = Color(0xCC07111B),
+            heroBottom = Color(0xF207111B),
+            isDark = false
+        )
+
+        /** The M3 purple-on-black theme (restored from the reverted M3 commit). */
+        fun dark(): AppPalette = AppPalette(
+            canvas = Color(0xFF0A0A0D),
+            canvasElevated = Color(0xFF0E0E12),
+            surface = Color(0xFF141419),
+            surfaceElevated = Color(0xFF1B1B21),
+            surfaceEmphasis = Color(0xFF232329),
+            surfaceAccent = Color(0xFF2A2A31),
+            brand = Color(0xFFD0BCFF),
+            brandMuted = Color(0x33D0BCFF),
+            brandStrong = Color(0xFFEADDFF),
+            onPrimary = Color(0xFF381E72),
+            focus = Color(0xFF8A8A92),
+            textPrimary = Color(0xFFF5F7FB),
+            textSecondary = Color(0xFFC2C2C8),
+            textTertiary = Color(0xFF8A8A92),
+            textDisabled = Color(0xFF606068),
+            live = Color(0xFFFF5C61),
+            success = Color(0xFF4FD39A),
+            warning = Color(0xFFFFC766),
+            info = Color(0xFF57C9FF),
+            divider = Color(0x1AF4F8FF),
+            outline = Color(0x26FFFFFF),
+            heroTop = Color(0xCC0A0A0D),
+            heroBottom = Color(0xF20A0A0D),
+            isDark = true
+        )
+    }
+}
+
+/**
+ * Central color access. Every property is backed by snapshot state, so any
+ * composable reading `AppColors.X` recomposes automatically when the theme
+ * palette is swapped by [com.streamvault.app.ui.theme.StreamVaultTheme].
+ */
 object AppColors {
-    val Canvas = Color(0xFF07111B)
-    val CanvasElevated = Color(0xFF0B1622)
-    val Surface = Color(0xFF0F1B29)
-    val SurfaceElevated = Color(0xFF162338)
-    val SurfaceEmphasis = Color(0xFF1D2E46)
-    val SurfaceAccent = Color(0xFF223754)
+    private val activeState: MutableState<AppPalette> = mutableStateOf(AppPalette.light())
 
-    val Brand = Color(0xFF69A8FF)
-    val BrandMuted = Color(0x335FA4FF)
-    val BrandStrong = Color(0xFF8BBCFF)
-    val Focus = Color(0xFFF4F8FF)
+    var current: AppPalette
+        get() = activeState.value
+        set(value) {
+            activeState.value = value
+        }
 
-    val TextPrimary = Color(0xFFF5F7FB)
-    val TextSecondary = Color(0xFFBBC6D8)
-    val TextTertiary = Color(0xFF7F8DA5)
-    val TextDisabled = Color(0xFF566173)
+    val Canvas: Color get() = current.canvas
+    val CanvasElevated: Color get() = current.canvasElevated
+    val Surface: Color get() = current.surface
+    val SurfaceElevated: Color get() = current.surfaceElevated
+    val SurfaceEmphasis: Color get() = current.surfaceEmphasis
+    val SurfaceAccent: Color get() = current.surfaceAccent
 
-    val Live = Color(0xFFFF5C61)
-    val Success = Color(0xFF4FD39A)
-    val Warning = Color(0xFFFFC766)
-    val Info = Color(0xFF57C9FF)
+    val Brand: Color get() = current.brand
+    val BrandMuted: Color get() = current.brandMuted
+    val BrandStrong: Color get() = current.brandStrong
+    val OnPrimary: Color get() = current.onPrimary
+    val Focus: Color get() = current.focus
 
-    val Divider = Color(0x1AF4F8FF)
-    val Outline = Color(0x264C6D95)
+    val TextPrimary: Color get() = current.textPrimary
+    val TextSecondary: Color get() = current.textSecondary
+    val TextTertiary: Color get() = current.textTertiary
+    val TextDisabled: Color get() = current.textDisabled
 
-    val HeroTop = Color(0xCC07111B)
-    val HeroBottom = Color(0xF207111B)
+    val Live: Color get() = current.live
+    val Success: Color get() = current.success
+    val Warning: Color get() = current.warning
+    val Info: Color get() = current.info
+
+    val Divider: Color get() = current.divider
+    val Outline: Color get() = current.outline
+
+    val HeroTop: Color get() = current.heroTop
+    val HeroBottom: Color get() = current.heroBottom
 }

--- a/app/src/main/java/com/streamvault/app/ui/design/FocusSpec.kt
+++ b/app/src/main/java/com/streamvault/app/ui/design/FocusSpec.kt
@@ -1,10 +1,14 @@
 package com.streamvault.app.ui.design
 
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 object FocusSpec {
     const val FocusedScale = 1.06f
     const val PressedScale = 0.98f
-    val BorderWidth = 3.dp
-    val CardBorderWidth = 4.dp
+
+    // The original blue theme uses a thick bright ring; the M3 purple theme
+    // uses a subtle 2dp border-role ring. Follows the active palette.
+    val BorderWidth: Dp get() = if (AppColors.current.isDark) 2.dp else 3.dp
+    val CardBorderWidth: Dp get() = if (AppColors.current.isDark) 2.dp else 4.dp
 }

--- a/app/src/main/java/com/streamvault/app/ui/design/MaterialScrollbar.kt
+++ b/app/src/main/java/com/streamvault/app/ui/design/MaterialScrollbar.kt
@@ -1,0 +1,96 @@
+package com.streamvault.app.ui.design
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+/**
+ * Material 3 style vertical scrollbar for [LazyListState]-backed lists.
+ *
+ * Thin (4dp) rounded thumb in a neutral `onSurfaceVariant`-adjacent tone;
+ * hidden when idle and fades in while the list is scrolling, matching M3
+ * scroll behavior. Call it inside a [androidx.compose.foundation.layout.Box]
+ * that also holds the [androidx.compose.foundation.lazy.LazyColumn].
+ *
+ * Implemented against [LazyListState] directly (this Compose version removed
+ * the `VerticalScrollbar`/`rememberScrollbarAdapter` foundation APIs).
+ */
+@Composable
+fun BoxScope.MaterialVerticalScrollbar(
+    state: LazyListState,
+    modifier: Modifier = Modifier
+) {
+    var visible by remember { mutableStateOf(false) }
+
+    // Auto-hide: show while the list is being scrolled, then fade out.
+    LaunchedEffect(state) {
+        snapshotFlow {
+            state.firstVisibleItemIndex to state.firstVisibleItemScrollOffset
+        }.collect {
+            visible = true
+            delay(650)
+            visible = false
+        }
+    }
+
+    val metrics: State<Pair<Float, Float>> = remember(state) {
+        derivedStateOf {
+            val info = state.layoutInfo
+            val total = info.totalItemsCount
+            val visibleItems = info.visibleItemsInfo
+            if (total == 0 || visibleItems.isEmpty()) {
+                1f to 0f
+            } else {
+                val first = visibleItems.first().index.toFloat()
+                val visibleCount = visibleItems.size.toFloat()
+                val scrollableRange = (total - visibleCount).coerceAtLeast(1f)
+                val thumbFraction = (visibleCount / total).coerceIn(0.04f, 1f)
+                val offsetFraction = (first / scrollableRange).coerceIn(0f, 1f)
+                thumbFraction to offsetFraction
+            }
+        }
+    }
+    val thumbFraction = metrics.value.first
+    val offsetFraction = metrics.value.second
+
+    if (visible) {
+        androidx.compose.foundation.layout.Box(
+            modifier = modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .width(4.dp)
+                .padding(vertical = 28.dp)
+                .drawBehind {
+                    val trackHeight = size.height
+                    val thumbHeight = trackHeight * thumbFraction
+                    val maxOffset = (trackHeight - thumbHeight).coerceAtLeast(0f)
+                    val thumbOffset = maxOffset * offsetFraction
+                    drawRoundRect(
+                        color = AppColors.TextTertiary.copy(alpha = 0.55f),
+                        topLeft = Offset(0f, thumbOffset),
+                        size = Size(size.width, thumbHeight),
+                        cornerRadius = CornerRadius(size.width / 2f)
+                    )
+                }
+        )
+    }
+}

--- a/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardScreen.kt
@@ -69,6 +69,8 @@ import com.streamvault.app.ui.time.LocalAppTimeFormat
 import com.streamvault.app.ui.time.createDateTimeFormat
 import com.streamvault.app.ui.design.AppColors.Brand as Primary
 import com.streamvault.app.ui.design.AppColors.Focus as FocusBorder
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
+import androidx.compose.foundation.lazy.rememberLazyListState
 import com.streamvault.app.ui.design.AppColors.SurfaceElevated as SurfaceElevated
 import com.streamvault.app.ui.design.AppColors.SurfaceEmphasis as SurfaceHighlight
 import com.streamvault.app.ui.design.AppColors.TextPrimary as OnBackground
@@ -115,6 +117,8 @@ fun DashboardScreen(
         }
     }
 
+    val dashboardListState = rememberLazyListState()
+
     Box(modifier = Modifier.fillMaxSize()) {
         AppScreenScaffold(
             currentRoute = currentRoute,
@@ -152,7 +156,9 @@ fun DashboardScreen(
                 }
             }
 
+            Box(modifier = Modifier.fillMaxSize()) {
             androidx.compose.foundation.lazy.LazyColumn(
+                state = dashboardListState,
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = 28.dp)
             ) {
@@ -305,6 +311,8 @@ fun DashboardScreen(
                 }
             }
             }
+            MaterialVerticalScrollbar(state = dashboardListState)
+        }
         }
 
         SnackbarHost(
@@ -502,7 +510,7 @@ private fun DashboardShortcutCard(
     val accentColor = when (shortcut.type) {
         DashboardShortcutType.FAVORITES -> Color(0xFFFFC857)
         DashboardShortcutType.RECENT -> Color(0xFF4FD1C5)
-        DashboardShortcutType.LAST_GROUP -> Color(0xFF60A5FA)
+        DashboardShortcutType.LAST_GROUP -> Color(0xFFA78BFA)
         DashboardShortcutType.CUSTOM_GROUP -> Primary
     }
 

--- a/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardShelfCustomizationDialog.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/dashboard/DashboardShelfCustomizationDialog.kt
@@ -27,6 +27,7 @@ import com.streamvault.app.R
 import com.streamvault.app.ui.components.dialogs.PremiumDialog
 import com.streamvault.app.ui.components.dialogs.PremiumDialogFooterButton
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnSurface
@@ -222,7 +223,7 @@ private fun DashboardShelfActionChip(
                 shape = RoundedCornerShape(12.dp)
             ),
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(12.dp)
             )
         )

--- a/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/epg/EpgGridComponents.kt
@@ -58,6 +58,7 @@ import com.streamvault.app.ui.model.guideLookupKey
 import com.streamvault.app.ui.time.LocalAppTimeFormat
 import com.streamvault.app.ui.time.createTimeFormatter
 import com.streamvault.app.ui.theme.FocusBorder
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
@@ -184,6 +185,7 @@ internal fun EpgGrid(
                 scrollState = horizontalScrollState
             )
             Spacer(modifier = Modifier.height(4.dp))
+            Box(modifier = Modifier.fillMaxSize()) {
             LazyColumn(
                 state = verticalListState,
                 modifier = Modifier.fillMaxSize(),
@@ -224,6 +226,8 @@ internal fun EpgGrid(
                     )
                 }
             }
+                MaterialVerticalScrollbar(state = verticalListState)
+        }
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/favorites/FavoritesScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/favorites/FavoritesScreen.kt
@@ -67,6 +67,7 @@ import com.streamvault.app.ui.components.shell.AppSectionHeader
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.theme.OnBackground
 import com.streamvault.app.ui.theme.OnPrimary
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
@@ -401,6 +402,7 @@ fun FavoritesScreen(
 
                 else -> {
                     Box(modifier = Modifier.fillMaxSize()) {
+                        Box(modifier = Modifier.fillMaxSize()) {
                         LazyColumn(
                             state = listState,
                             modifier = Modifier.fillMaxSize(),
@@ -619,6 +621,8 @@ fun FavoritesScreen(
                                 section = activeReorderSection,
                                 movingFavoriteId = uiState.reorderItem?.id
                             )
+                        }
+                        MaterialVerticalScrollbar(state = listState)
                         }
                     }
                 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/home/HomeSidebarComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/home/HomeSidebarComponents.kt
@@ -433,7 +433,7 @@ internal fun ReorderSidePanel(
                     onClick = onSave,
                     colors = ButtonDefaults.colors(
                         containerColor = Primary,
-                        contentColor = Color.White
+                        contentColor = Color.Black
                     ),
                     modifier = Modifier.weight(1f)
                 ) { Text(stringResource(R.string.action_save), maxLines = 1) }

--- a/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/movies/MovieDetailScreen.kt
@@ -452,7 +452,7 @@ private fun MovieDetailHeroText(
                 modifier = Modifier.focusRequester(playButtonFocusRequester),
                 colors = ButtonDefaults.colors(
                     containerColor = AppColors.Brand,
-                    contentColor = Color.White
+                    contentColor = Color.Black
                 )
             ) {
                 Text(
@@ -510,7 +510,7 @@ private fun MovieDetailHeroText(
                 onClick = onToggleFavorite,
                 colors = ButtonDefaults.colors(
                     containerColor = if (movie.isFavorite) AppColors.Brand else AppColors.SurfaceEmphasis,
-                    contentColor = if (movie.isFavorite) Color.White else AppColors.TextSecondary
+                    contentColor = if (movie.isFavorite) Color.Black else AppColors.TextSecondary
                 )
             ) {
                 Icon(

--- a/app/src/main/java/com/streamvault/app/ui/screens/multiview/EnhancedMultiViewControlHud.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/multiview/EnhancedMultiViewControlHud.kt
@@ -23,6 +23,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Surface
 import androidx.tv.material3.Text
 import com.streamvault.app.R
+import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.theme.Primary
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.interaction.TvButton
@@ -50,7 +51,7 @@ internal fun EnhancedMultiViewControlHud(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),
         modifier = Modifier
-            .background(Color(0xFF0B1220).copy(alpha = 0.94f), RoundedCornerShape(24.dp))
+            .background(AppColors.CanvasElevated.copy(alpha = 0.94f), RoundedCornerShape(24.dp))
             .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(24.dp))
             .padding(horizontal = 22.dp, vertical = 18.dp)
     ) {
@@ -153,7 +154,7 @@ internal fun EnhancedMultiViewControlHud(
                 TvButton(
                     onClick = onClearPinnedAudio,
                     colors = ButtonDefaults.colors(
-                        containerColor = Color(0xFF203A5C),
+                        containerColor = AppColors.SurfaceAccent,
                         contentColor = Color.White,
                         focusedContainerColor = Color.White,
                         focusedContentColor = Color.Black
@@ -166,7 +167,7 @@ internal fun EnhancedMultiViewControlHud(
                     onClick = onPinAudioToFocusedSlot,
                     enabled = focused != null && !focused.isEmpty && focused.performanceBlockedReason == null,
                     colors = ButtonDefaults.colors(
-                        containerColor = Color(0xFF203A5C),
+                        containerColor = AppColors.SurfaceAccent,
                         contentColor = Color.White,
                         focusedContainerColor = Color.White,
                         focusedContentColor = Color.Black
@@ -210,7 +211,7 @@ internal fun EnhancedMultiViewControlHud(
                         TvButton(
                             onClick = { onSavePreset(preset.index) },
                             colors = ButtonDefaults.colors(
-                                containerColor = Color(0xFF172033),
+                                containerColor = AppColors.SurfaceElevated,
                                 contentColor = Color.White,
                                 focusedContainerColor = Color.White,
                                 focusedContentColor = Color.Black

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerControlsChrome.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerControlsChrome.kt
@@ -69,6 +69,7 @@ import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import com.streamvault.app.R
 import com.streamvault.app.device.rememberIsTelevisionDevice
+import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.components.rememberCrossfadeImageModel
 import com.streamvault.app.ui.model.isArchivePlayable
 import com.streamvault.app.ui.screens.player.NumericChannelInputState
@@ -612,7 +613,7 @@ private fun PlayerBottomBar(
                 Modifier.fillMaxWidth()
             },
             shape = RoundedCornerShape(if (isVod) 20.dp else 28.dp),
-            colors = SurfaceDefaults.colors(containerColor = Color(0xFF0C1624).copy(alpha = 0.92f))
+            colors = SurfaceDefaults.colors(containerColor = AppColors.CanvasElevated.copy(alpha = 0.92f))
         ) {
             Column(
                 modifier = Modifier

--- a/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerSystemOverlays.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/player/overlay/PlayerSystemOverlays.kt
@@ -104,7 +104,7 @@ fun PlayerNoticeBanner(
 
     val (containerColor, focusedContainerColor) = when {
         notice.isRetryNotice || notice.recoveryType == PlayerRecoveryType.NETWORK || notice.recoveryType == PlayerRecoveryType.CATCH_UP ->
-            Color(0xCC17314E) to Color(0xFF214C78)
+            Color(0xCC372F63) to Color(0xFF4F378B)
         notice.recoveryType == PlayerRecoveryType.SOURCE ||
             notice.recoveryType == PlayerRecoveryType.BUFFER_TIMEOUT ||
             notice.recoveryType == PlayerRecoveryType.DECODER ->

--- a/app/src/main/java/com/streamvault/app/ui/screens/plugins/PluginsScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/plugins/PluginsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -64,6 +65,8 @@ import com.streamvault.app.ui.components.shell.AppNavigationChrome
 import com.streamvault.app.ui.components.shell.AppScreenScaffold
 import com.streamvault.app.ui.components.shell.StatusPill
 import com.streamvault.app.ui.design.AppColors
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
+import androidx.compose.foundation.lazy.rememberLazyListState
 import com.streamvault.app.ui.design.FocusSpec
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.theme.FocusBorder
@@ -104,6 +107,7 @@ fun PluginsScreen(
             modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
+            val pluginsListState = rememberLazyListState()
             val configuration = uiState.configuration
             if (configuration != null) {
                 PluginConfigurationPanel(
@@ -159,7 +163,9 @@ fun PluginsScreen(
                     )
                 }
 
+                Box(modifier = Modifier.fillMaxSize()) {
                 LazyColumn(
+                    state = pluginsListState,
                     modifier = Modifier.fillMaxSize(),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
@@ -182,6 +188,8 @@ fun PluginsScreen(
                     }
                     item { Spacer(modifier = Modifier.height(20.dp)) }
                 }
+                MaterialVerticalScrollbar(state = pluginsListState)
+            }
             }
         }
         SnackbarHost(hostState = snackbarHostState)
@@ -205,9 +213,9 @@ private fun PluginButton(
     val colors = when (tone) {
         PluginButtonTone.Primary -> ButtonDefaults.colors(
             containerColor = Primary,
-            contentColor = Color.White,
+            contentColor = Color.Black,
             focusedContainerColor = Primary.copy(alpha = 0.88f),
-            focusedContentColor = Color.White,
+            focusedContentColor = Color.Black,
             disabledContainerColor = AppColors.SurfaceEmphasis.copy(alpha = 0.56f),
             disabledContentColor = AppColors.TextDisabled
         )
@@ -465,6 +473,7 @@ private fun PluginConfigurationPanel(
     onValueChange: (String, String) -> Unit,
     onRunAction: (PluginConfigurationAction) -> Unit
 ) {
+    val pluginsConfigListState = rememberLazyListState()
     val busy = configuration.isSaving || configuration.runningActionId != null
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -478,8 +487,10 @@ private fun PluginConfigurationPanel(
             onSave = onSave
         )
 
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
         LazyColumn(
-            modifier = Modifier.weight(1f),
+            state = pluginsConfigListState,
+            modifier = Modifier.fillMaxSize(),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             configuration.schema.sections.forEach { section ->
@@ -505,6 +516,8 @@ private fun PluginConfigurationPanel(
             }
 
             item { Spacer(modifier = Modifier.height(20.dp)) }
+        }
+        MaterialVerticalScrollbar(state = pluginsConfigListState)
         }
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/series/SeriesDetailScreen.kt
@@ -558,7 +558,7 @@ private fun SeriesDetailActions(
             onClick = { onResumeClick(resumeEpisode) },
             colors = ButtonDefaults.colors(
                 containerColor = AppColors.Brand,
-                contentColor = Color.White
+                contentColor = Color.Black
             )
         ) {
             Text(
@@ -614,7 +614,7 @@ private fun SeriesDetailFavoriteAction(
         onClick = onToggleFavorite,
         colors = ButtonDefaults.colors(
             containerColor = if (series.isFavorite) AppColors.Brand else AppColors.SurfaceEmphasis,
-            contentColor = if (series.isFavorite) Color.White else AppColors.TextSecondary
+            contentColor = if (series.isFavorite) Color.Black else AppColors.TextSecondary
         )
     ) {
         Icon(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBrowsingSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsBrowsingSection.kt
@@ -75,6 +75,15 @@ internal fun LazyListScope.settingsBrowsingSection(
     onRemoteShortcutDialogTargetChange: (RemoteShortcutDialogTarget?) -> Unit
 ) {
     item {
+        SwitchSettingsRow(
+            label = stringResource(R.string.settings_dark_theme),
+            value = stringResource(
+                if (uiState.darkTheme) R.string.settings_enabled else R.string.settings_disabled
+            ),
+            checked = uiState.darkTheme,
+            onCheckedChange = viewModel::setDarkTheme
+        )
+        HorizontalDivider(color = Color.White.copy(alpha = 0.07f), modifier = Modifier.padding(vertical = 4.dp))
         ClickableSettingsRow(
             label = stringResource(R.string.settings_live_tv_channel_mode),
             value = stringResource(uiState.liveTvChannelMode.labelResId()),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsCombinedM3uComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsCombinedM3uComponents.kt
@@ -38,6 +38,7 @@ import com.streamvault.app.R
 import com.streamvault.app.ui.components.dialogs.PremiumDialog
 import com.streamvault.app.ui.components.dialogs.PremiumDialogFooterButton
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.ErrorColor
 import com.streamvault.app.ui.theme.OnBackground
@@ -421,7 +422,7 @@ internal fun AddCombinedProviderDialog(
                                     shape = RoundedCornerShape(12.dp)
                                 ),
                                 focusedBorder = Border(
-                                    border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                                    border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                                     shape = RoundedCornerShape(12.dp)
                                 )
                             ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsContentPane.kt
@@ -2,13 +2,17 @@ package com.streamvault.app.ui.screens.settings
 
 import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
 import com.streamvault.domain.model.LegacyProvider as Provider
 
 @Composable
@@ -40,8 +44,12 @@ internal fun SettingsContentPane(
     onOpenUri: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val settingsListState = rememberLazyListState()
+
+    Box(modifier = modifier.fillMaxSize()) {
     LazyColumn(
-        modifier = modifier
+        state = settingsListState,
+        modifier = Modifier
             .fillMaxHeight()
             .imePadding(),
         contentPadding = PaddingValues(start = 20.dp, top = 76.dp, end = 20.dp, bottom = 32.dp),
@@ -208,5 +216,7 @@ internal fun SettingsContentPane(
                 onDeleteCrashReport = onDeleteCrashReport
             )
         }
+    }
+        MaterialVerticalScrollbar(state = settingsListState)
     }
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSection.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSection.kt
@@ -33,6 +33,7 @@ import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import androidx.compose.foundation.lazy.items
+import com.streamvault.app.ui.design.AppColors
 import com.streamvault.app.ui.design.FocusSpec
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
@@ -182,7 +183,7 @@ private fun ProviderGuideAndLogoPolicyCard(
             .fillMaxWidth()
             .padding(bottom = 16.dp)
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF152333))
+            .background(AppColors.SurfaceElevated)
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
@@ -229,11 +230,11 @@ private fun PolicyChip(
         modifier = Modifier,
         shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(999.dp)),
         colors = ClickableSurfaceDefaults.colors(
-            containerColor = if (selected) Primary.copy(alpha = 0.22f) else Color(0xFF0F1B29),
-            focusedContainerColor = if (selected) Primary.copy(alpha = 0.32f) else Color(0xFF1A2A3B)
+            containerColor = if (selected) Primary.copy(alpha = 0.22f) else AppColors.Surface,
+            focusedContainerColor = if (selected) Primary.copy(alpha = 0.32f) else AppColors.SurfaceEmphasis
         ),
         border = ClickableSurfaceDefaults.border(
-            border = Border(BorderStroke(1.dp, if (selected) Primary else Color(0xFF2D4358))),
+            border = Border(BorderStroke(1.dp, if (selected) Primary else AppColors.SurfaceAccent)),
             focusedBorder = Border(BorderStroke(2.dp, Primary))
         ),
         glow = ClickableSurfaceDefaults.glow(),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSourceComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsEpgSourceComponents.kt
@@ -28,6 +28,7 @@ import androidx.tv.material3.ClickableSurfaceDefaults
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
@@ -336,7 +337,7 @@ internal fun epgActionBorder(shape: RoundedCornerShape, enabled: Boolean = true)
             shape = shape
         ),
         focusedBorder = Border(
-            border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+            border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
             shape = shape
         )
     )

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsNavigationRail.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsNavigationRail.kt
@@ -58,7 +58,7 @@ internal fun SettingsNavigationRail(
         SettingsNavEntry(
             label = stringResource(R.string.settings_backup_restore),
             icon = "B",
-            accent = Color(0xFF42A5F5)
+            accent = Color(0xFF9575CD)
         ),
         SettingsNavEntry(
             label = "EPG Sources",

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceModels.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceModels.kt
@@ -48,6 +48,7 @@ internal data class SettingsPreferenceSnapshot(
     val parentalControlLevel: Int,
     val hasParentalPin: Boolean,
     val appLanguage: String,
+    val darkTheme: Boolean,
     val appLandingDestination: AppLandingDestination,
     val appTopLevelDestinations: List<AppTopLevelDestination>,
     val appHomeDashboardShelves: List<AppHomeDashboardShelf>,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceSnapshotMapper.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsPreferenceSnapshotMapper.kt
@@ -8,6 +8,7 @@ internal fun SettingsUiState.applyPreferenceSnapshot(snapshot: SettingsPreferenc
         parentalControlLevel = snapshot.parentalControlLevel,
         hasParentalPin = snapshot.hasParentalPin,
         appLanguage = snapshot.appLanguage,
+        darkTheme = snapshot.darkTheme,
         appLandingDestination = snapshot.appLandingDestination,
         appTopLevelDestinations = snapshot.appTopLevelDestinations,
         appHomeDashboardShelves = snapshot.appHomeDashboardShelves,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsProviderCardSections.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsProviderCardSections.kt
@@ -23,6 +23,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import com.streamvault.app.R
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.ErrorColor
 import com.streamvault.app.ui.theme.OnBackground
@@ -234,7 +235,7 @@ private fun ProviderActionButton(
         ),
         border = ClickableSurfaceDefaults.border(
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(6.dp)
             )
         ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingBrowserDialog.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingBrowserDialog.kt
@@ -41,6 +41,7 @@ import com.streamvault.app.ui.components.TvEmptyState
 import com.streamvault.app.ui.theme.ErrorColor
 import com.streamvault.app.ui.theme.OnBackground
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
@@ -263,7 +264,7 @@ private fun RecordingPickerRow(
                 shape = RoundedCornerShape(12.dp)
             ),
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(12.dp)
             )
         ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingBrowserDisplay.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingBrowserDisplay.kt
@@ -105,7 +105,7 @@ internal fun recordingStatusLabel(status: RecordingStatus): String = when (statu
 internal fun recordingStatusAccent(status: RecordingStatus): Color = when (status) {
     RecordingStatus.RECORDING -> Primary
     RecordingStatus.SCHEDULED -> Secondary
-    RecordingStatus.COMPLETED -> Color(0xFF7BA7FF)
+    RecordingStatus.COMPLETED -> Color(0xFF4FD1C5)
     RecordingStatus.FAILED -> ErrorColor
     RecordingStatus.CANCELLED -> OnSurfaceDim
 }

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingComponents.kt
@@ -41,6 +41,7 @@ import com.streamvault.app.ui.components.dialogs.PremiumDialog
 import com.streamvault.app.ui.components.dialogs.PremiumDialogActionButton
 import com.streamvault.app.ui.components.dialogs.PremiumDialogFooterButton
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.interaction.mouseClickable
@@ -106,7 +107,7 @@ internal fun RecordingActionButton(
                 shape = RoundedCornerShape(10.dp)
             ),
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(10.dp)
             )
         ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingItemComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsRecordingItemComponents.kt
@@ -25,6 +25,7 @@ import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import com.streamvault.app.R
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.ErrorColor
 import com.streamvault.app.ui.theme.OnBackground
@@ -254,7 +255,7 @@ internal fun CompactRecordingActionChip(label: String, accent: Color, onClick: (
         ),
         border = ClickableSurfaceDefaults.border(
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(8.dp)
             )
         ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSharedUiComponents.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsSharedUiComponents.kt
@@ -44,6 +44,7 @@ import androidx.tv.material3.SurfaceDefaults
 import androidx.tv.material3.Text
 import com.streamvault.app.R
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.theme.OnBackground
 import com.streamvault.app.ui.theme.OnSurfaceDim
@@ -159,7 +160,7 @@ internal fun CompactSettingsActionChip(
                 shape = RoundedCornerShape(8.dp)
             ),
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(8.dp)
             )
         ),

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsStateBindings.kt
@@ -46,6 +46,7 @@ internal fun observeSettingsPreferenceSnapshot(
             parentalControlLevel = level,
             hasParentalPin = hasParentalPin,
             appLanguage = "system",
+            darkTheme = false,
             appLandingDestination = AppLandingDestination.HOME,
             appTopLevelDestinations = AppTopLevelDestination.defaultOrder,
             appHomeDashboardShelves = AppHomeDashboardShelf.defaultOrder,
@@ -126,6 +127,8 @@ internal fun observeSettingsPreferenceSnapshot(
         )
     }.combine(preferencesRepository.appLanguage) { snapshot, language ->
         snapshot.copy(appLanguage = language)
+    }.combine(preferencesRepository.darkTheme) { snapshot, darkTheme ->
+        snapshot.copy(darkTheme = darkTheme)
     }.combine(preferencesRepository.appLandingDestination) { snapshot, destination ->
         snapshot.copy(appLandingDestination = destination)
     }.combine(preferencesRepository.appTopLevelDestinations) { snapshot, destinations ->

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsUiStateModel.kt
@@ -73,6 +73,7 @@ data class SettingsUiState(
     val parentalControlLevel: Int = 0,
     val hasParentalPin: Boolean = false,
     val appLanguage: String = "system",
+    val darkTheme: Boolean = false,
     val appLandingDestination: AppLandingDestination = AppLandingDestination.HOME,
     val appTopLevelDestinations: List<AppTopLevelDestination> = AppTopLevelDestination.defaultOrder,
     val appHomeDashboardShelves: List<AppHomeDashboardShelf> = AppHomeDashboardShelf.defaultOrder,

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/SettingsViewModel.kt
@@ -463,6 +463,12 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setDarkTheme(enabled: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.setDarkTheme(enabled)
+        }
+    }
+
     fun setAppLandingDestination(destination: AppLandingDestination) {
         viewModelScope.launch {
             preferencesRepository.setAppLandingDestination(

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/TopNavigationDialog.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/TopNavigationDialog.kt
@@ -29,6 +29,7 @@ import com.streamvault.app.ui.components.dialogs.PremiumDialogFooterButton
 import com.streamvault.app.ui.interaction.TvButton
 import com.streamvault.app.ui.interaction.TvClickableSurface
 import com.streamvault.app.ui.design.FocusSpec
+import com.streamvault.app.ui.theme.FocusBorder
 import com.streamvault.app.ui.theme.OnSurface
 import com.streamvault.app.ui.theme.OnSurfaceDim
 import com.streamvault.app.ui.theme.Primary
@@ -202,7 +203,7 @@ private fun NavigationVisibilityToggle(
                 shape = RoundedCornerShape(12.dp)
             ),
             focusedBorder = Border(
-                border = BorderStroke(FocusSpec.BorderWidth, Color.White),
+                border = BorderStroke(FocusSpec.BorderWidth, FocusBorder),
                 shape = RoundedCornerShape(12.dp)
             )
         )

--- a/app/src/main/java/com/streamvault/app/ui/screens/settings/parental/ParentalControlGroupScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/settings/parental/ParentalControlGroupScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import com.streamvault.app.ui.design.AppColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -322,8 +323,8 @@ private fun CategoryModeChip(
         onClick = onClick,
         shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(999.dp)),
         colors = ClickableSurfaceDefaults.colors(
-            containerColor = if (selected) Color(0xFF3E7BFA).copy(alpha = 0.18f) else MaterialTheme.colorScheme.surfaceVariant,
-            focusedContainerColor = Color(0xFF3E7BFA).copy(alpha = 0.28f)
+            containerColor = if (selected) AppColors.Brand.copy(alpha = 0.18f) else MaterialTheme.colorScheme.surfaceVariant,
+            focusedContainerColor = AppColors.Brand.copy(alpha = 0.28f)
         ),
         border = ClickableSurfaceDefaults.border(),
         scale = ClickableSurfaceDefaults.scale(focusedScale = 1f)
@@ -331,7 +332,7 @@ private fun CategoryModeChip(
         Text(
             text = label,
             style = MaterialTheme.typography.labelLarge,
-            color = if (selected) Color(0xFF7EB1FF) else MaterialTheme.colorScheme.onSurface,
+            color = if (selected) AppColors.Brand else MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp)
         )
     }
@@ -356,7 +357,7 @@ private fun ProtectionSummaryCard(
         Text(
             text = selectedTypeLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = Color(0xFF7EB1FF)
+            color = AppColors.Brand
         )
         Text(
             text = stringResource(R.string.settings_category_protection_summary_title),
@@ -414,7 +415,7 @@ private fun VisibilitySummaryCard(
         Text(
             text = selectedTypeLabel,
             style = MaterialTheme.typography.labelMedium,
-            color = Color(0xFF7EB1FF)
+            color = AppColors.Brand
         )
         Text(
             text = stringResource(R.string.settings_category_visibility_summary_title),
@@ -460,11 +461,11 @@ private fun SettingsActionButton(
         colors = ClickableSurfaceDefaults.colors(
             containerColor = when {
                 !enabled -> MaterialTheme.colorScheme.surface.copy(alpha = 0.55f)
-                emphasized -> Color(0xFF3E7BFA).copy(alpha = 0.18f)
+                emphasized -> AppColors.Brand.copy(alpha = 0.18f)
                 else -> MaterialTheme.colorScheme.surface
             },
             focusedContainerColor = if (enabled) {
-                if (emphasized) Color(0xFF3E7BFA).copy(alpha = 0.28f) else MaterialTheme.colorScheme.surface
+                if (emphasized) AppColors.Brand.copy(alpha = 0.28f) else MaterialTheme.colorScheme.surface
             } else {
                 MaterialTheme.colorScheme.surface.copy(alpha = 0.55f)
             }
@@ -476,7 +477,7 @@ private fun SettingsActionButton(
             style = MaterialTheme.typography.labelLarge,
             color = when {
                 !enabled -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.45f)
-                emphasized -> Color(0xFF7EB1FF)
+                emphasized -> AppColors.Brand
                 else -> MaterialTheme.colorScheme.onSurface
             },
             modifier = Modifier.padding(horizontal = 18.dp, vertical = 10.dp)
@@ -552,7 +553,7 @@ private fun CategoryProtectionCard(
                 style = MaterialTheme.typography.labelLarge,
                 color = when {
                     item.category.isAdult -> MaterialTheme.colorScheme.error
-                    item.isProtected -> Color(0xFF7EB1FF)
+                    item.isProtected -> AppColors.Brand
                     else -> MaterialTheme.colorScheme.onSurfaceVariant
                 }
             )
@@ -603,7 +604,7 @@ private fun CategoryVisibilityCard(
                         Text(
                             text = stringResource(R.string.settings_category_status_hidden),
                             style = MaterialTheme.typography.bodySmall,
-                            color = Color(0xFF7EB1FF)
+                            color = AppColors.Brand
                         )
                     }
                 }
@@ -623,7 +624,7 @@ private fun CategoryVisibilityCard(
                     stringResource(R.string.settings_hide_category)
                 },
                 style = MaterialTheme.typography.labelLarge,
-                color = if (item.isHidden) Color(0xFF7EB1FF) else MaterialTheme.colorScheme.onSurface
+                color = if (item.isHidden) AppColors.Brand else MaterialTheme.colorScheme.onSurface
             )
         }
     }

--- a/app/src/main/java/com/streamvault/app/ui/screens/vod/VodScreen.kt
+++ b/app/src/main/java/com/streamvault/app/ui/screens/vod/VodScreen.kt
@@ -46,6 +46,7 @@ import com.streamvault.app.ui.components.shell.VodBrowseOptionsDialog
 import com.streamvault.app.ui.components.shell.VodCategoryOption
 import com.streamvault.app.ui.components.shell.VodCategoryPickerDialog
 import com.streamvault.app.ui.components.shell.VodSectionHeader
+import com.streamvault.app.ui.design.MaterialVerticalScrollbar
 import com.streamvault.app.ui.model.VodViewMode
 import com.streamvault.domain.model.LibraryFilterType
 import com.streamvault.domain.model.LibrarySortBy
@@ -139,6 +140,7 @@ private fun VodModernShelves(
     var showCategoryPicker by rememberSaveable { mutableStateOf(false) }
     val listState = rememberLazyListState()
     InfiniteScrollEffect(listState, true, canLoadMore, false, onLoadMore = onLoadMore)
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(
         state = listState,
         modifier = Modifier.fillMaxSize(),
@@ -177,6 +179,8 @@ private fun VodModernShelves(
             }
         }
     }
+        MaterialVerticalScrollbar(state = listState)
+    }
     if (showCategoryPicker) {
         VodCategoryPickerDialog(
             title = stringResource(R.string.vod_category_picker_title),
@@ -203,6 +207,7 @@ private fun VodClassicCategories(
     var showCategoryPicker by rememberSaveable { mutableStateOf(false) }
     val listState = rememberLazyListState()
     InfiniteScrollEffect(listState, true, canLoadMore, false, onLoadMore = onLoadMore)
+    Box(modifier = Modifier.fillMaxSize()) {
     LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
         item(key = "vod_classic_actions") {
             VodActionChipRow(
@@ -228,6 +233,8 @@ private fun VodClassicCategories(
                 )
             }
         }
+    }
+        MaterialVerticalScrollbar(state = listState)
     }
     if (showCategoryPicker) {
         VodCategoryPickerDialog(

--- a/app/src/main/java/com/streamvault/app/ui/theme/Color.kt
+++ b/app/src/main/java/com/streamvault/app/ui/theme/Color.kt
@@ -3,36 +3,40 @@ package com.streamvault.app.ui.theme
 import androidx.compose.ui.graphics.Color
 import com.streamvault.app.ui.design.AppColors
 
-val Primary = AppColors.Brand
-val PrimaryLight = AppColors.BrandStrong
-val PrimaryGlow = AppColors.BrandMuted
+// Every alias below is a computed getter over the theme-reactive AppColors
+// palette, so existing `import ...ui.theme.Primary` call sites follow the
+// active dark/light theme without any changes at the call site.
 
-val BackgroundDeep = AppColors.Canvas
-val Background = AppColors.CanvasElevated
-val Surface = AppColors.Surface
-val SurfaceElevated = AppColors.SurfaceElevated
-val SurfaceHighlight = AppColors.SurfaceEmphasis
+val Primary: Color get() = AppColors.Brand
+val PrimaryLight: Color get() = AppColors.BrandStrong
+val PrimaryGlow: Color get() = AppColors.BrandMuted
 
-val TextPrimary = AppColors.TextPrimary
-val TextSecondary = AppColors.TextSecondary
-val TextTertiary = AppColors.TextTertiary
-val TextDisabled = AppColors.TextDisabled
+val BackgroundDeep: Color get() = AppColors.Canvas
+val Background: Color get() = AppColors.CanvasElevated
+val Surface: Color get() = AppColors.Surface
+val SurfaceElevated: Color get() = AppColors.SurfaceElevated
+val SurfaceHighlight: Color get() = AppColors.SurfaceEmphasis
 
-val OnBackground = TextPrimary
-val OnSurface = TextPrimary
-val OnSurfaceDim = TextTertiary
+val TextPrimary: Color get() = AppColors.TextPrimary
+val TextSecondary: Color get() = AppColors.TextSecondary
+val TextTertiary: Color get() = AppColors.TextTertiary
+val TextDisabled: Color get() = AppColors.TextDisabled
 
-val AccentRed = AppColors.Live
-val AccentGreen = AppColors.Success
-val AccentAmber = AppColors.Warning
-val AccentCyan = AppColors.Info
+val OnBackground: Color get() = TextPrimary
+val OnSurface: Color get() = TextPrimary
+val OnSurfaceDim: Color get() = TextTertiary
 
-val OnPrimary = Color(0xFFFFFFFF)
-val Secondary = AppColors.Success
-val ErrorColor = AccentRed
+val AccentRed: Color get() = AppColors.Live
+val AccentGreen: Color get() = AppColors.Success
+val AccentAmber: Color get() = AppColors.Warning
+val AccentCyan: Color get() = AppColors.Info
 
-val GradientOverlayTop = AppColors.HeroTop
-val GradientOverlayBottom = AppColors.HeroBottom
+val OnPrimary: Color get() = AppColors.OnPrimary
+val Secondary: Color get() = AppColors.Success
+val ErrorColor: Color get() = AccentRed
 
-val FocusBorder = AppColors.Focus
-val ProgressBarBackground = AppColors.SurfaceAccent
+val GradientOverlayTop: Color get() = AppColors.HeroTop
+val GradientOverlayBottom: Color get() = AppColors.HeroBottom
+
+val FocusBorder: Color get() = AppColors.Focus
+val ProgressBarBackground: Color get() = AppColors.SurfaceAccent

--- a/app/src/main/java/com/streamvault/app/ui/theme/Theme.kt
+++ b/app/src/main/java/com/streamvault/app/ui/theme/Theme.kt
@@ -2,36 +2,89 @@ package com.streamvault.app.ui.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.darkColorScheme
+import androidx.tv.material3.lightColorScheme
 import com.streamvault.app.ui.design.AppColors
+import com.streamvault.app.ui.design.AppPalette
 import com.streamvault.app.ui.design.AppShapes
 import com.streamvault.app.ui.design.LocalAppShapes
 import com.streamvault.app.ui.design.LocalAppSpacing
 import com.streamvault.app.ui.design.rememberAppTypography
 
-private val DarkColorScheme = darkColorScheme(
-    primary = AppColors.Brand,
-    onPrimary = OnPrimary,
-    surface = AppColors.Surface,
-    onSurface = AppColors.TextPrimary,
-    surfaceVariant = AppColors.SurfaceElevated,
-    onSurfaceVariant = AppColors.TextSecondary,
-    background = AppColors.CanvasElevated,
-    onBackground = AppColors.TextPrimary,
-    error = AppColors.Live,
-    onError = OnPrimary
-)
+/**
+ * StreamVault theme.
+ *
+ * - Light (default): the ORIGINAL blue StreamVault look.
+ * - Dark: the M3 purple-on-black look (lavender primary, neutral surfaces).
+ *
+ * Beyond the Material scheme, this installs the shared [AppColors] palette so
+ * every hardcoded `AppColors.X` / `ui.theme.X` color reference follows the
+ * dark/light toggle.
+ */
+private fun colorSchemeFor(palette: AppPalette, dark: Boolean) =
+    if (dark) {
+        // M3 purple scheme: dark purple text on the lavender primary.
+        darkColorScheme(
+            primary = palette.brand,
+            onPrimary = palette.onPrimary,
+            secondary = palette.success,
+            onSecondary = Color(0xFF003320),
+            tertiary = palette.info,
+            onTertiary = Color(0xFF00344A),
+            background = palette.canvasElevated,
+            onBackground = palette.textPrimary,
+            surface = palette.surface,
+            onSurface = palette.textPrimary,
+            surfaceVariant = palette.surfaceElevated,
+            onSurfaceVariant = palette.textSecondary,
+            error = palette.live,
+            onError = palette.onPrimary,
+            errorContainer = palette.live.copy(alpha = 0.20f),
+            onErrorContainer = Color(0xFFFFDCDE)
+        )
+    } else {
+        // Original blue scheme: white text on the blue primary.
+        lightColorScheme(
+            primary = palette.brand,
+            onPrimary = Color.White,
+            secondary = palette.success,
+            onSecondary = Color(0xFF003320),
+            tertiary = palette.info,
+            onTertiary = Color(0xFF00344A),
+            background = palette.canvasElevated,
+            onBackground = palette.textPrimary,
+            surface = palette.surface,
+            onSurface = palette.textPrimary,
+            surfaceVariant = palette.surfaceElevated,
+            onSurfaceVariant = palette.textSecondary,
+            error = palette.live,
+            onError = Color.White,
+            errorContainer = palette.live.copy(alpha = 0.14f),
+            onErrorContainer = Color(0xFF5F1316)
+        )
+    }
+
+val LocalDarkTheme = staticCompositionLocalOf { false }
 
 @Composable
-fun StreamVaultTheme(content: @Composable () -> Unit) {
+fun StreamVaultTheme(
+    useDarkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
     val typography = rememberAppTypography()
+    // Install the palette before composing children so every AppColors read in
+    // this pass observes the active theme (and all past readers recompose).
+    AppColors.current = if (useDarkTheme) AppPalette.dark() else AppPalette.light()
     CompositionLocalProvider(
         LocalAppSpacing provides com.streamvault.app.ui.design.AppSpacing(),
-        LocalAppShapes provides AppShapes()
+        LocalAppShapes provides AppShapes(),
+        LocalDarkTheme provides useDarkTheme
     ) {
         MaterialTheme(
-            colorScheme = DarkColorScheme,
+            colorScheme = colorSchemeFor(AppColors.current, useDarkTheme),
             typography = typography,
             content = content
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -649,6 +649,7 @@
     <string name="settings_build_verification_unavailable">Verification unavailable</string>
     <string name="settings_enabled">Enabled</string>
     <string name="settings_disabled">Disabled</string>
+    <string name="settings_dark_theme">Dark theme</string>
     <string name="settings_developed_by">Developed by</string>
     <string name="settings_developer_name">David Nashash</string>
     <string name="settings_github">GitHub</string>

--- a/data/src/main/java/com/streamvault/data/manager/BackupManagerImpl.kt
+++ b/data/src/main/java/com/streamvault/data/manager/BackupManagerImpl.kt
@@ -201,6 +201,7 @@ class BackupManagerImpl @Inject constructor(
                 put("parentalPinHash", parentalPinBackup?.hash ?: "")
                 put("parentalPinSalt", parentalPinBackup?.saltBase64 ?: "")
                 put("appLanguage", preferencesRepository.appLanguage.first())
+                put("darkTheme", preferencesRepository.darkTheme.first().toString())
                 put("appTimeFormat", preferencesRepository.appTimeFormat.first().storageValue)
                 put("defaultViewMode", preferencesRepository.defaultViewMode.first().orEmpty())
                 put("appLandingDestination", preferencesRepository.appLandingDestination.first().storageValue)
@@ -3140,6 +3141,7 @@ class BackupManagerImpl @Inject constructor(
             put("parentalPinHash", parentalPinBackup?.hash.orEmpty())
             put("parentalPinSalt", parentalPinBackup?.saltBase64.orEmpty())
             put("appLanguage", preferencesRepository.appLanguage.first())
+            put("darkTheme", preferencesRepository.darkTheme.first().toString())
             put("appTimeFormat", preferencesRepository.appTimeFormat.first().storageValue)
             put("defaultViewMode", preferencesRepository.defaultViewMode.first().orEmpty())
             put("appLandingDestination", preferencesRepository.appLandingDestination.first().storageValue)
@@ -3595,6 +3597,8 @@ class BackupManagerImpl @Inject constructor(
             ).takeIf { it.hash.isNotBlank() && it.saltBase64.isNotBlank() }
         )
         prefs["appLanguage"]?.takeIf { it.isNotBlank() }?.let { preferencesRepository.setAppLanguage(it) }
+        prefs["darkTheme"]?.toBooleanStrictOrNull()
+            ?.let { preferencesRepository.setDarkTheme(it) }
         prefs["appTimeFormat"]?.takeIf { it.isNotBlank() }?.let { savedFormat ->
             preferencesRepository.setAppTimeFormat(
                 com.streamvault.domain.model.AppTimeFormat.fromStorage(savedFormat)

--- a/data/src/main/java/com/streamvault/data/manager/PreferenceBackupRegistry.kt
+++ b/data/src/main/java/com/streamvault/data/manager/PreferenceBackupRegistry.kt
@@ -12,7 +12,7 @@ internal object PreferenceBackupRegistry {
     private val portableStorageKeys = setOf(
         "last_active_provider_id", "active_live_source_type", "active_live_source_id",
         "default_view_mode", "parental_control_level", "parental_pin_hash", "parental_pin_salt",
-        "default_category_id", "app_language", "app_landing_destination", "app_top_level_destinations",
+        "default_category_id", "app_language", "dark_theme", "app_landing_destination", "app_top_level_destinations",
         "app_home_dashboard_shelves", "app_time_format", "live_tv_channel_mode",
         "show_live_source_switcher", "show_favorites_category", "show_all_channels_category",
         "show_recent_channels_category", "live_tv_category_filters", "live_tv_quick_filter_visibility",
@@ -86,7 +86,7 @@ internal object PreferenceBackupRegistry {
         "vodVariantSelections_"
     )
     private val globalKeys = setOf(
-        "parentalControlLevel", "parentalPinHash", "parentalPinSalt", "appLanguage", "appTimeFormat",
+        "parentalControlLevel", "parentalPinHash", "parentalPinSalt", "appLanguage", "darkTheme", "appTimeFormat",
         "defaultViewMode", "appLandingDestination", "appTopLevelDestinations", "appHomeDashboardShelves",
         "remoteShortcutPreferences", "liveTvCategoryFilters", "liveTvQuickFilterVisibility", "liveTvChannelMode",
         "showLiveSourceSwitcher", "showFavoritesCategory", "showAllChannelsCategory", "showRecentChannelsCategory",

--- a/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
+++ b/data/src/main/java/com/streamvault/data/preferences/PreferencesRepository.kt
@@ -185,6 +185,7 @@ class PreferencesRepository @Inject constructor(
         val PARENTAL_PIN_SALT = stringPreferencesKey("parental_pin_salt")
         val DEFAULT_CATEGORY_ID = longPreferencesKey("default_category_id")
         val APP_LANGUAGE = stringPreferencesKey("app_language")
+        val DARK_THEME = booleanPreferencesKey("dark_theme")
         val APP_LANDING_DESTINATION = stringPreferencesKey("app_landing_destination")
         val APP_TOP_LEVEL_DESTINATIONS = stringPreferencesKey("app_top_level_destinations")
         val APP_HOME_DASHBOARD_SHELVES = stringPreferencesKey("app_home_dashboard_shelves")
@@ -1457,6 +1458,10 @@ class PreferencesRepository @Inject constructor(
         preferences[PreferencesKeys.APP_LANGUAGE] ?: "system"
     }
 
+    val darkTheme: Flow<Boolean> = context.dataStore.data.map { preferences ->
+        preferences[PreferencesKeys.DARK_THEME] ?: false
+    }
+
     val remoteShortcutPreferences: Flow<RemoteShortcutPreferences> = context.dataStore.data.map { preferences ->
         decodeRemoteShortcutPreferences { profile, button ->
             preferences[stringPreferencesKey(remoteShortcutKey(profile, button))]
@@ -1466,6 +1471,12 @@ class PreferencesRepository @Inject constructor(
     suspend fun setAppLanguage(language: String) {
         context.dataStore.edit { preferences ->
             preferences[PreferencesKeys.APP_LANGUAGE] = language
+        }
+    }
+
+    suspend fun setDarkTheme(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferencesKeys.DARK_THEME] = enabled
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a **dark theme toggle** (Settings → Browsing → "Dark theme") persisted via a new `dark_theme` preference; **light (the original blue-on-navy theme) remains the default**
- The **light theme is the original StreamVault palette** (blue `#69A8FF` brand on navy surfaces, near-white focus ring, thick focus borders) restored exactly
- The **dark theme is the M3 purple-on-black palette** (lavender `#D0BCFF` primary with dark-purple `onPrimary`, neutral surfaces, subtle gray focus ring, 2dp focus borders)
- Makes the palette **theme-reactive**: `AppColors` is now backed by snapshot state, so the ~90 UI files that paint with hardcoded `AppColors.*` / `ui.theme.*` colors follow the toggle with no call-site changes
- Derives both Material color schemes from the same active palette and provides `LocalDarkTheme` for composables that need the mode
- Wires the preference through MainActivity and TvInputSetupActivity (no restart needed), includes it in backups/restore, and registers the previously unclassified `vod_portal_search` preference in the backup registry (its registry test was failing)
- Removes the M3 color mapping docs (`docs/UI_ELEMENTS.md`, `docs/UI_ELEMENTS_COLORS.md`)
- Keeps the auto-hiding Material-style scrollbars from the reverted theming attempt

## Testing
- `:app:compileDebugKotlin`, `:app:compileDebugAndroidTestKotlin` clean
- All `:app:testDebugUnitTest` pass; `PreferenceBackupRegistryTest` green
- Installed on emulator + device; toggling switches every surface (shell, guide, player overlays, dialogs) between the two looks without a restart

🤖 Generated with Codebuff

<img width="584" height="338" alt="image" src="https://github.com/user-attachments/assets/02cd6f8d-b9bd-4d57-840d-4cad096fe204" />
<img width="570" height="331" alt="image" src="https://github.com/user-attachments/assets/833bdfff-c3b3-4159-8ec1-371ef40dffce" />
