### PR TITLE
feat(vod): show content-type icon on cards instead of bottom-left text

### DIFF
--- a/app/src/main/java/com/streamvault/app/ui/components/Cards.kt
+++ b/app/src/main/java/com/streamvault/app/ui/components/Cards.kt
@@ -18,7 +18,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.runtime.Composable
@@ -414,19 +416,6 @@ fun MovieCard(
         }
 
         if (!isLocked) {
-            if (showTypeBadge) {
-                StatusPill(
-                    label = stringResource(R.string.badge_movie),
-                    containerColor = Color.Black.copy(alpha = 0.72f),
-                    cornerRadius = 4.dp,
-                    horizontalPadding = 6.dp,
-                    verticalPadding = 2.dp,
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(start = 8.dp, bottom = 8.dp)
-                )
-            }
-
             if (movie.rating > 0f) {
                 Box(
                     modifier = Modifier
@@ -439,6 +428,26 @@ fun MovieCard(
                         text = formatVodRatingLabel(movie.rating),
                         style = MaterialTheme.typography.labelSmall,
                         color = AccentAmber
+                    )
+                }
+            }
+
+            if (showTypeBadge) {
+                // Content-type icon (bottom-right). Replaces the old bottom-left MOVIE text
+                // pill; the corner stays free of the rating (top-left) and favorite star
+                // (top-right) overlays.
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 8.dp, bottom = 8.dp)
+                        .background(Color.Black.copy(alpha = 0.72f), RoundedCornerShape(4.dp))
+                        .padding(4.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Movie,
+                        contentDescription = stringResource(R.string.badge_movie),
+                        tint = Color.White,
+                        modifier = Modifier.size(13.dp)
                     )
                 }
             }
@@ -538,19 +547,6 @@ fun SeriesCard(
         }
 
         if (!isLocked) {
-            if (showTypeBadge) {
-                StatusPill(
-                    label = stringResource(R.string.badge_series),
-                    containerColor = Color.Black.copy(alpha = 0.72f),
-                    cornerRadius = 4.dp,
-                    horizontalPadding = 6.dp,
-                    verticalPadding = 2.dp,
-                    modifier = Modifier
-                        .align(Alignment.BottomStart)
-                        .padding(start = 8.dp, bottom = 8.dp)
-                )
-            }
-
             if (series.rating > 0f) {
                 Box(
                     modifier = Modifier
@@ -563,6 +559,26 @@ fun SeriesCard(
                         text = formatVodRatingLabel(series.rating),
                         style = MaterialTheme.typography.labelSmall,
                         color = AccentAmber
+                    )
+                }
+            }
+
+            if (showTypeBadge) {
+                // Content-type icon (bottom-right). Replaces the old bottom-left SERIES text
+                // pill; the corner stays free of the rating (top-left) and favorite star
+                // (top-right) overlays.
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = 8.dp, bottom = 8.dp)
+                        .background(Color.Black.copy(alpha = 0.72f), RoundedCornerShape(4.dp))
+                        .padding(4.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Tv,
+                        contentDescription = stringResource(R.string.badge_series),
+                        tint = Color.White,
+                        modifier = Modifier.size(13.dp)
                     )
                 }
             }


### PR DESCRIPTION
## What
Replaces the bottom-left **MOVIE**/**SERIES** text pill on VOD poster cards with a small content-type **icon** chip in the **bottom-right** corner of each card:
- Movies → film icon
- Series → TV icon

## Why
The bottom-left text label cluttered the poster; a corner icon is cleaner and still distinguishes movies from series at a glance in mixed shelves/grids.

## Layout (unchanged)
- Top-left: rating overlay
- Top-right: favorite-star overlay (favorited cards only)


- Bottom-right: type icon (new)
- Bottom-left: free of the text pill

## Before 
<img width="512" height="302" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/581c9cdc-efb1-4468-b25d-23836d4381ee" />

## After

<img width="505" height="201" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/c10182f2-f9cb-4b70-877f-5f4f72d0ab93" />



## Verification
- `:app:compileDebugKotlin` passes
- Verified on emulator: text pills gone, icon chips present at bottom-right of each card, no crashes